### PR TITLE
Mapper

### DIFF
--- a/core/mapper.py
+++ b/core/mapper.py
@@ -29,6 +29,7 @@ from qtpy.QtWidgets import QAbstractSlider
 from qtpy.QtWidgets import QComboBox
 from qtpy.QtWidgets import QDoubleSpinBox
 from qtpy.QtWidgets import QLineEdit
+from qtpy.QtWidgets import QPlainTextEdit
 from qtpy.QtWidgets import QSpinBox
 
 import functools
@@ -172,16 +173,18 @@ class Mapper():
             raise Exception('Widget {0} already mapped.'.format(repr(widget)))
         # guess widget property if not specified
         if widget_property_name == '':
-            if isinstance(widget, QLineEdit):
-                widget_property_name = 'text'
-            elif isinstance(widget, QAbstractButton):
+            if isinstance(widget, QAbstractButton):
                 widget_property_name = 'checked'
+            elif isinstance(widget, QComboBox):
+                widget_property_name = 'currentIndex'
+            elif isinstance(widget, QLineEdit):
+                widget_property_name = 'text'
             elif (isinstance(widget, QSpinBox)
                   or isinstance(widget, QDoubleSpinBox)
                   or isinstance(widget, QAbstractSlider)):
                 widget_property_name = 'value'
-            elif isinstance(widget, QComboBox):
-                widget_property_name = 'currentIndex'
+            elif isinstance(widget, QPlainTextEdit):
+                widget_property_name = 'plainText'
             else:
                 raise Exception('Property of widget {0} could not be '
                                 'guessed.'.format(repr(widget)))

--- a/core/mapper.py
+++ b/core/mapper.py
@@ -26,6 +26,7 @@ from qtpy.QtCore import QThread
 from qtpy.QtCore import QTimer
 from qtpy.QtWidgets import QAbstractButton
 from qtpy.QtWidgets import QAbstractSlider
+from qtpy.QtWidgets import QComboBox
 from qtpy.QtWidgets import QDoubleSpinBox
 from qtpy.QtWidgets import QLineEdit
 from qtpy.QtWidgets import QSpinBox
@@ -128,6 +129,8 @@ class Mapper(QObject):
                   or isinstance(widget, QDoubleSpinBox)
                   or isinstance(widget, QAbstractSlider)):
                 widget_property_name = 'value'
+            elif isinstance(widget, QComboBox):
+                widget_property_name = 'currentIndex'
             else:
                 raise Exception('Property of widget {0} could not be '
                                 'guessed.'.format(repr(widget)))

