### PR TITLE
pyqt5 compatibility

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -27,7 +27,7 @@ __version__ = '0.1'
 import os
 import sys
 
-# If we are using PyQt, ACQ4 requires API version 2 for QString and QVariant. 
+# If we are using PyQt, ACQ4 requires API version 2 for QString and QVariant.
 # Check for those here..
 set_api = True
 if 'PyQt4' in sys.modules:
@@ -78,7 +78,7 @@ if sys.platform == 'win32':
     except:
         print('SetCurrentProcessExplicitAppUserModelID failed! This is probably not Microsoft Windows!')
 
-# rename any orphaned .pyc files -- these are probably leftover from 
+# rename any orphaned .pyc files -- these are probably leftover from
 # a module being moved and may interfere with expected operation.
 compiledModuleDir = os.path.abspath(os.path.split(__file__)[0])
 pg.renamePyc(compiledModuleDir)
@@ -91,7 +91,7 @@ def messageHandler(msgType, msg):
     traceback.print_stack()
     try:
         logf = "crash.log"
-            
+
         fh = open(logf, 'a')
         fh.write(str(msg)+'\n')
         fh.write('\n'.join(traceback.format_stack()))
@@ -109,4 +109,7 @@ def messageHandler(msgType, msg):
         except:
             pass
 
-pg.QtCore.qInstallMsgHandler(messageHandler)
+if 'PyQt4' in sys.modules:
+    pg.QtCore.qInstallMsgHandler(messageHandler)
+else:
+    pg.QtCore.qInstallMessageHandler(messageHandler)

--- a/gui/confocal/plotwidget_modified.py
+++ b/gui/confocal/plotwidget_modified.py
@@ -20,7 +20,7 @@ Copyright (C) 2015 Alexander Stark alexander.stark@uni-ulm.de
 """
 
 from pyqtgraph import PlotWidget
-from PyQt4 import QtGui, QtCore
+from pyqtgraph.Qt import QtGui, QtCore
 
 class PlotWidgetModified(PlotWidget):
     """ Extend the PlotWidget Class with more adjustment possibilities.

--- a/gui/notebook/notebookgui.py
+++ b/gui/notebook/notebookgui.py
@@ -18,7 +18,11 @@ along with QuDi. If not, see <http://www.gnu.org/licenses/>.
 Copyright (C) 2015-2016 Jan M. Binder jan.binder@uni-ulm.de
 """
 from pyqtgraph.Qt import QtCore, QtGui, uic
-from PyQt4 import QtWebKit
+import sys
+if 'PyQt4' in sys.modules:
+    from PyQt4 import QtWebKit
+else:
+    from PyQt5 import QtWebKit
 from gui.guibase import GUIBase
 import os
 

--- a/gui/poimanager/poimangui.py
+++ b/gui/poimanager/poimangui.py
@@ -19,7 +19,6 @@ Copyright (C) 2015 Lachlan J. Rogers  lachlan.j.rogers@quantum.diamonds
 """
 
 from pyqtgraph.Qt import QtCore, QtGui, uic
-from PyQt4.QtGui import QFileDialog
 import pyqtgraph as pg
 import numpy as np
 import time
@@ -853,7 +852,7 @@ class PoiManagerGui(GUIBase):
         '''Load a saved ROI from file.
         '''
 
