### PR TITLE
easier access to IN connector objects

### DIFF
--- a/core/base.py
+++ b/core/base.py
@@ -126,12 +126,17 @@ class Base(QtCore.QObject, Fysom):
         """
         Attribute getter.
 
-        We'll reimplement it here because otherwise only __getattr__ of the
-        first base class (QObject) is called and the second base class is
-        never looked up.
-        Here we look up the first base class first and if the attribute is
-        not found, we'll look into the second base class.
+        If name is an IN connector we return the corresponding object which
+        gives you simpler access. Otherwise we look for attributes in the
+        two base classes. We check attributes of QObject first and if not
+        existing we check Fysom.
+
+        Note, that we'll reimplement it here because otherwise only
+        __getattr__ of the first base class (QObject) is called and the
+        second base class is never looked up.
         """
+        if name in self.connector['in']:
+            return self.connector['in'][name]['object']
         try:
             return QtCore.QObject.__getattr__(self, name)
         except AttributeError:


### PR DESCRIPTION
if you have defined an IN connector by
```...
_in = {'savelogic': 'SaveLogic'}
```
you can access it inside the module by calling 
```
self.savelogic
```

Note that this is slower than defining an abbreviation in `on_activate` yourself as each time self.connector['in'][name]['object'] is looked up. It though hides the connector dictionary from users which I think is more user-friendly.
A possibility would have been to implement this in on_activate in the base class but then the user has to call super() in his/her implementation. 

This patch potentially breaks some modules defining attributes with the same name as IN connectors. Not sure that this is done anywhere, but I wanted to give you this warning.