### PR TITLE
use argparse for commandline argument parsing

### DIFF
--- a/core/__main__.py
+++ b/core/__main__.py
@@ -119,7 +119,7 @@ class AppWatchdog(QtCore.QObject):
 
 
 # Possibility to start the program with additional parameters.
-parser = argparse.ArgumentParser(description='QuDi', prog='start.py')
+parser = argparse.ArgumentParser(prog='start.py')
 group = parser.add_mutually_exclusive_group()
 group.add_argument('-p', '--profile', action='store_true',
         help='enables profiler')

--- a/core/manager.py
+++ b/core/manager.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 import os
 import sys
 import gc
-import getopt
 import glob
 import re
 import time

--- a/start.py
+++ b/start.py
@@ -27,7 +27,7 @@ import subprocess
 import sys
 import os
 
-myenv = os.environ.copy() 
+myenv = os.environ.copy()
 
 if sys.platform == 'win32':
     from core.util.win_interrupt import create_interrupt_event
@@ -58,6 +58,9 @@ while True:
         elif retval == 42:
             print('Restarting...')
             continue
+        elif retval == 2:
+            # invalid commandline argument
+            break
         else:
             print('Unexpected return value {0}. Exiting.'.format(retval))
             sys.exit(retval)


### PR DESCRIPTION
This patch replaces getopt with argparse and puts parsing of arguments in one place. Thus, all options are now displayed if -h is specified (before profile, callgraph and manhole were not displayed). 
Removed --storage-dir as it wasn't used.
Removed some code in relation to argument parsing that wasn't used. 