-        this_file = QFileDialog.getOpenFileName(
+        this_file = QtGui.QFileDialog.getOpenFileName(
             self._mw, str("Open ROI"), None, str("Data files (*.dat)"))
 
         self._poi_manager_logic.load_roi_from_file(filename=this_file)

--- a/gui/pulsed/checkbox_delegate.py
+++ b/gui/pulsed/checkbox_delegate.py
@@ -19,7 +19,7 @@ along with QuDi. If not, see <http://www.gnu.org/licenses/>.
 Copyright (C) 2015 Alexander Stark alexander.stark@uni-ulm.de
 """
 
-from PyQt4 import QtGui, QtCore
+from pyqtgraph.Qt import QtGui, QtCore
 
 class CheckBoxDelegate(QtGui.QStyledItemDelegate):
     """

--- a/gui/pulsed/combobox_delegate.py
+++ b/gui/pulsed/combobox_delegate.py
@@ -19,7 +19,7 @@ along with QuDi. If not, see <http://www.gnu.org/licenses/>.
 Copyright (C) 2015 Alexander Stark alexander.stark@uni-ulm.de
 """
 
-from PyQt4 import QtGui, QtCore
+from pyqtgraph.Qt import QtGui, QtCore
 
 class ComboBoxDelegate(QtGui.QStyledItemDelegate):
 

--- a/gui/pulsed/doublespinbox_delegate.py
+++ b/gui/pulsed/doublespinbox_delegate.py
@@ -19,7 +19,7 @@ along with QuDi. If not, see <http://www.gnu.org/licenses/>.
 Copyright (C) 2015 Alexander Stark alexander.stark@uni-ulm.de
 """
 
-from PyQt4 import QtGui, QtCore
+from pyqtgraph.Qt import QtGui, QtCore
 
 class DoubleSpinBoxDelegate(QtGui.QStyledItemDelegate):
     """ Make a QDoubleSpinBox delegate for the QTableWidget."""

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -21,7 +21,7 @@ Copyright (C) 2016 Nikolas Tomek nikolas.tomek@uni-ulm.de
 Copyright (C) 2016 Simon Schmitt simon.schmitt@uni-ulm.de
 """
 
-from PyQt4 import QtGui, QtCore, uic
+from pyqtgraph.Qt import QtGui, QtCore, uic
 import numpy as np
 import os
 from collections import OrderedDict

--- a/gui/pulsed/qradiobutton_custom.py
+++ b/gui/pulsed/qradiobutton_custom.py
@@ -19,8 +19,8 @@ along with QuDi. If not, see <http://www.gnu.org/licenses/>.
 Copyright (C) 2016 Alexander Stark alexander.stark@uni-ulm.de
 """
 
-from PyQt4 import QtGui
-from PyQt4 import QtCore
+from pyqtgraph.Qt import QtGui
+from pyqtgraph.Qt import QtCore
 
 
 class CustomQRadioButton(QtGui.QRadioButton):

--- a/gui/pulsed/spinbox_delegate.py
+++ b/gui/pulsed/spinbox_delegate.py
@@ -19,7 +19,7 @@ along with QuDi. If not, see <http://www.gnu.org/licenses/>.
 Copyright (C) 2015 Alexander Stark alexander.stark@uni-ulm.de
 """
 
-from PyQt4 import QtGui, QtCore
+from pyqtgraph.Qt import QtGui, QtCore
 
 class SpinBoxDelegate(QtGui.QStyledItemDelegate):
     """

--- a/hardware/fast_counter_dummy.py
+++ b/hardware/fast_counter_dummy.py
@@ -23,7 +23,7 @@ Copyright (C) 2015 Alexander Stark alexander.stark@uni-ulm.de
 import time
 import os
 import numpy as np
-from PyQt4 import QtGui
+from pyqtgraph.Qt import QtGui
 
 from core.base import Base
 from interface.fast_counter_interface import FastCounterInterface

--- a/hardware/picoquant/picoharp300.py
+++ b/hardware/picoquant/picoharp300.py
@@ -23,8 +23,6 @@ import numpy as np
 import time
 from pyqtgraph.Qt import QtCore
 
-from PyQt4.QtCore import QThread
-
 from core.base import Base
 from core.util.mutex import Mutex
 from interface.slow_counter_interface import SlowCounterInterface

--- a/logic/jupyterkernel/qzmqkernel.py
+++ b/logic/jupyterkernel/qzmqkernel.py
@@ -68,7 +68,7 @@ from .redirect import redirect_stdout, redirect_stderr
 from .stream import QZMQStream
 from .helpers import *
 
-from PyQt4 import QtCore
+from pyqtgraph.Qt import QtCore
 QtCore.Signal = QtCore.pyqtSignal
 
 
@@ -86,7 +86,7 @@ class QZMQHeartbeat(QtCore.QObject):
                 raise
 
 class QZMQKernel(QtCore.QObject):
-    
+
     sigShutdownFinished = QtCore.Signal(str)
 
     def __init__(self, config=None):
@@ -114,7 +114,7 @@ class QZMQKernel(QtCore.QObject):
                 'stdin_port'        : 0,
                 'transport'         : 'tcp'
             }
-     
+
         self.hb_thread = QtCore.QThread()
         self.hb_thread.setObjectName(self.engine_id)
         self.connection = config["transport"] + "://" + config["ip"]
