### PR TITLE
Nicard voltage range

### DIFF
--- a/hardware/confocal_scanner_dummy.py
+++ b/hardware/confocal_scanner_dummy.py
@@ -50,17 +50,16 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
             self._clock_frequency = config['clock_frequency']
         else:
             self._clock_frequency = 100
-            self.log.warning('No clock_frequency configured taking 100 Hz '
-                    'instead.')
+            self.log.warning('No clock_frequency configured taking 100 Hz instead.')
 
 
         # Internal parameters
         self._line_length = None
         self._scanner_counter_daq_task = None
-        self._voltage_range = [-10., 10.]
+        self._voltage_range = [-10, 10]
 
-        self._position_range = [[0., 100.], [0., 100.], [0., 100.], [0., 1.]]
-        self._current_position = [0., 0., 0., 0.]
+        self._position_range = [[0, 100], [0, 100], [0, 100], [0, 1]]
+        self._current_position = [0, 0, 0, 0]
 
         self._num_points = 500
 
@@ -81,9 +80,7 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
         # put randomly distributed NVs in the scanner, first the x,y scan
         self._points = np.empty([self._num_points, 7])
         # amplitude
-        self._points[:, 0] = np.random.normal(4e5,
-                                              1e5,
-                                              self._num_points)
+        self._points[:, 0] = np.random.normal(4e5, 1e5, self._num_points)
         # x_zero
         self._points[:, 1] = np.random.uniform(self._position_range[0][0],
                                                self._position_range[0][1],
@@ -93,13 +90,9 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
                                                self._position_range[1][1],
                                                self._num_points)
         # sigma_x
-        self._points[:, 3] = np.random.normal(0.7,
-                                              0.1,
-                                              self._num_points)
+        self._points[:, 3] = np.random.normal(0.7, 0.1, self._num_points)
         # sigma_y
-        self._points[:, 4] = np.random.normal(0.7,
-                                              0.1,
-                                              self._num_points)
+        self._points[:, 4] = np.random.normal(0.7, 0.1, self._num_points)
         # theta
         self._points[:, 5] = 10
         # offset
@@ -110,19 +103,13 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
 
         self._points_z = np.empty([self._num_points, 4])
         # amplitude
-        self._points_z[:, 0] = np.random.normal(1,
-                                                0.05,
-                                                self._num_points)
+        self._points_z[:, 0] = np.random.normal(1, 0.05, self._num_points)
 
         # x_zero
-        self._points_z[:, 1] = np.random.uniform(45,
-                                                 55,
-                                                 self._num_points)
+        self._points_z[:, 1] = np.random.uniform(45, 55, self._num_points)
 
         # sigma
-        self._points_z[:, 2] = np.random.normal(0.5,
-                                              0.1,
-                                              self._num_points)
+        self._points_z[:, 2] = np.random.normal(0.5, 0.1, self._num_points)
 
         # offset
         self._points_z[:, 3] = 0
@@ -175,9 +162,8 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
         for pos in myrange:
             if len(pos) != 2:
                 self.log.error('Given range limit {1:d} should have '
-                        'dimension 2, but has {0:d} instead.'.format(
-                            len(pos),
-                            pos))
+                        'dimension 2, but has {0:d} instead.'
+                        ''.format(len(pos), pos))
                 return -1
             if pos[0]>pos[1]:
                 self.log.error('Given range limit {0:d} has the wrong '
@@ -185,18 +171,17 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
                 return -1
 
         self._position_range = myrange
-
         return 0
 
     def set_voltage_range(self, myrange=None):
         """ Sets the voltage range of the NI Card.
 
-        @param float [2] myrange: array containing lower and upper limit
+        @param float [4][2] myrange: array containing lower and upper limit
 
         @return int: error code (0:OK, -1:error)
         """
         if myrange is None:
-            myrange = [-10.,10.]
+            myrange = [[-10, 10], [-10, 10], [-10, 10], [-10, 10]]
 
         if not isinstance(myrange, (frozenset, list, set, tuple, np.ndarray, )):
             self.log.error('Given range is no array type.')
@@ -282,14 +267,11 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
         """
 
         if self.getState() == 'locked':
-            self.log.error('A Scanner is already running, close this one '
-                    'first.')
+            self.log.error('A Scanner is already running, close this one first.')
             return -1
 
         time.sleep(0.01)
-
         self._current_position = [x, y, z, a]
-
         return 0
 
     def get_scanner_position(self):
@@ -309,9 +291,6 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
         """
 
         self._line_length = length
-
-#        self.log.debug('ConfocalScannerInterfaceDummy>set_up_line')
-
         return 0
 
 
@@ -357,8 +336,8 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
                               *(self._points_z[i]))))
 
 
