### PR TITLE
added a float and an int qt property to the scientific spinbox widget

### DIFF
--- a/qtwidgets/pyqtgraphmod/SpinBox.py
+++ b/qtwidgets/pyqtgraphmod/SpinBox.py
@@ -9,6 +9,8 @@ from decimal import Decimal as D  ## Use decimal to avoid accumulating floating-
 from decimal import *
 import weakref
 
+from qtpy.QtCore import Property
+
 __all__ = ['SpinBox']
 class SpinBox(QtGui.QAbstractSpinBox):
     """
@@ -351,6 +353,10 @@ class SpinBox(QtGui.QAbstractSpinBox):
 
         return value
 
+    value_float = Property(float, value, setValue,
+                           doc='Qt property value as type float')
+    value_int = Property(int, value, setValue,
+                         doc='Qt property value as type int')
 
     def emitChanged(self):
         self.lastValEmitted = self.val


### PR DESCRIPTION
Since the mapper is based on Qt properties it doesn't work with the current implementation of the scientific spinbox (the modded spinbox from pyqtgraph). This patch adds two lines to add a Qt property for float and int values. Qt properties cannot be changed at runtime (as far as I know) so I added a property for each possible type.