@@ -153,15 +153,15 @@ class QZMQKernel(QtCore.QObject):
         self.config["shell_port"] = self.bind(self.shell_socket, self.connection, self.config["shell_port"])
         self.shell_stream = QZMQStream(self.shell_socket)
         self.shell_stream.sigMsgRecvd.connect(self.shell_handler)
-     
+
         logging.info( "Config: %s" % json.dumps(self.config))
         logging.info( "Starting loops...")
-     
+
         self.heartbeat_handler = QZMQHeartbeat(self.heartbeat_socket)
         self.heartbeat_handler.moveToThread(self.hb_thread)
         self.heartbeat_stream.sigMsgRecvd.connect(self.heartbeat_handler.beat)
         self.hb_thread.start()
-     
+
         self.init_exec_env()
         logging.info( "Ready! Listening...")
 
@@ -261,7 +261,7 @@ class QZMQKernel(QtCore.QObject):
             'image/svg+xml'
             )
         if mimetype in supported_mime:
-            
+
             content = {
                 'source': '',
                 'data': {
@@ -363,7 +363,7 @@ class QZMQKernel(QtCore.QObject):
             'execution_state': "idle",
         }
         self.send(self.iopub_stream, 'status', content, parent_header=msg['header'])
- 
+
         # publich execution result on shell channel
         metadata = {
             "dependencies_met": True,
@@ -385,7 +385,7 @@ class QZMQKernel(QtCore.QObject):
             metadata=metadata,
             parent_header=msg['header'],
             identities=identities)
- 
+
         self.execution_count += 1
 
     def shell_kernel_info(self, identities, msg):
@@ -447,17 +447,17 @@ class QZMQKernel(QtCore.QObject):
             metadata=metadata,
             parent_header=msg['header'],
             identities=identities)
- 
+
     def deserialize_wire_msg(self, wire_msg):
         """split the routing prefix and message frames from a message on the wire"""
         delim_idx = wire_msg.index(self.DELIM)
         identities = wire_msg[:delim_idx]
         m_signature = wire_msg[delim_idx + 1]
         msg_frames = wire_msg[delim_idx + 2:]
-     
+
         def jdecode(msg):
             return json.loads(msg.decode('ascii'))
-     
+
         m = {}
         m['header']        = jdecode(msg_frames[0])
         m['parent_header'] = jdecode(msg_frames[1])
@@ -466,7 +466,7 @@ class QZMQKernel(QtCore.QObject):
         check_sig = self.sign(msg_frames)
         if check_sig != m_signature:
             raise ValueError("Signatures do not match")
-     
+
         return identities, m
 
     def control_handler(self, wire_msg):
@@ -525,7 +525,7 @@ class QZMQKernel(QtCore.QObject):
 
         if (not raw_cell) or raw_cell.isspace():
             return result
-        
+
         if silent:
             store_history = False
 
@@ -601,7 +601,7 @@ class QZMQKernel(QtCore.QObject):
                     if store_history:
                         self.execution_count += 1
                     return error_before_exec(e)
-         
+
                 # Apply AST transformations
                 try:
                     code_ast = self.transform_ast(code_ast)
@@ -610,11 +610,11 @@ class QZMQKernel(QtCore.QObject):
                     if store_history:
                         self.execution_count += 1
                     return error_before_exec(e)
-         
+
                 # Give the displayhook a reference to our ExecutionResult so it
                 # can fill in the output value.
                 #self.displayhook.exec_result = result
-         
+
                 # Execute the user code
                 interactivity = "none" if silent else self.ast_node_interactivity
                 self.run_ast_nodes(
@@ -623,11 +623,11 @@ class QZMQKernel(QtCore.QObject):
                     interactivity=interactivity,
                     compiler=compiler,
                     result=result)
-         
+
                 # Reset this so later displayed values do not modify the
                 # ExecutionResult
                 #self.displayhook.exec_result = None
-         
+
                 #self.events.trigger('post_execute')
                 if not silent:
                     pass
@@ -641,16 +641,16 @@ class QZMQKernel(QtCore.QObject):
             self.execution_count += 1
 
         return result