-        time.sleep(self._line_length*1./self._clock_frequency)
-        time.sleep(self._line_length*1./self._clock_frequency)
+        time.sleep(self._line_length * 1/self._clock_frequency)
+        time.sleep(self._line_length * 1/self._clock_frequency)
 
 #        self.log.warning('ConfocalScannerInterfaceDummy>scan_line: length {0:d}.'.format(self._line_length))
 
@@ -433,17 +412,12 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
         x_zero = float(x_zero)
         y_zero = float(y_zero)
 
-        a = (np.cos(theta)**2)/(2*sigma_x**2) \
-                                    + (np.sin(theta)**2)/(2*sigma_y**2)
-        b = -(np.sin(2*theta))/(4*sigma_x**2) \
-                                    + (np.sin(2*theta))/(4*sigma_y**2)
-        c = (np.sin(theta)**2)/(2*sigma_x**2) \
-                                    + (np.cos(theta)**2)/(2*sigma_y**2)
-        g = offset + amplitude*np.exp( - (a*((x-x_zero)**2) \
-                                + 2*b*(x-x_zero)*(y-y_zero) \
-                                + c*((y-y_zero)**2)))
+        a = (np.cos(theta)**2) / (2 * sigma_x**2) + (np.sin(theta)**2) / (2 * sigma_y**2)
+        b = -(np.sin(2 * theta)) / (4 * sigma_x**2) + (np.sin(2 * theta)) / (4 * sigma_y**2)
+        c = (np.sin(theta)**2) / (2 * sigma_x**2) + (np.cos(theta)**2) / (2 * sigma_y**2)
+        g = offset + amplitude * np.exp(
+            - (a*((x-x_zero)**2) + 2*b*(x-x_zero)*(y-y_zero) c * ((y - y_zero)**2)))
         return g.ravel()
-
 
     def gaussian_function(self, x_data=None, amplitude=None, x_zero=None,
                           sigma=None, offset=None):

--- a/hardware/confocal_scanner_dummy.py
+++ b/hardware/confocal_scanner_dummy.py
@@ -206,6 +206,10 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
 
         return 0
 