--- a/core/mapper.py
+++ b/core/mapper.py
@@ -1,0 +1,341 @@
+# -*- coding: utf-8 -*-
+"""
+This file contains the Qudi mapper module.
+
+QuDi is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+QuDi is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with QuDi. If not, see <http://www.gnu.org/licenses/>.
+
+Copyright (c) the Qudi Developers. See the COPYRIGHT.txt file at the
+top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi/>
+"""
+
+
+from qtpy.QtCore import QCoreApplication
+from qtpy.QtCore import QObject
+from qtpy.QtCore import QThread
+from qtpy.QtCore import QTimer
+from qtpy.QtWidgets import QAbstractButton
+from qtpy.QtWidgets import QAbstractSlider
+from qtpy.QtWidgets import QDoubleSpinBox
+from qtpy.QtWidgets import QLineEdit
+from qtpy.QtWidgets import QSpinBox
+
+import functools
+
+SUBMIT_POLICY_AUTO = 0
+"""automatically submit changes"""
+SUBMIT_POLICY_MANUAL = 1
+"""wait with submitting changes until submit() is called"""
+
+
+class Mapper(QObject):
+    """
+    The Mapper connects a Qt widget for displaying and editing certain data
+    types with a model property or setter and getter functions. The model can
+    be e.g. a logic or a hardware module.
+
+    Usage Example:
+    ==============
+
+    We assume to have a hardware module which is connected to our GUI via a
+    connector and we can access it by the `hardware_model` variable. We
+    further assume that this hardware module has a string property called
+    `property` and a signal `property_changed` which is emitted when the
+    property is changed programmatically.
+    In the GUI module we have defined a QLineEdit, e.g. by
+    ```
+    lineedit = QLineEdit()
+    ```
+    In the on_activate method of the GUI module, we define the following
+    mapping between the line edit and the hardware property:
+    ```
+    def on_activate(self, e):
+        self.mapper = Mapper()
+        self.mapper.add_mapping(self.lineedit, self.hardware_model,
+                'property', 'property_changed')
+    ```
+    Now, if the user changes the string in the lineedit, the property of the
+    hardware module gets changed. If the hardware module property is changed
+    programmatically, the change is displayed in the GUI.
+
+    If the GUI module is deactivated we can delete all mappings:
+    ```
+    def on_deactivate(self, e):
+        self.mapper.clear_mappings()
+    ```
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._submit_policy = SUBMIT_POLICY_AUTO
+        self._mappings = {}
+        self._widget_property_notifications_disabled = False
+        self._model_notifications_disabled = False
+
+    def add_mapping(self, widget, model, model_setter,
+                    model_property_notifier=None, model_getter=None,
+                    widget_property_name=''):
+        """
+        Adds a mapping.
+
+        Parameters
+        ==========
+        widget QtWidget A widget displaying some data. You want to map this
+                        widget to model data
+        model  object   Instance of a class holding model data (e.g. a logic
+                        or hardware module)
+        model_setter property/callable either a property holding the data to
+                                       be displayed in widget or a setter
+                                       method called if the data in the widget
+                                       was changed
+        model_property_notifier SIGNAL A signal that is fired when the data
+                                       was changed.
+                                       Default: None. If None then data
+                                       changes are not monitored and the
+                                       widget is not updated.
+        model_getter callable A getter method to retrieve data from the model.
+                              If model_setter is a property the getter can be
+                              determined from this property and model_getter
+                              is ignored if it is None. If it is not None
+                              always this callable is used.
+                              Default: None
+        widget_property_name str The name of the pyqtProperty of the widget
+                                 used to map the data.
+                                 Default: ''
+                                 If it is an empty string the relevant
+                                 property is guessed from the widget's type.
+
+        """
+        if widget in self._mappings:
+            raise Exception('Widget {0} already mapped.'.format(repr(widget)))
+        # guess widget property if not specified
+        if widget_property_name == '':
+            if isinstance(widget, QLineEdit):
+                widget_property_name = 'text'
+            elif isinstance(widget, QAbstractButton):
+                widget_property_name = 'checked'
+            elif (isinstance(widget, QSpinBox)
+                  or isinstance(widget, QDoubleSpinBox)
+                  or isinstance(widget, QAbstractSlider)):
+                widget_property_name = 'value'
+            else:
+                raise Exception('Property of widget {0} could not be '
+                                'guessed.'.format(repr(widget)))
+        # check if widget property is available
+        index = widget.metaObject().indexOfProperty(widget_property_name)
+        if index == -1:
+            raise Exception('Property ''{0}'' of widget ''{1}'' not '
+                            'available.'.format(widget_property_name,
+                                                widget.__class__.__name__))
+
+        meta_property = widget.metaObject().property(index)
+        # check that property as a notify signal
+        if not meta_property.hasNotifySignal():
+            raise Exception('Property ''{0}'' of widget ''{1}'' has '
+                            'no notify signal.'.format(
+                                widget_property_name,
+                                widget.__class__.__name__))
+        widget_property_notifier = getattr(
+            widget,
+            meta_property.notifySignal().name().data().decode('utf8'))
+
+        # check that widget property is readable
+        if not meta_property.isReadable():
+            raise Exception('Property ''{0}'' of widget ''{1}'' is not '
+                            'readable.'.format(widget_property_name,
+                                               widget.__class__.__name__))
+        widget_property_getter = meta_property.read
+        # check that widget property is writable if requested
+        if not meta_property.isWritable():
+            raise Exception('Property ''{0}'' of widget ''{1}'' is not '
+                            'writable.'.format(widget_property_name,
+                                               widget.__class__.__name__))
+        widget_property_setter = meta_property.write
+
+        if isinstance(model_setter, str):
+            # check if it is a property
+            attr = getattr(model.__class__, model_setter, None)
+            if attr is None:
+                raise Exception('Model has no attribute {0}'.format(
+                    model_setter))
+            if isinstance(attr, property):
+                # retrieve setter from property
+                model_property_name = model_setter
+                model_setter = functools.partial(attr.fset, model)
+                if model_setter is None:
+                    raise Exception('Attribute {0} of model is readonly.'
+                                    ''.format(model_property_name))
+                # if no getter was specified, get it from the property
+                if model_getter is None:
+                    model_getter = functools.partial(attr.fget, model)
+        if isinstance(model_getter, str):
+            model_getter_name = model_getter
+            model_getter = getattr(model, model_getter)
+            if not callable(model_getter):
+                raise Exception('{0} is not callable'.format(
+                    model_getter_name))
+        if isinstance(model_property_notifier, str):
+            model_property_notifier = getattr(model, model_property_notifier)
+
+        # connect to widget property notifier
+        widget_property_notifier_slot = functools.partial(
+            self._on_widget_property_notification, widget)
+        widget_property_notifier.connect(widget_property_notifier_slot)
+
+        # if model_notify_signal was specified, connect to it
+        model_property_notifier_slot = None
+        if model_property_notifier is not None:
+            model_property_notifier_slot = functools.partial(
+                self._on_model_notification, widget)
+            model_property_notifier.connect(model_property_notifier_slot)
+        # save mapping
+        self._mappings[widget] = {
+            'widget_property_name': widget_property_name,
+            'widget_property_getter': widget_property_getter,
+            'widget_property_setter': widget_property_setter,
+            'widget_property_notifier': widget_property_notifier,
+            'widget_property_notifier_slot': widget_property_notifier_slot,
+            'model': model,
+            'model_property_setter': model_setter,
+            'model_property_getter': model_getter,
+            'model_property_notifier': model_property_notifier,
+            'model_property_notifier_slot': model_property_notifier_slot}
+
+    def _on_widget_property_notification(self, widget, *args):
+        """
+        Event handler for widget property change notification. Used with
+        functools.partial to get the widget as first parameter.
+
+        Parameters
+        ==========
+        widget: QtWidget The widget the property notification signal was
+                         emitted from.
+        args*: List list of event parameters
+        """
+        if self._widget_property_notifications_disabled:
+            return
+        if self._submit_policy == SUBMIT_POLICY_AUTO:
+            self._model_notifications_disabled = True
+            try:
+                setter = self._mappings[widget]['model_property_setter']
+                setter(self._mappings[widget]['widget_property_getter'](
+                    widget))
+            finally:
+                self._model_notifications_disabled = False
+        else:
+            pass
+
+    def _on_model_notification(self, widget, *args):
+        """
+        Event handler for model data change notification. Used with
+        functools.partial to get the widget as first parameter.
+
+        Parameters
+        ==========
+        widget: QtWidget The widget the property notification signal was
+                         emitted from.
+        args*: List list of event parameters
+        """
+        if self._model_notifications_disabled:
+            return
+        getter = self._mappings[widget]['model_property_getter']
+        widget_property_setter = self._mappings[widget][
+            'widget_property_setter']
+        self._widget_property_notifications_disabled = True
+        try:
+            widget_property_setter(widget, getter())
+        finally:
+            self._widget_property_notifications_disabled = False
+
+    def clear_mapping(self):
+        """
+        Clears all mappings.
+        """
+        for key in list(self._mappings.keys()):
+            self.remove_mapping(key)
+
+    def remove_mapping(self, widget):
+        """
+        Removes the mapping which maps the QtWidget widget to some model data.
+
+        Parameters
+        ==========
+        widget: QtWidget widget the mapping is attached to
+        """
+        # check that widget has a mapping
+        if not widget in self._mappings:
+            raise Exception('Widget {0} is not mapped.'.format(repr(widget)))
+        # disconnect signals
+        self._mappings[widget]['widget_property_notifier'].disconnect(
+            self._mappings[widget]['widget_property_notifier_slot'])
+        if self._mappings[widget]['model_property_notifier'] is not None:
+            self._mappings[widget]['model_property_notifier'].disconnect(
+                self._mappings[widget]['model_property_notifier_slot'])
+        # remove from dictionary
+        del self._mappings[widget]
+
+    @property
+    def submit_policy(self):
+        """
+        Returns the submit policy.
+        """
+        return self._submit_policy
+
+    @submit_policy.setter
+    def submit_policy(self, policy):
+        """
+        Sets submit policy.
+
+        Submit policy can either be SUBMIT_POLICY_AUTO or
+        SUBMIT_POLICY_MANUAL. If the submit policy is auto then changes in
+        the widgets are automatically submitted to the model. If manual
+        call submit() to submit it.
+
+        Parameters
+        ==========
+        policy: enum submit policy
+        """
+        if policy not in [SUBMIT_POLICY_AUTO, SUBMIT_POLICY_MANUAL]:
+            raise Exception('Unknown submit policy ''{0}'''.format(policy))
+        self._submit_policy = policy
+
+    def submit(self):
+        """
+        Submits the current values stored in the widgets to the models.
+        """
+        # make sure it is called from main thread
+        if (not QThread.currentThread() == QCoreApplication.instance(
+        ).thread()):
+            QTimer.singleShot(0, self.submit)
+            return
+
+        submit_policy = self._submit_policy
+        self.submit_policy = SUBMIT_POLICY_AUTO
+        try:
+            for widget in self._mappings:
+                self._on_widget_property_notification(widget)
+        finally:
+            self.submit_policy = submit_policy
+
+    def revert(self):
+        """
+        Takes the data stored in the models and displays them in the widgets.
+        """
+        # make sure it is called from main thread
+        if (not QThread.currentThread() == QCoreApplication.instance(
+        ).thread()):
+            QTimer.singleShot(0, self.revert)
+            return
+
+        for widget in self._mappings:
+            self._on_model_notification(widget)

--- a/core/mapper.py
+++ b/core/mapper.py
@@ -85,28 +85,28 @@ class Mapper():
     Usage Example:
     ==============
 
-    We assume to have a hardware module which is connected to our GUI via a
-    connector and we can access it by the `hardware_model` variable. We
-    further assume that this hardware module has a string property called
-    `property` and a signal `property_changed` which is emitted when the
+    We assume to have a logic module which is connected to our GUI via a
+    connector and we can access it by the `logic_module` variable. We
+    further assume that this logic module has a string property called
+    `some_value` and a signal `some_value_changed` which is emitted when the
     property is changed programmatically.
     In the GUI module we have defined a QLineEdit, e.g. by
     ```
     lineedit = QLineEdit()
     ```
     In the on_activate method of the GUI module, we define the following
-    mapping between the line edit and the hardware property:
+    mapping between the line edit and the logic property:
     ```
     def on_activate(self, e):
         self.mapper = Mapper()
-        self.mapper.add_mapping(self.lineedit, self.hardware_model,
-                'property', 'property_changed')
+        self.mapper.add_mapping(self.lineedit, self.logic_module,
+                'some_value', 'some_value_changed')
     ```
     Now, if the user changes the string in the lineedit, the property of the
-    hardware module gets changed. If the hardware module property is changed
-    programmatically, the change is displayed in the GUI.
+    logic module is changed. If the logic module's property is changed
+    programmatically, the change is automatically displayed in the GUI.
 
-    If the GUI module is deactivated we can delete all mappings:
+    If the GUI module is deactivated we should delete all mappings:
     ```
     def on_deactivate(self, e):
         self.mapper.clear_mapping()

--- a/qtwidgets/checkbox.py
+++ b/qtwidgets/checkbox.py
@@ -1,0 +1,86 @@
+"""
+QCheckBox with a callback function for acceptance or denial of state change.
+
+QuDi is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+QuDi is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with QuDi. If not, see <http://www.gnu.org/licenses/>.
+
+Copyright (c) the Qudi Developers. See the COPYRIGHT.txt file at the
+top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi/>
+"""
+
+from qtpy.QtWidgets import QCheckBox
+
+class CheckBox(QCheckBox):
+    """
+    This QCheckBox provides a callback function which is called before
+    the state is changed and which can be used to prevent state changes on
+    certain conditions.
+
+    The callback function has the following signature:
+    bool callback(new_state: bool)
+    where new_state is a boolean with the new state if accepted and the return
+    value is True for acceptance and False for denial.
+
+    Usage Example:
+    checkbox = CheckBox()
+    def on_accept_state_change(new_state):
+        if (not new_state):
+            result = QMessageBox.question(
+                    self,
+                    'Are you sure you want to disable this?',
+                    QMessageBox.StandardButtons(
+                        QMessageBox.Yes | QMessageBox.No)
+                    )
+            return result == QMessageBox.Yes
+    checkbox.accept_state_change_callback = on_accept_state_change
+    """
+    def __init__(self, *args, **kwargs):
+        """
+        Constructor. See QCheckBox for details.
+        """
+        super().__init__(*args, **kwargs)
+        self._callback = None
+
+    @property
+    def accept_state_change_callback(self):
+        """
+        Returns state changing callback function.
+
+        The callback function has the following signature:
+        bool callback(new_state: bool)
+        where new_state is a boolean with the new state if accepted and the
+        return value is True for acceptance and False for denial.
+        """
+        return self._callback
+
+    @accept_state_change_callback.setter
+    def accept_state_change_callback(self, value):
+        """
+        Sets state changing callback function.
+
+        The callback function has the following signature:
+        bool callback(new_state: bool)
+        where new_state is a boolean with the new state if accepted and the
+        return value is True for acceptance and False for denial.
+        """
+        self._callback = value
+
+    def nextCheckState(self):
+        """
+        Protected functions that calls the callback.
+        """
+        if (self._callback is not None):
+            if (self._callback(not self.isChecked())):
+                super().nextCheckState()
+        else:
+            super().nextCheckState()


### PR DESCRIPTION
this is a new core module to establish mappings between a displaying widget in a gui module and a property (or getter and setter functions) in e.g. a logic module.

The purpose of it is to enable automatic updates in both directions. If a user changes the value in a widget, the property is automatically updated. If a user changes the property programatically, the GUI is updated. It seems to me that especially the latter is not implemented in all modules, e.g. the counter module where the count frequency can be changed in the logic module, but the GUI isn't updated.

I tried to implement this as general as possible and so far it covers all my own use cases, but it could be that something is still missing. In case, I'm happy to add such use cases.

Please see the documentation of the Mapper class for an example.