-    
+
     def transform_ast(self, node):
         """Apply the AST transformations from self.ast_transformers
-        
+
         Parameters
         ----------
         node : ast.Node
           The root node to be transformed. Typically called with the ast.Module
           produced by parsing user input.
-        
+
         Returns
         -------
         An ast.Node corresponding to the node it was called with. Note that it
@@ -668,11 +668,11 @@ class QZMQKernel(QtCore.QObject):
             except Exception:
                 warn("AST transformer %r threw an error. It will be unregistered." % transformer)
                 self.ast_transformers.remove(transformer)
-        
+
         if self.ast_transformers:
             ast.fix_missing_locations(node)
         return node
-                
+
 
     def run_ast_nodes(self, nodelist, cell_name, interactivity='last_expr',
                         compiler=compile, result=None):
@@ -825,10 +825,10 @@ class QZMQKernel(QtCore.QObject):
 
     def _get_exc_info(self, exc_tuple=None):
         """get exc_info from a given tuple, sys.exc_info() or sys.last_type etc.
-        
+
         Ensures sys.last_type,value,traceback hold the exc_info we found,
         from whichever source.
-        
+
         raises ValueError if none of these contain any information
         """
         if exc_tuple is None:
@@ -840,10 +840,10 @@ class QZMQKernel(QtCore.QObject):
             if hasattr(sys, 'last_type'):
                 etype, value, tb = sys.last_type, sys.last_value, \
                                    sys.last_traceback
-        
+
         if etype is None:
             raise ValueError("No exception to find")
-        
+
         # Now store the exception info in sys.last_type etc.
         # WARNING: these variables are somewhat deprecated and not
         # necessarily safe to use in a threaded environment, but tools
@@ -852,9 +852,9 @@ class QZMQKernel(QtCore.QObject):
         sys.last_type = etype
         sys.last_value = value
         sys.last_traceback = tb
-        
+
         return etype, value, tb
-    
+
     def get_exception_only(self, exc_tuple=None):
         """
         Return as a string (ending with a newline) the exception that
@@ -907,7 +907,7 @@ if __name__ == '__main__':
     logging.info( "Reading config file '%s'..." % sys.argv[1])
 
     config = json.loads("".join(open(sys.argv[1]).readlines()))
-    
+
     app = QtCore.QCoreApplication(sys.argv)
     kernel = QZMQKernel(config)
     kernel.sigShutdownFinished.connect(app.quit)

--- a/logic/jupyterkernel/stream.py
+++ b/logic/jupyterkernel/stream.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import zmq
-from PyQt4 import QtCore
+from pyqtgraph.Qt import QtCore
 QtCore.Signal = QtCore.pyqtSignal
 import logging
 
@@ -10,12 +10,12 @@ class QZMQStream(QtCore.QObject):
     def __init__(self, zmqsocket):
         super().__init__()
         self.socket = zmqsocket
-        self.readnotifier = QtCore.QSocketNotifier( 
+        self.readnotifier = QtCore.QSocketNotifier(
             self.socket.get(zmq.FD),
             QtCore.QSocketNotifier.Read)
         logging.debug( "Notifier: %s" % self.readnotifier.socket())
         self.readnotifier.activated.connect(self.checkForMessage)
-    
+
     def checkForMessage(self, socket):
         logging.debug( "Check: %s" % self.readnotifier.socket())
         self.readnotifier.setEnabled(False)

--- a/logic/magnet_logic.py
+++ b/logic/magnet_logic.py
@@ -19,7 +19,7 @@ along with QuDi. If not, see <http://www.gnu.org/licenses/>.
 Copyright (C) 2016 Alexander Stark alexander.stark@uni-ulm.de
 """
 
-from PyQt4 import QtCore
+from pyqtgraph.Qt import QtCore
 import numpy as np
 import time
 import os

--- a/logic/nuclear_operations_logic.py
+++ b/logic/nuclear_operations_logic.py
@@ -20,7 +20,7 @@ Copyright (C) 2016 Alexander Stark alexander.stark@uni-ulm.de
 """
 
 import numpy as np
-from PyQt4 import QtCore
+from pyqtgraph.Qt import QtCore
 import time
 from collections import OrderedDict
 

--- a/logic/trace_analysis_logic.py
+++ b/logic/trace_analysis_logic.py
@@ -19,7 +19,7 @@ Copyright (C) 2016 Alexander Stark alexander.stark@uni-ulm.de
 """
 
 
-from PyQt4 import QtCore
+from pyqtgraph.Qt import QtCore
 import numpy as np
 from scipy.signal import gaussian
 from scipy.ndimage import filters


### PR DESCRIPTION
requires development version of pyqtgraph for pyqt5. It is still compatible with pyqt4. If both are installed on a system pyqt4 will be used. To use pyqt5 you have to change the variable libOrder in pyqtgraph/Qt.py