+    def get_scanner_axes(self):
+        """ Dummy scanner is always 3D cartesian.
+        """
+        return ['x', 'y', 'z']
 
     def set_up_scanner_clock(self, clock_frequency=None, clock_channel=None):
         """ Configures the hardware clock of the NiDAQ card to give the timing.
@@ -416,7 +420,7 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
         b = -(np.sin(2 * theta)) / (4 * sigma_x**2) + (np.sin(2 * theta)) / (4 * sigma_y**2)
         c = (np.sin(theta)**2) / (2 * sigma_x**2) + (np.cos(theta)**2) / (2 * sigma_y**2)
         g = offset + amplitude * np.exp(
-            - (a*((x-x_zero)**2) + 2*b*(x-x_zero)*(y-y_zero) c * ((y - y_zero)**2)))
+            - (a*((x-x_zero)**2) + 2*b*(x-x_zero)*(y-y_zero) + c * ((y - y_zero)**2)))
         return g.ravel()
 
     def gaussian_function(self, x_data=None, amplitude=None, x_zero=None,

--- a/hardware/ni_card.py
+++ b/hardware/ni_card.py
@@ -358,7 +358,8 @@ class NICard(Base, SlowCounterInterface, ConfocalScannerInterface, ODMRCounterIn
                     'Configuration ({0}) of x_voltage_range incorrect, taking [-10, 10] instead.'
                     ''.format(config['x_voltage_range']))
         else:
-            self.log.warning('No x_voltage_range configured, taking [-10, 10] instead.')
+            if 'voltage_range' not in config.keys():
+                self.log.warning('No x_voltage_range configured, taking [-10, 10] instead.')
 
         if 'y_voltage_range' in config.keys():
             if float(config['y_voltage_range'][0]) < float(config['y_voltage_range'][1]):
@@ -370,7 +371,8 @@ class NICard(Base, SlowCounterInterface, ConfocalScannerInterface, ODMRCounterIn
                     'Configuration ({0}) of y_voltage_range incorrect, taking [-10, 10] instead.'
                     ''.format(config['y_voltage_range']))
         else:
-            self.log.warning('No y_voltage_range configured, taking [-10, 10] instead.')
+            if 'voltage_range' not in config.keys():
+                self.log.warning('No y_voltage_range configured, taking [-10, 10] instead.')
 
         if 'z_voltage_range' in config.keys():
             if float(config['z_voltage_range'][0]) < float(config['z_voltage_range'][1]):
@@ -382,7 +384,8 @@ class NICard(Base, SlowCounterInterface, ConfocalScannerInterface, ODMRCounterIn
                     'Configuration ({0}) of z_voltage_range incorrect, taking [-10, 10] instead.'
                     ''.format(config['z_voltage_range']))
         else:
-            self.log.warning('No z_voltage_range configured, taking [-10, 10] instead.')
+            if 'voltage_range' not in config.keys():
+                self.log.warning('No z_voltage_range configured, taking [-10, 10] instead.')
 
         if 'a_voltage_range' in config.keys():
             if float(config['a_voltage_range'][0]) < float(config['a_voltage_range'][1]):
@@ -394,7 +397,8 @@ class NICard(Base, SlowCounterInterface, ConfocalScannerInterface, ODMRCounterIn
                     'Configuration ({0}) of a_voltage_range incorrect, taking [-10, 10] instead.'
                     ''.format(config['a_voltage_range']))
         else:
-            self.log.warning('No a_voltage_range configured taking [-10, 10] instead.')
+            if 'voltage_range' not in config.keys():
+                self.log.warning('No a_voltage_range configured taking [-10, 10] instead.')
 
         # Analog output is always needed and it does not interfere with the
         # rest, so start it always and leave it running
@@ -1344,11 +1348,11 @@ class NICard(Base, SlowCounterInterface, ConfocalScannerInterface, ODMRCounterIn
         volts = np.vstack(vlist)
 
         for v in volts.enumerate():
-        if v.min() < self._voltage_range[i][0] or v.max() > self._voltage_range[i][1]:
-            self.log.error(
-                'Voltages ({0}, {1}) exceed the limit, the positions have to '
-                'be adjusted to stay in the given range.'.format(v.min(), v.max()))
-            return np.array([np.NaN])
+            if v.min() < self._voltage_range[i][0] or v.max() > self._voltage_range[i][1]:
+                self.log.error(
+                    'Voltages ({0}, {1}) exceed the limit, the positions have to '
+                    'be adjusted to stay in the given range.'.format(v.min(), v.max()))
+                return np.array([np.NaN])
         return volts
 
     def get_scanner_position(self):

--- a/hardware/ni_card.py
+++ b/hardware/ni_card.py
@@ -1381,73 +1381,73 @@ class NICard(Base, SlowCounterInterface, ConfocalScannerInterface, ODMRCounterIn
         self._line_length = length
 
         try:
-           # Just a formal check whether length is not a too huge number
-           if length < np.inf:
+            # Just a formal check whether length is not a too huge number
+            if length < np.inf:
 
-               # Configure the Sample Clock Timing.
-               # Set up the timing of the scanner counting while the voltages are
-               # being scanned (i.e. that you go through each voltage, which
-               # corresponds to a position. How fast the voltages are being
-               # changed is combined with obtaining the counts per voltage peak).
-               daq.DAQmxCfgSampClkTiming(
-                   # add to this task
-                   self._scanner_ao_task,
-                   # use this channel as clock
-                   self._my_scanner_clock_channel+'InternalOutput',
-                   # Maximum expected clock frequency
-                   self._scanner_clock_frequency,
-                   # Generate sample on falling edge
-                   daq.DAQmx_Val_Falling,
-                   # generate finite number of samples
-                   daq.DAQmx_Val_FiniteSamps,
-                   # number of samples to generate
-                   self._line_length)
+                # Configure the Sample Clock Timing.
+                # Set up the timing of the scanner counting while the voltages are
+                # being scanned (i.e. that you go through each voltage, which
+                # corresponds to a position. How fast the voltages are being
+                # changed is combined with obtaining the counts per voltage peak).
+                daq.DAQmxCfgSampClkTiming(
+                    # add to this task
+                    self._scanner_ao_task,
+                    # use this channel as clock
+                    self._my_scanner_clock_channel+'InternalOutput',
+                    # Maximum expected clock frequency
+                    self._scanner_clock_frequency,
+                    # Generate sample on falling edge
+                    daq.DAQmx_Val_Falling,
+                    # generate finite number of samples
+                    daq.DAQmx_Val_FiniteSamps,
+                    # number of samples to generate
+                    self._line_length)
 
-           # Configure Implicit Timing for the clock.
-           # Set timing for scanner clock task to the number of pixel.
-           daq.DAQmxCfgImplicitTiming(
-               # define task
-               self._scanner_clock_daq_task,
-               # only a limited number of# counts
-               daq.DAQmx_Val_FiniteSamps,
-               # count twice for each voltage +1 for safety
-               self._line_length + 1)
+            # Configure Implicit Timing for the clock.
+            # Set timing for scanner clock task to the number of pixel.
+            daq.DAQmxCfgImplicitTiming(
+                # define task
+                self._scanner_clock_daq_task,
+                # only a limited number of# counts
+                daq.DAQmx_Val_FiniteSamps,
+                # count twice for each voltage +1 for safety
+                self._line_length + 1)
 
-           # Configure Implicit Timing for the scanner counting task.
-           # Set timing for scanner count task to the number of pixel.
-           daq.DAQmxCfgImplicitTiming(
-               # define task
-               self._scanner_counter_daq_task,
-               # only a limited number of counts
-               daq.DAQmx_Val_FiniteSamps,
-               # count twice for each voltage +1 for safety
-               2 * self._line_length + 1)
+            # Configure Implicit Timing for the scanner counting task.
+            # Set timing for scanner count task to the number of pixel.
+            daq.DAQmxCfgImplicitTiming(
+                # define task
+                self._scanner_counter_daq_task,
+                # only a limited number of counts
+                daq.DAQmx_Val_FiniteSamps,
+                # count twice for each voltage +1 for safety
+                2 * self._line_length + 1)
 
-           # Set the Read point Relative To an operation.
-           # Specifies the point in the buffer at which to begin a read operation,
-           # here we read samples from beginning of acquisition and do not overwrite
-           daq.DAQmxSetReadRelativeTo(
-               # define to which task to connect this function
-               self._scanner_counter_daq_task,
-               # Start reading samples relative to the last sample returned by the previous read
-               daq.DAQmx_Val_CurrReadPos)
+            # Set the Read point Relative To an operation.
+            # Specifies the point in the buffer at which to begin a read operation,
+            # here we read samples from beginning of acquisition and do not overwrite
+            daq.DAQmxSetReadRelativeTo(
+                # define to which task to connect this function
+                self._scanner_counter_daq_task,
+                # Start reading samples relative to the last sample returned by the previous read
+                daq.DAQmx_Val_CurrReadPos)
 
-           # Set the Read Offset.
-           # Specifies an offset in samples per channel at which to begin a read
-           # operation. This offset is relative to the location you specify with
-           # RelativeTo. Here we do not read the first sample.
-           daq.DAQmxSetReadOffset(
-               # connect to this taks
-               self._scanner_counter_daq_task,
-               # Offset after which to read
-               1)
+            # Set the Read Offset.
+            # Specifies an offset in samples per channel at which to begin a read
+            # operation. This offset is relative to the location you specify with
+            # RelativeTo. Here we do not read the first sample.
+            daq.DAQmxSetReadOffset(
+                # connect to this taks
+                self._scanner_counter_daq_task,
+                # Offset after which to read
+                1)
 
-           # Set Read OverWrite Mode.
-           # Specifies whether to overwrite samples in the buffer that you have
-           # not yet read. Unread data in buffer will be overwritten:
-           daq.DAQmxSetReadOverWrite(
-               self._scanner_counter_daq_task,
-               daq.DAQmx_Val_DoNotOverwriteUnreadSamps)
+            # Set Read OverWrite Mode.
+            # Specifies whether to overwrite samples in the buffer that you have
+            # not yet read. Unread data in buffer will be overwritten:
+            daq.DAQmxSetReadOverWrite(
+                self._scanner_counter_daq_task,
+                daq.DAQmx_Val_DoNotOverwriteUnreadSamps)
         except:
             self.log.exception('Error while setting up scanner to scan a line.')
             return -1

--- a/hardware/ni_card.py
+++ b/hardware/ni_card.py
@@ -189,6 +189,8 @@ class NICard(Base, SlowCounterInterface, ConfocalScannerInterface, ODMRCounterIn
                 self._scanner_ao_channels.append(config['scanner_y_ao'])
                 if 'scanner_z_ao' in config.keys():
                     self._scanner_ao_channels.append(config['scanner_z_ao'])
+                    if 'scanner_a_ao' in config.keys():
+                        self._scanner_ao_channels.append(config['scanner_a_ao'])
         if len(self._scanner_ao_channels) < 1:
             self.log.error(
                 'Not enough scanner channels found in the configuration!\n'
@@ -382,7 +384,7 @@ class NICard(Base, SlowCounterInterface, ConfocalScannerInterface, ODMRCounterIn
 
         if 'z_voltage_range' in config.keys():
             if float(config['z_voltage_range'][0]) < float(config['z_voltage_range'][1]):
-                vlow = float(config['z_voltage__range'][0])
+                vlow = float(config['z_voltage_range'][0])
                 vhigh = float(config['z_voltage_range'][1])
                 self._voltage_range[2] = [vlow, vhigh]
             else:

--- a/hardware/ni_card.py
+++ b/hardware/ni_card.py
@@ -961,6 +961,18 @@ class NICard(Base, SlowCounterInterface, ConfocalScannerInterface, ODMRCounterIn
                 retval = -1
         return retval
 
+    def get_scanner_axes(self):
+        """ Scanner axes depends on how many channels tha analog output task has.
+        """
+        if self._scanner_ao_task is None:
+            return []
+        
+        n_channels = daq.int32()
+        daq.DAQmxGetTaskNumChans(self._scanner_ao_task, daq.byref(n_channels))
+        possible_channels = ['x', 'y', 'z', 'a']
+
+        return possible_channels[0:n_channels]
+
     def get_position_range(self):
         """ Returns the physical range of the scanner.
 

