### PR TITLE
msg in message handler is str in pyside

### DIFF
--- a/core/__main__.py
+++ b/core/__main__.py
@@ -80,7 +80,7 @@ def qt_message_handler(msgType, msg):
     A message handler handling Qt messages.
     """
     logger = logging.getLogger('Qt')
-    if qtpy.PYQT4 or qtpy.PYSIDE:
+    if qtpy.PYQT4:
         msg = msg.decode('utf-8')
     if msgType == QtCore.QtDebugMsg:
         logger.debug(msg)


### PR DESCRIPTION
This fixed one of many problems with pyside.

in core.logger.py we get the following error message:

> Specified Qt API: pyside
> Used Qt API: PySide
> Traceback (most recent call last):
>   File "/usr/lib/python3.5/runpy.py", line 193, in _run_module_as_main
>     "__main__", mod_spec)
>   File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
>     exec(code, run_globals)
>   File "/home/jan/qo/qudi-tobias/core/__main__.py", line 59, in <module>
>     logger.info('Loading Qudi...')
>   File "/usr/lib/python3.5/logging/__init__.py", line 1280, in info
>     self._log(INFO, msg, args, **kwargs)
>   File "/usr/lib/python3.5/logging/__init__.py", line 1416, in _log
>     self.handle(record)
>   File "/usr/lib/python3.5/logging/__init__.py", line 1426, in handle
>     self.callHandlers(record)
>   File "/usr/lib/python3.5/logging/__init__.py", line 1488, in callHandlers
>     hdlr.handle(record)
>   File "/usr/lib/python3.5/logging/__init__.py", line 856, in handle
>     self.emit(record)
>   File "/home/jan/qo/qudi-tobias/core/logger.py", line 112, in emit
>     self.sigLoggedMessage.emit(record)
> TypeError: emit() takes 2 positional arguments but 3 were given
> Unexpected return value 1. Exiting.

The problem here is that pyside defines a method "emit" which we override. pyqt* and even Qt itself does not define this method. I don't see an easy fix for this problem.

Commenting the line in question out and applying this pull request at least starts up the manager, but we get more errors and the manager is not fully functional:

> Specified Qt API: pyside
> Used Qt API: PySide
> Loading Qudi...
> QGtkStyle could not resolve GTK. Make sure you have installed the proper libraries.
> ============= Starting Manager configuration from /home/tobias/Development/projects/qudi/config/example/default.cfg =================
> 
> ============= Manager configuration complete =================
> 
> Remote connection not secured! Use a certificate!
> <module 'gui.manager.managergui' from '/home/tobias/Development/projects/qudi/gui/manager/managergui.py'> ManagerGui
> 
> Traceback (most recent call last):
>   File "/home/tobias/.local/opt-hdd/conda/envs/pyside/lib/python3.4/site-packages/qtpy/uic.py", line 145, in createWidget
>     widget = self.customWidgets[class_name](parent)
> TypeError: __init__() takes 1 positional argument but 2 were given
> Designer: The creation of a widget of the class '' failed.
> 
> Traceback (most recent call last):
>   File "/home/tobias/.local/opt-hdd/conda/envs/pyside/lib/python3.4/site-packages/qtpy/uic.py", line 145, in createWidget
>     widget = self.customWidgets[class_name](parent)
> TypeError: __init__() takes 1 positional argument but 2 were given
> Designer: The creation of a widget of the class '' failed.
> Could not get git repo because: name 'Repo' is not defined
> Error during activation
> Traceback (most recent call last):
>   File "/home/tobias/Development/projects/qudi/core/base.py", line 157, in _wrap_activation
>     self.activate()
>   File "/home/tobias/.local/opt-hdd/conda/envs/pyside/lib/python3.4/site-packages/fysom/__init__.py", line 300, in fn
>     self.transition()
>   File "/home/tobias/.local/opt-hdd/conda/envs/pyside/lib/python3.4/site-packages/fysom/__init__.py", line 295, in _tran
>     self._after_event(e)
>   File "/home/tobias/.local/opt-hdd/conda/envs/pyside/lib/python3.4/site-packages/fysom/__init__.py", line 326, in _after_event
>     return getattr(self, fnname)(e)
>   File "/home/tobias/.local/opt-hdd/conda/envs/pyside/lib/python3.4/site-packages/fysom/__init__.py", line 89, in _callback
>     return func(obj, *args, **kwargs)
>   File "/home/tobias/Development/projects/qudi/gui/manager/managergui.py", line 160, in on_activate
>     self._mw.threadWidget.threadListView.setModel(self._manager.tm)
> AttributeError: 'ManagerMainWindow' object has no attribute 'threadWidget'
> <module 'gui.trayicon' from '/home/tobias/Development/projects/qudi/gui/trayicon.py'> TrayIcon
> <module 'logic.taskrunner' from '/home/tobias/Development/projects/qudi/logic/taskrunner.py'> TaskRunner
> logic module tasklogic: error during activation:
> Traceback (most recent call last):
>   File "/home/tobias/Development/projects/qudi/core/manager.py", line 864, in activateModule
>     QtCore.Q_RETURN_ARG(bool))
> AttributeError: 'module' object has no attribute 'Q_RETURN_ARG'
> 

I don't really have any motivation to fix these issues.