--- a/interface/confocal_scanner_interface.py
+++ b/interface/confocal_scanner_interface.py
@@ -65,7 +65,7 @@ class ConfocalScannerInterface(metaclass=InterfaceMetaclass):
     def set_voltage_range(self, myrange=None):
         """ Sets the voltage range of the NI Card.
 
-        @param float [2] myrange: array containing lower and upper limit
+        @param float [4][2] myrange: array of 4 ranges  containing lower and upper limit
 
         @return int: error code (0:OK, -1:error)
         """

--- a/interface/confocal_scanner_interface.py
+++ b/interface/confocal_scanner_interface.py
@@ -72,6 +72,22 @@ class ConfocalScannerInterface(metaclass=InterfaceMetaclass):
         pass
 
     @abc.abstractmethod
+    def get_scanner_axes(self):
+    """ Find out how many axes the scanning device is using for confocal and their names.
+
+    @return list(str): list of axis names
+
+    Example:
+      For 3D confocal microscopy in cartesian coordinates, ['x', 'y', 'z'] is a sensible value.
+      For 2D, ['x', 'y'] would be typical.
+      You could build a turntable microscope with ['r', 'phi', 'z'].
+      Most callers of this function will only care about the number of axes, though.
+
+      On error, return an empty list.
+    """
+    pass
+
+    @abc.abstractmethod
     def set_up_scanner_clock(self, clock_frequency=None, clock_channel=None):
         """ Configures the hardware clock of the NiDAQ card to give the timing.
 

--- a/interface/confocal_scanner_interface.py
+++ b/interface/confocal_scanner_interface.py
@@ -73,19 +73,19 @@ class ConfocalScannerInterface(metaclass=InterfaceMetaclass):
 
     @abc.abstractmethod
     def get_scanner_axes(self):
-    """ Find out how many axes the scanning device is using for confocal and their names.
-
-    @return list(str): list of axis names
-
-    Example:
-      For 3D confocal microscopy in cartesian coordinates, ['x', 'y', 'z'] is a sensible value.
-      For 2D, ['x', 'y'] would be typical.
-      You could build a turntable microscope with ['r', 'phi', 'z'].
-      Most callers of this function will only care about the number of axes, though.
-
-      On error, return an empty list.
-    """
-    pass
+        """ Find out how many axes the scanning device is using for confocal and their names.
+ 
+        @return list(str): list of axis names
+ 
+        Example:
+          For 3D confocal microscopy in cartesian coordinates, ['x', 'y', 'z'] is a sensible value.
+          For 2D, ['x', 'y'] would be typical.
+          You could build a turntable microscope with ['r', 'phi', 'z'].
+          Most callers of this function will only care about the number of axes, though.
+ 
+          On error, return an empty list.
+        """
+        pass
 
     @abc.abstractmethod
     def set_up_scanner_clock(self, clock_frequency=None, clock_channel=None):

--- a/interface/confocal_scanner_interface.py
+++ b/interface/confocal_scanner_interface.py
@@ -120,7 +120,7 @@ class ConfocalScannerInterface(metaclass=InterfaceMetaclass):
 
     @abc.abstractmethod
     def scanner_set_position(self, x=None, y=None, z=None, a=None):
-        """Move stage to x, y, z, a (where a is the fourth voltage channel).
+        """Move stage to x, y, z, a (where a is the fourth voltage channel).ha
 
         @param float x: postion in x-direction (volts)
         @param float y: postion in y-direction (volts)

--- a/logic/confocal_logic.py
+++ b/logic/confocal_logic.py
@@ -493,7 +493,7 @@ class ConfocalLogic(GenericLogic):
 
         # Arrays for retrace line
         self._return_XL = np.linspace(self._XL[-1], self._XL[0], self.return_slowness)
-        self._return_AL = np.zeros(self._return_XL.shape)
+        self._return_AL = np.ones(self._return_XL.shape)
 
         if self._zscan:
             if self.depth_scan_dir_is_xz:
@@ -514,7 +514,7 @@ class ConfocalLogic(GenericLogic):
                 self.depth_image[:, :, 2] = z_value_matrix.transpose()
                 # now we are scanning along the y-axis, so we need a new return line along Y:
                 self._return_YL = np.linspace(self._YL[-1], self._YL[0], self.return_slowness)
-                self._return_AL = np.zeros(self._return_YL.shape)
+                self._return_AL = np.ones(self._return_YL.shape)
             self.sigImageDepthInitialized.emit()
         else:
             self._image_vert_axis = self._Y
@@ -682,7 +682,7 @@ class ConfocalLogic(GenericLogic):
                     np.linspace(self._current_x, image[self._scan_counter, 0, 0], self.return_slowness),
                     np.linspace(self._current_y, image[self._scan_counter, 0, 1], self.return_slowness),
                     np.linspace(self._current_z, image[self._scan_counter, 0, 2], self.return_slowness),
-                    np.linspace(self._current_a, 0, self.return_slowness)
+                    np.full((self.return_slowness, ), self._current_a)
                     ))
                 # move to the start position of the scan, counts are thrown away
                 start_line_counts = self._scanning_device.scan_line(start_line)
@@ -699,7 +699,8 @@ class ConfocalLogic(GenericLogic):
             line = np.vstack((image[self._scan_counter, :, 0],
                               image[self._scan_counter, :, 1],
                               image[self._scan_counter, :, 2],
-                              image[self._scan_counter, :, 3]))
+                              np.full(image[self._scan_counter, :, 3].shape, self._current_a)
+                              ))
             # scan the line in the scan
             line_counts = self._scanning_device.scan_line(line)
             if line_counts[0] == -1:
@@ -713,14 +714,14 @@ class ConfocalLogic(GenericLogic):
                     self._return_XL,
                     image[self._scan_counter, 0, 1] * np.ones(self._return_XL.shape),
                     image[self._scan_counter, 0, 2] * np.ones(self._return_XL.shape),
-                    self._return_AL
+                    self._return_AL * self._current_a
                     ))
             else:
                 return_line = np.vstack((
                     image[self._scan_counter, 0, 1] * np.ones(self._return_YL.shape),
                     self._return_YL,
                     image[self._scan_counter, 0, 2] * np.ones(self._return_YL.shape),
-                    self._return_AL
+                    self._return_AL * self._current_a
                     ))
 
             # return the scanner to the start of next line, counts are thrown away

--- a/logic/confocal_logic.py
+++ b/logic/confocal_logic.py
@@ -673,6 +673,7 @@ class ConfocalLogic(GenericLogic):
                 return
 
         image = self.depth_image if self._zscan else self.xy_image
+        n_ch = len(self._scanning_device.get_scanner_axes())
 
         try:
             if self._scan_counter == 0:
@@ -683,7 +684,7 @@ class ConfocalLogic(GenericLogic):
                     np.linspace(self._current_y, image[self._scan_counter, 0, 1], self.return_slowness),
                     np.linspace(self._current_z, image[self._scan_counter, 0, 2], self.return_slowness),
                     np.full((self.return_slowness, ), self._current_a)
-                    ))
+                    )[0:n_ch])
                 # move to the start position of the scan, counts are thrown away
                 start_line_counts = self._scanning_device.scan_line(start_line)
                 if start_line_counts[0] == -1:
@@ -700,7 +701,7 @@ class ConfocalLogic(GenericLogic):
                               image[self._scan_counter, :, 1],
                               image[self._scan_counter, :, 2],
                               np.full(image[self._scan_counter, :, 3].shape, self._current_a)
-                              ))
+                              )[0:n_ch])
             # scan the line in the scan
             line_counts = self._scanning_device.scan_line(line)
             if line_counts[0] == -1:
@@ -715,14 +716,14 @@ class ConfocalLogic(GenericLogic):
                     image[self._scan_counter, 0, 1] * np.ones(self._return_XL.shape),
                     image[self._scan_counter, 0, 2] * np.ones(self._return_XL.shape),
                     self._return_AL * self._current_a
-                    ))
+                    )[0:n_ch])
             else:
                 return_line = np.vstack((
                     image[self._scan_counter, 0, 1] * np.ones(self._return_YL.shape),
                     self._return_YL,
                     image[self._scan_counter, 0, 2] * np.ones(self._return_YL.shape),
                     self._return_AL * self._current_a
-                    ))
+                    )[0:n_ch])
 
             # return the scanner to the start of next line, counts are thrown away
             return_line_counts = self._scanning_device.scan_line(return_line)

--- a/logic/confocal_logic.py
+++ b/logic/confocal_logic.py
@@ -631,8 +631,7 @@ class ConfocalLogic(GenericLogic):
         self._scanning_device.scanner_set_position(
             x=self._current_x,
             y=self._current_y,
-            z=self._current_z,
-            a=self._current_a
+            z=self._current_z
         )
         return 0
 

--- a/logic/confocal_logic.py
+++ b/logic/confocal_logic.py
@@ -613,6 +613,8 @@ class ConfocalLogic(GenericLogic):
             self._current_y = y
         if z is not None:
             self._current_z = z
+        if a is not None:
+            self._current_a = a
 
         # Checks if the scanner is still running
         if self.getState() == 'locked' or self._scanning_device.getState() == 'locked':
@@ -627,14 +629,15 @@ class ConfocalLogic(GenericLogic):
 
         @return int: error code (0:OK, -1:error)
         """
-        # if tag == 'optimizer' or tag == 'scanner' or tag == 'activation':
-        self._scanning_device.scanner_set_position(
-            x=self._current_x,
-            y=self._current_y,
-            z=self._current_z
-        )
-        return 0
+        ch_array = ['x', 'y', 'z', 'a']
+        pos_array = [self._current_x, self._current_y, self._current_z, self._current_a]
+        pos_dict = {}
 
+        for i, ch in enumerate(self._scanning_device.get_scanner_axes()):
+            pos_dict[ch_array[i]] = pos_array[i]
+
+        self._scanning_device.scanner_set_position(**pos_dict)
+        return 0
 
     def get_position(self):
         """Forwarding the desired new position from the GUI to the scanning device.
@@ -643,7 +646,7 @@ class ConfocalLogic(GenericLogic):
                       position in microns
         """
         #FIXME: change that to SI units!
-        return self._scanning_device.get_scanner_position()[:3]
+        return self._scanning_device.get_scanner_position()
 
     def _scan_line(self):
         """scanning an image in either depth or xy

--- a/logic/interfuse/scanner_tilt_interfuse.py
+++ b/logic/interfuse/scanner_tilt_interfuse.py
@@ -101,6 +101,10 @@ class ScannerTiltInterfuse(GenericLogic, ConfocalScannerInterface):
             myrange = [-10., 10.]
         return self._scanning_device.set_voltage_range(myrange)
 
+    def get_scanner_axes(self):
+        """ Pass through scanner axes """
+        return self._scanning_device.get_scanner_axes()
+
     def set_up_scanner_clock(self, clock_frequency=None, clock_channel=None):
         """ Configures the hardware clock of the NiDAQ card to give the timing.
 


### PR DESCRIPTION
Every scanner axis now has its own voltage range and you can specify up to 3 axes for ni_card.
Right now, confocal logic will probably only work with 3 or 4 given channels.

When this goes live, you need to change the following configuration settings for the ni_card module:
Replace scanner_ao_channels with scanner_x_ao, scanner_y_ao and scanner_z_ao.

Example:
replace
    scanner_ao_channels: '/Dev0/AO0:3'
with
    scanner_x_ao: '/Dev0/AO0'
    scanner_y_ao: '/Dev0/AO1'
    scanner_z_ao: '/Dev0/AO2'

voltage_range can (but does not have to) be replaced with x_voltage_range,  y_voltage_range,  z_voltage_range.
 
I tested this, but please test to minimize problems.