### PR TITLE
Retire out connectors

### DIFF
--- a/config/example/default.cfg
+++ b/config/example/default.cfg
@@ -30,7 +30,7 @@ hardware:
         module.Class: 'confocal_scanner_dummy.ConfocalScannerDummy'
         clock_frequency: 100
         connect:
-            fitlogic: 'fitlogic.fitlogic'
+            fitlogic: 'fitlogic'
 
     mydummycounter:
         module.Class: 'slow_counter_dummy.SlowCounterDummy'
@@ -43,7 +43,7 @@ hardware:
         module.Class: 'odmr_counter_dummy.ODMRCounterDummy'
         clock_frequency: 100
         connect:
-            fitlogic: 'fitlogic.fitlogic'
+            fitlogic: 'fitlogic'
 
     mydummyfastcounter:
         module.Class: 'fast_counter_dummy.FastCounterDummy'
@@ -66,7 +66,7 @@ hardware:
     myspectrometer:
         module.Class: 'spectrometer.spectrometer_dummy.SpectrometerInterfaceDummy'
         connect:
-            fitlogic: 'fitlogic.fitlogic'
+            fitlogic: 'fitlogic'
 
     motordummy:
         module.Class: 'motor.motor_dummy.MotorDummy'
@@ -84,19 +84,19 @@ logic:
     simpledatalogic:
         module.Class: 'simple_data_logic.SimpleDataLogic'
         connect:
-            simpledata: 'simpledatadummy.simple'
+            simpledata: 'simpledatadummy'
 
     softpid:
         module.Class: 'software_pid_controller.SoftPIDController'
         connect:
-            process: 'processdummy.dummy'
-            control: 'processdummy.dummy'
+            process: 'processdummy'
+            control: 'processdummy'
 
     pidlogic:
         module.Class: 'pid_logic.PIDLogic'
         connect:
-            controller: 'softpid.controller'
-            savelogic: 'savelogic.savelogic'
+            controller: 'softpid'
+            savelogic: 'savelogic'
 
     kernellogic:
         module.Class: 'jupyterkernel.kernellogic.QudiKernelLogic'
@@ -106,8 +106,8 @@ logic:
         module.Class: 'pulsed_master_logic.PulsedMasterLogic'
         direct_write: False
         connect:
-            pulsedmeasurementlogic: 'pulsedmeasurementlogic.pulsedmeasurementlogic'
-            sequencegeneratorlogic: 'sequencegeneratorlogic.sequencegenerator'
+            pulsedmeasurementlogic: 'pulsedmeasurementlogic'
+            sequencegeneratorlogic: 'sequencegeneratorlogic'
 
     sequencegeneratorlogic:
         module.Class: 'sequence_generator_logic.SequenceGeneratorLogic'
@@ -122,73 +122,73 @@ logic:
     pulsedmeasurementlogic:
         module.Class: 'pulsed_measurement_logic.PulsedMeasurementLogic'
         connect:
-            fastcounter: 'mydummyfastcounter.fastcounter'
-            pulseanalysislogic: 'pulseanalysislogic.pulseanalysislogic'
-            pulseextractionlogic: 'pulseextractionlogic.pulseextractionlogic'
-            pulsegenerator: 'mydummypulser.pulser'
-            fitlogic: 'fitlogic.fitlogic'
-            savelogic: 'savelogic.savelogic'
-            microwave: 'mykrowave.mwsourcedummy'
+            fastcounter: 'mydummyfastcounter'
+            pulseanalysislogic: 'pulseanalysislogic'
+            pulseextractionlogic: 'pulseextractionlogic'
+            pulsegenerator: 'mydummypulser'
+            fitlogic: 'fitlogic'
+            savelogic: 'savelogic'
+            microwave: 'mykrowave'
 
     counterlogic:
         module.Class: 'counter_logic.CounterLogic'
         connect:
-            counter1: 'mydummycounter.counter'
-            savelogic: 'savelogic.savelogic'
+            counter1: 'mydummycounter'
+            savelogic: 'savelogic'
 
     gatedcounterlogic:
         module.Class: 'counter_logic.CounterLogic'
         connect:
-            counter1: 'mydummycounter.counter'
-            savelogic: 'savelogic.savelogic'
+            counter1: 'mydummycounter'
+            savelogic: 'savelogic'
 
     wavemeterloggerlogic:
         module.Class: 'wavemeter_logger_logic.WavemeterLoggerLogic'
         logic_acquisition_timing: 20
         logic_update_timing: 100
         connect:
-            wavemeter1: 'mydummywavemeter.highhinessewavemeter'
-            savelogic: 'savelogic.savelogic'
-            counterlogic: 'counterlogic.counterlogic'
+            wavemeter1: 'mydummywavemeter'
+            savelogic: 'savelogic'
+            counterlogic: 'counterlogic'
 
     switchlogic:
         module.Class: 'switch_logic.SwitchLogic'
         connect:
-            switch1: 'mydummyswitch1.switch'
-            switch2: 'mydummyswitch2.switch'
+            switch1: 'mydummyswitch1'
+            switch2: 'mydummyswitch2'
 
     scannerlogic:
         module.Class: 'confocal_logic.ConfocalLogic'
         connect:
-            confocalscanner1: 'scanner_tilt_interfuse.confocalscanner1'
-            savelogic: 'savelogic.savelogic'
+            confocalscanner1: 'scanner_tilt_interfuse'
+            savelogic: 'savelogic'
 
     scanner_tilt_interfuse:
         module.Class: 'interfuse.scanner_tilt_interfuse.ScannerTiltInterfuse'
         connect:
-            confocalscanner1: 'mydummyscanner.confocalscanner'
+            confocalscanner1: 'mydummyscanner'
 
     optimizerlogic:
         module.Class: 'optimizer_logic.OptimizerLogic'
         connect:
-            confocalscanner1: 'scanner_tilt_interfuse.confocalscanner1'
-            fitlogic: 'fitlogic.fitlogic'
+            confocalscanner1: 'scanner_tilt_interfuse'
+            fitlogic: 'fitlogic'
 
     poimanagerlogic:
         module.Class: 'poi_manager_logic.PoiManagerLogic'
         connect:
-            scannerlogic: 'scannerlogic.scannerlogic'
-            optimizer1: 'optimizerlogic.optimizerlogic'
-            savelogic: 'savelogic.savelogic'
+            scannerlogic: 'scannerlogic'
+            optimizer1: 'optimizerlogic'
+            savelogic: 'savelogic'
 
     odmrlogic:
         module.Class: 'odmr_logic.ODMRLogic'
         connect:
-            odmrcounter: 'mydummyodmrcounter.odmrcounter'
-            fitlogic: 'fitlogic.fitlogic'
-            microwave1: 'mykrowave.mwsourcedummy'
-            savelogic: 'savelogic.savelogic'
-            taskrunner: 'tasklogic.runner'
+            odmrcounter: 'mydummyodmrcounter'
+            fitlogic: 'fitlogic'
+            microwave1: 'mykrowave'
+            savelogic: 'savelogic'
+            taskrunner: 'tasklogic'
 
     fitlogic:
         module.Class: 'fit_logic.FitLogic'
@@ -225,7 +225,7 @@ logic:
     automationlogic:
         module.Class: 'automation.AutomationLogic'
         connect:
-            taskrunner: 'tasklogic.runner'
+            taskrunner: 'tasklogic'
 
     savelogic:
         module.Class: 'save_logic.SaveLogic'
@@ -236,62 +236,62 @@ logic:
     spectrumlogic:
         module.Class: 'spectrum.SpectrumLogic'
         connect:
-            spectrometer: 'myspectrometer.spec'
-            savelogic: 'savelogic.savelogic'
-            odmrlogic1: 'odmrlogic.odmrlogic'
+            spectrometer: 'myspectrometer'
+            savelogic: 'savelogic'
+            odmrlogic1: 'odmrlogic'
 
     magnet_logic:
         module.Class: 'magnet_logic.MagnetLogic'
         connect:
-            magnetstage: 'magnetdummy.magnetstage'
-            optimizerlogic: 'optimizerlogic.optimizerlogic'
-            counterlogic: 'counterlogic.counterlogic'
-            odmrlogic: 'odmrlogic.odmrlogic'
-            savelogic: 'savelogic.savelogic'
-            scannerlogic: 'scannerlogic.scannerlogic'
-            traceanalysis: 'trace_analysis_logic.traceanalysislogic1'
-            gatedcounterlogic: 'gatedcounterlogic.counterlogic'
-            sequencegeneratorlogic: 'sequencegeneratorlogic.sequencegenerator'
+            magnetstage: 'magnetdummy'
+            optimizerlogic: 'optimizerlogic'
+            counterlogic: 'counterlogic'
+            odmrlogic: 'odmrlogic'
+            savelogic: 'savelogic'
+            scannerlogic: 'scannerlogic'
+            traceanalysis: 'trace_analysis_logic'
+            gatedcounterlogic: 'gatedcounterlogic'
+            sequencegeneratorlogic: 'sequencegeneratorlogic'
 
     magnet_motor_interfuse:
         module.Class: 'interfuse.magnet_motor_interfuse.MagnetMotorInterfuse'
         connect:
-            motorstage: 'motordummy.motorstage'
+            motorstage: 'motordummy'
 
     trace_analysis_logic:
         module.Class: 'trace_analysis_logic.TraceAnalysisLogic'
         connect:
-            counterlogic1: 'gatedcounterlogic.counterlogic'
-            savelogic: 'savelogic.savelogic'
-            fitlogic: 'fitlogic.fitlogic'
+            counterlogic1: 'gatedcounterlogic'
+            savelogic: 'savelogic'
+            fitlogic: 'fitlogic'
 
     qdplotlogic:
         module.Class: 'qdplot_logic.QdplotLogic'
         connect:
-            savelogic: 'savelogic.savelogic'
+            savelogic: 'savelogic'
 
     nuopslogic:
         module.Class: 'nuclear_operations_logic.NuclearOperationsLogic'
         connect:
-            sequencegenerationlogic: 'sequencegeneratorlogic.sequencegenerator'
-            traceanalysislogic: 'trace_analysis_logic.traceanalysislogic1'
-            gatedcounterlogic: 'gatedcounterlogic.counterlogic'
+            sequencegenerationlogic: 'sequencegeneratorlogic'
+            traceanalysislogic: 'trace_analysis_logic'
+            gatedcounterlogic: 'gatedcounterlogic'
             odmrlogic: 'odmrlogic.odmrlogic'
-            optimizerlogic: 'optimizerlogic.optimizerlogic'
-            scannerlogic: 'scannerlogic.scannerlogic'
-            savelogic: 'savelogic.savelogic'
+            optimizerlogic: 'optimizerlogic'
+            scannerlogic: 'scannerlogic'
+            savelogic: 'savelogic'
 
     laserlogic:
         module.Class: 'laser_logic.LaserLogic'
         connect:
-            laser: 'laserdummy.laser'
+            laser: 'laserdummy'
 
     pulsedextractionexternallogic:
         module.Class: 'pulsed_extraction_external_logic.PulsedExtractionExternalLogic'
         connect:
-            savelogic: 'savelogic.savelogic'
-            pulseextractionlogic: 'pulseextractionlogic.pulseextractionlogic'
-            pulseanalysislogic: 'pulseanalysislogic.pulseanalysislogic'
+            savelogic: 'savelogic'
+            pulseextractionlogic: 'pulseextractionlogic'
+            pulseanalysislogic: 'pulseanalysislogic'
 
 gui:
     tray:
@@ -303,14 +303,14 @@ gui:
     counter:
         module.Class: 'counter.countergui.CounterGui'
         connect:
-            counterlogic1: 'counterlogic.counterlogic'
+            counterlogic1: 'counterlogic'
 
     confocal:
         module.Class: 'confocal.confocalgui.ConfocalGui'
         connect:
-            confocallogic1: 'scannerlogic.scannerlogic'
-            savelogic: 'savelogic.savelogic'
-            optimizerlogic1: 'optimizerlogic.optimizerlogic'
+            confocallogic1: 'scannerlogic'
+            savelogic: 'savelogic'
+            optimizerlogic1: 'optimizerlogic'
         fixed_aspect_ratio_xy: True
         fixed_aspect_ratio_depth: True
         slider_stepsize: 0.001  # in micrometer
@@ -321,14 +321,14 @@ gui:
     poimanager:
         module.Class: 'poimanager.poimangui.PoiManagerGui'
         connect:
-            poimanagerlogic1: 'poimanagerlogic.poimanagerlogic'
-            confocallogic1: 'scannerlogic.scannerlogic'
+            poimanagerlogic1: 'poimanagerlogic'
+            confocallogic1: 'scannerlogic'
 
     odmr:
         module.Class: 'odmr.odmrgui.ODMRGui'
         connect:
-            odmrlogic1: 'odmrlogic.odmrlogic'
-            savelogic: 'savelogic.savelogic'
+            odmrlogic1: 'odmrlogic'
+            savelogic: 'savelogic'
 
     #notebookgui:
     #    module.Class: 'notebook.notebookgui.NotebookWebView'
@@ -336,56 +336,56 @@ gui:
     wavemeterlogger:
         module.Class: 'wavemeterlogger.wavemeterloggui.WavemeterLogGui'
         connect:
-            wavemeterloggerlogic1: 'wavemeterloggerlogic.wavemeterloggerlogic'
-            savelogic: 'savelogic.savelogic'
+            wavemeterloggerlogic1: 'wavemeterloggerlogic'
+            savelogic: 'savelogic'
 
     switches:
         module.Class: 'switcher.switchgui.SwitchGui'
         connect:
-            switchlogic: 'switchlogic.switchlogic'
+            switchlogic: 'switchlogic'
 
     taskrunner:
         module.Class: 'taskrunner.taskgui.TaskGui'
         connect:
-            tasklogic: 'tasklogic.runner'
+            tasklogic: 'tasklogic'
 
     automation:
         module.Class: 'automation.automationgui.AutomationGui'
         connect:
-            automationlogic: 'automationlogic.automationlogic'
+            automationlogic: 'automationlogic'
 
     spectrometer:
         module.Class: 'spectrometer.spectrometergui.SpectrometerGui'
         connect:
-            spectrumlogic1: 'spectrumlogic.spectrumlogic'
+            spectrumlogic1: 'spectrumlogic'
 
     pulsedmeasurement:
         module.Class: 'pulsed.pulsed_maingui.PulsedMeasurementGui'
         connect:
-            pulsedmasterlogic: 'pulsedmasterlogic.pulsedmasterlogic'
-            savelogic: 'savelogic.savelogic'
+            pulsedmasterlogic: 'pulsedmasterlogic'
+            savelogic: 'savelogic'
 
     simpledata:
         module.Class: 'simpledatagui.simpledatagui.SimpleDataGui'
         connect:
-            simplelogic: 'simpledatalogic.simplelogic'
+            simplelogic: 'simpledatalogic'
 
     magnet:
         module.Class: 'magnet.magnet_gui.MagnetGui'
         connect:
-            magnetlogic1: 'magnet_logic.magnetlogic'
-            savelogic: 'savelogic.savelogic'
+            magnetlogic1: 'magnet_logic'
+            savelogic: 'savelogic'
 
     gatedcounter:
         module.Class: 'gated_counter.gated_counter_gui.GatedCounterGui'
         connect:
-            gatedcounterlogic1: 'gatedcounterlogic.counterlogic'
-            traceanalysislogic1: 'trace_analysis_logic.traceanalysislogic1'
+            gatedcounterlogic1: 'gatedcounterlogic'
+            traceanalysislogic1: 'trace_analysis_logic'
 
     pidcontrol:
         module.Class: 'pidgui.pidgui.PIDGui'
         connect:
-            pidlogic: 'pidlogic.pidlogic'
+            pidlogic: 'pidlogic'
 
     errortest:
         module.Class: 'testgui.TestGui'
@@ -393,21 +393,21 @@ gui:
     qdplotter:
         module.Class: 'qdplotter.qdplottergui.QdplotterGui'
         connect:
-            qdplotlogic1: 'qdplotlogic.qdplotlogic'
+            qdplotlogic1: 'qdplotlogic'
 
     nuclearops:
         module.Class: 'nuclear_operations.nuclear_operations.NuclearOperationsGui'
         connect:
             nuclearoperationslogic: 'nuopslogic.nuclearoperationlogic'
-            savelogic: 'savelogic.savelogic'
+            savelogic: 'savelogic'
 
     laser:
         module.Class: 'laser.laser.LaserGUI'
         connect:
-            laserlogic: 'laserlogic.laserlogic'
+            laserlogic: 'laserlogic'
 
 
     externalpulseextraction:
         module.Class: 'pulsed.pulsed_extraction_external_gui.PulsedExtractionExternalGui'
         connect:
-            pulsedextractionexternallogic1: 'pulsedextractionexternallogic.pulsedextractionexternallogic'
+            pulsedextractionexternallogic1: 'pulsedextractionexternallogic'

--- a/core/base.py
+++ b/core/base.py
@@ -49,8 +49,8 @@ class Base(QtCore.QObject, Fysom):
     sigStateChanged = QtCore.Signal(object)  # (module name, state change)
     _modclass = 'base'
     _modtype = 'base'
-    _in = dict()
-    _out = dict()
+    _in = dict() # legacy
+    _connectors = dict()
 
     def __init__(self, manager, name, config=None, callbacks=None, **kwargs):
         """ Initialise Base class object and set up its state machine.
@@ -104,17 +104,16 @@ class Base(QtCore.QObject, Fysom):
             super().__init__(cfg=_baseStateList, **kwargs)
 
         # add connection base
-        self.connector = OrderedDict()
-        self.connector['in'] = OrderedDict()
+        self.connectors = OrderedDict()
+        for con in self._connectors:
+            self.connectors[con] = OrderedDict()
+            self.connectors[con]['class'] = self._connectors[con]
+            self.connectors[con]['object'] = None
+        # legacy (deprecated soon)
         for con in self._in:
-            self.connector['in'][con] = OrderedDict()
-            self.connector['in'][con]['class'] = self._in[con]
-            self.connector['in'][con]['object'] = None
-
-        self.connector['out'] = OrderedDict()
-        for con in self._out:
-            self.connector['out'][con] = OrderedDict()
-            self.connector['out'][con]['class'] = self._out[con]
+            self.connectors[con] = OrderedDict()
+            self.connectors[con]['class'] = self._in[con]
+            self.connectors[con]['object'] = None
 
         self._manager = manager
         self._name = name
@@ -267,14 +266,14 @@ class Base(QtCore.QObject, Fysom):
         """
         return os.path.abspath(os.path.expanduser('~'))
 
-    def get_in_connector(self, connector_name):
+    def get_connector(self, connector_name):
         """ Return module connected to the given named connector.
           @param str connector_name: name of the connector
 
           @return obj: module that is connected to the named connector
         """
-        obj = self.connector['in'][connector_name]['object']
-        if obj is None:
+        obj = self.connectors[connector_name]['object']
+        if (obj is None):
             raise TypeError('No module connected')
         return obj
 

--- a/gui/automation/automationgui.py
+++ b/gui/automation/automationgui.py
@@ -50,7 +50,7 @@ class AutomationGui(GUIBase):
         """
         self._mw = AutomationMainWindow()
         self.restoreWindowPos(self._mw)
-        self.logic = self.get_in_connector('automationlogic')
+        self.logic = self.get_connector('automationlogic')
         self._mw.autoTreeView.setModel(self.logic.model)
         #self._mw.taskTableView.clicked.connect(self.setRunToolState)
         #self._mw.actionStart_Task.triggered.connect(self.manualStart)

--- a/gui/automation/automationgui.py
+++ b/gui/automation/automationgui.py
@@ -31,7 +31,7 @@ class AutomationGui(GUIBase):
     _modclass = 'AutomationGui'
     _modtype = 'gui'
     ## declare connectors
-    _in = {'automationlogic': 'AutomationLogic'}
+    _connectors = {'automationlogic': 'AutomationLogic'}
 
     sigRunTaskFromList = QtCore.Signal(object)
     sigPauseTaskFromList = QtCore.Signal(object)

--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -183,7 +183,7 @@ class ConfocalGui(GUIBase):
     _modtype = 'gui'
 
     # declare connectors
-    _in = {'confocallogic1': 'ConfocalLogic',
+    _connectors = {'confocallogic1': 'ConfocalLogic',
            'savelogic': 'SaveLogic',
            'optimizerlogic1': 'OptimizerLogic'
            }

--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -231,10 +231,10 @@ class ConfocalGui(GUIBase):
         """
 
         # Getting an access to all connectors:
-        self._scanning_logic = self.get_in_connector('confocallogic1')
-        self._save_logic = self.get_in_connector('savelogic')
-        self._optimizer_logic = self.get_in_connector('optimizerlogic1')
-        self._save_logic = self.get_in_connector('savelogic')
+        self._scanning_logic = self.get_connector('confocallogic1')
+        self._save_logic = self.get_connector('savelogic')
+        self._optimizer_logic = self.get_connector('optimizerlogic1')
+        self._save_logic = self.get_connector('savelogic')
 
         self._hardware_state = True
 

--- a/gui/counter/countergui.py
+++ b/gui/counter/countergui.py
@@ -54,7 +54,7 @@ class CounterGui(GUIBase):
     _modtype = 'gui'
 
     # declare connectors
-    _in = {'counterlogic1': 'CounterLogic'}
+    _connectors = {'counterlogic1': 'CounterLogic'}
 
     sigStartCounter = QtCore.Signal()
     sigStopCounter = QtCore.Signal()
@@ -80,7 +80,7 @@ class CounterGui(GUIBase):
                          had happened.
         """
 
-        self._counting_logic = self.get_in_connector('counterlogic1')
+        self._counting_logic = self.get_connector('counterlogic1')
 
         #####################
         # Configuring the dock widgets

--- a/gui/gated_counter/gated_counter_gui.py
+++ b/gui/gated_counter/gated_counter_gui.py
@@ -81,8 +81,8 @@ class GatedCounterGui(GUIBase):
                          had happened.
         """
 
-        self._counter_logic = self.get_in_connector('gatedcounterlogic1')
-        self._trace_analysis = self.get_in_connector('traceanalysislogic1')
+        self._counter_logic = self.get_connector('gatedcounterlogic1')
+        self._trace_analysis = self.get_connector('traceanalysislogic1')
 
         self._mw = GatedCounterMainWindow()
         self._mw.centralwidget.hide()

--- a/gui/gated_counter/gated_counter_gui.py
+++ b/gui/gated_counter/gated_counter_gui.py
@@ -53,7 +53,7 @@ class GatedCounterGui(GUIBase):
     _modtype = 'gui'
 
     ## declare connectors
-    _in = {'gatedcounterlogic1': 'GatedCounterLogic',
+    _connectors = {'gatedcounterlogic1': 'GatedCounterLogic',
            'traceanalysislogic1': 'TraceAnalysisLogic'}
 
 

--- a/gui/laser/laser.py
+++ b/gui/laser/laser.py
@@ -89,7 +89,7 @@ class LaserGUI(GUIBase):
                          of the state which should be reached after the event
                          had happened.
         """
-        self._laser_logic = self.get_in_connector('laserlogic')
+        self._laser_logic = self.get_connector('laserlogic')
 
         #####################
         # Configuring the dock widgets

--- a/gui/laser/laser.py
+++ b/gui/laser/laser.py
@@ -67,7 +67,7 @@ class LaserGUI(GUIBase):
     _modtype = 'gui'
 
     ## declare connectors
-    _in = {'laserlogic': 'LaserLogic'}
+    _connectors = {'laserlogic': 'LaserLogic'}
 
     sigLaser = QtCore.Signal(bool)
     sigShutter = QtCore.Signal(bool)

--- a/gui/laserscanner/laserscangui.py
+++ b/gui/laserscanner/laserscangui.py
@@ -77,8 +77,8 @@ class LaserScanningGui(GUIBase):
                          had happened.
         """
 
-        self._scanning_logic = self.get_in_connector('laserscanninglogic1')
-        self._save_logic = self.get_in_connector('savelogic')
+        self._scanning_logic = self.get_connector('laserscanninglogic1')
+        self._save_logic = self.get_connector('savelogic')
 
         # setting up the window
         self._mw = LaserScanWindow()

--- a/gui/laserscanner/laserscangui.py
+++ b/gui/laserscanner/laserscangui.py
@@ -48,7 +48,7 @@ class LaserScanningGui(GUIBase):
     _modtype = 'gui'
 
     ## declare connectors
-    _in = { 'laserscanninglogic1': 'LaserScanningLogic',
+    _connectors = { 'laserscanninglogic1': 'LaserScanningLogic',
             'savelogic': 'SaveLogic'
             }
 

--- a/gui/laserscanner/laserscannergui.py
+++ b/gui/laserscanner/laserscannergui.py
@@ -52,7 +52,7 @@ class VoltScanGui(GUIBase):
     _modclass = 'VoltScanGui'
     _modtype = 'gui'
     ## declare connectors
-    _in = {'voltagescannerlogic1': 'VoltageScannerLogic',
+    _connectors = {'voltagescannerlogic1': 'VoltageScannerLogic',
           }
 
     def __init__(self, config, **kwargs):

--- a/gui/laserscanner/laserscannergui.py
+++ b/gui/laserscanner/laserscannergui.py
@@ -85,7 +85,7 @@ class VoltScanGui(GUIBase):
 
         """
 
-        self._voltscan_logic = self.get_in_connector('odmrlogic1')
+        self._voltscan_logic = self.get_connector('odmrlogic1')
         print("ODMR logic is", self._odmr_logic)
 
         # Use the inherited class 'Ui_VoltagescannerGuiUI' to create now the

--- a/gui/magnet/magnet_gui.py
+++ b/gui/magnet/magnet_gui.py
@@ -190,8 +190,8 @@ class MagnetGui(GUIBase):
                          of the state which should be reached after the event
                          had happened.
         """
-        self._magnet_logic = self.get_in_connector('magnetlogic1')
-        self._save_logic = self.get_in_connector('savelogic')
+        self._magnet_logic = self.get_connector('magnetlogic1')
+        self._save_logic = self.get_connector('savelogic')
 
         self._mw = MagnetMainWindow()
 

--- a/gui/magnet/magnet_gui.py
+++ b/gui/magnet/magnet_gui.py
@@ -164,7 +164,7 @@ class MagnetGui(GUIBase):
     _modtype = 'gui'
 
     ## declare connectors
-    _in = {'magnetlogic1': 'MagnetLogic',
+    _connectors = {'magnetlogic1': 'MagnetLogic',
            'savelogic': 'SaveLogic'}
 
     def __init__(self, config, **kwargs):

--- a/gui/notebook/notebookgui.py
+++ b/gui/notebook/notebookgui.py
@@ -33,7 +33,7 @@ class NotebookWebView(GUIBase):
     _modclass = 'NotebookWebView'
     _modtype = 'gui'
     ## declare connectors
-    _in = {'notebooklogic': 'NotebookLogic'}
+    _connectors = {'notebooklogic': 'NotebookLogic'}
 
     def on_activate(self, e):
         """ Initializes all needed UI files and establishes the connectors.

--- a/gui/nuclear_operations/nuclear_operations.py
+++ b/gui/nuclear_operations/nuclear_operations.py
@@ -78,8 +78,8 @@ class NuclearOperationsGui(GUIBase):
         *.ui file and configures the event handling between the modules.
         """
 
-        self._no_logic = self.get_in_connector('nuclearoperationslogic')
-        self._save_logic = self.get_in_connector('savelogic')
+        self._no_logic = self.get_connector('nuclearoperationslogic')
+        self._save_logic = self.get_connector('savelogic')
 
         # Create the MainWindow to display the GUI
         self._mw = NuclearOperationsMainWindow()

--- a/gui/nuclear_operations/nuclear_operations.py
+++ b/gui/nuclear_operations/nuclear_operations.py
@@ -46,7 +46,7 @@ class NuclearOperationsGui(GUIBase):
     _modtype = 'gui'
 
     # declare connectors
-    _in = {'nuclearoperationslogic': 'NuclearOperationsLogic',
+    _connectors = {'nuclearoperationslogic': 'NuclearOperationsLogic',
            'savelogic': 'SaveLogic'}
 
     def __init__(self, manager, name, config, **kwargs):

--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -103,8 +103,8 @@ class ODMRGui(GUIBase):
         *.ui file and configures the event handling between the modules.
         """
 
-        self._odmr_logic = self.get_in_connector('odmrlogic1')
-        self._save_logic = self.get_in_connector('savelogic')
+        self._odmr_logic = self.get_connector('odmrlogic1')
+        self._save_logic = self.get_connector('savelogic')
 
         # Use the inherited class 'Ui_ODMRGuiUI' to create now the
         # GUI element:

--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -67,7 +67,7 @@ class ODMRGui(GUIBase):
     _modtype = 'gui'
 
     # declare connectors
-    _in = {'odmrlogic1': 'ODMRLogic',
+    _connectors = {'odmrlogic1': 'ODMRLogic',
            'savelogic': 'SaveLogic'}
 
     sigStartODMRScan = QtCore.Signal()

--- a/gui/pidgui/pidgui.py
+++ b/gui/pidgui/pidgui.py
@@ -51,7 +51,7 @@ class PIDGui(GUIBase):
     _modtype = 'gui'
 
     ## declare connectors
-    _in = {'pidlogic': 'PIDLogic'}
+    _connectors = {'pidlogic': 'PIDLogic'}
 
     sigStart = QtCore.Signal()
     sigStop = QtCore.Signal()

--- a/gui/pidgui/pidgui.py
+++ b/gui/pidgui/pidgui.py
@@ -76,7 +76,7 @@ class PIDGui(GUIBase):
                          of the state which should be reached after the event
                          had happened.
         """
-        self._pid_logic = self.get_in_connector('pidlogic')
+        self._pid_logic = self.get_connector('pidlogic')
 
         #####################
         # Configuring the dock widgets

--- a/gui/poimanager/poimangui.py
+++ b/gui/poimanager/poimangui.py
@@ -222,7 +222,7 @@ class PoiManagerGui(GUIBase):
     _modtype = 'gui'
 
     # declare connectors
-    _in = {'poimanagerlogic1': 'PoiManagerLogic',
+    _connectors = {'poimanagerlogic1': 'PoiManagerLogic',
            'confocallogic1': 'ConfocalLogic'
            }
 

--- a/gui/poimanager/poimangui.py
+++ b/gui/poimanager/poimangui.py
@@ -253,8 +253,8 @@ class PoiManagerGui(GUIBase):
         self.selected_poi_key = None
 
         # Connectors
-        self._poi_manager_logic = self.get_in_connector('poimanagerlogic1')
-        self._confocal_logic = self.get_in_connector('confocallogic1')
+        self._poi_manager_logic = self.get_connector('poimanagerlogic1')
+        self._confocal_logic = self.get_connector('confocallogic1')
         self.log.debug("POI Manager logic is {0}".format(self._poi_manager_logic))
         self.log.debug("Confocal logic is {0}".format(self._confocal_logic))
 

--- a/gui/pulsed/pulsed_extraction_external_gui.py
+++ b/gui/pulsed/pulsed_extraction_external_gui.py
@@ -65,7 +65,7 @@ class PulsedExtractionExternalGui(GUIBase):
     _modtype = 'gui'
 
     # declare connectors
-    _in = {'pulsedextractionexternallogic1': 'PulsedExtractionExternalLogic'}
+    _connectors = {'pulsedextractionexternallogic1': 'PulsedExtractionExternalLogic'}
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)

--- a/gui/pulsed/pulsed_extraction_external_gui.py
+++ b/gui/pulsed/pulsed_extraction_external_gui.py
@@ -93,7 +93,7 @@ class PulsedExtractionExternalGui(GUIBase):
         # Use the inherited class 'PulsedExtractionExternalMainWindow' to create the GUI window
         self._mw = PulsedExtractionExternalMainWindow()
 
-        self._epe_logic = self.get_in_connector('pulsedextractionexternallogic1')
+        self._epe_logic = self.get_connector('pulsedextractionexternallogic1')
 
         # Setup dock widgets
         self._mw.setDockNestingEnabled(True)

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -156,7 +156,7 @@ class PulsedMeasurementGui(GUIBase):
     _modtype = 'gui'
 
     ## declare connectors
-    _in = {'pulsedmasterlogic': 'PulsedMasterLogic',
+    _connectors = {'pulsedmasterlogic': 'PulsedMasterLogic',
            'savelogic': 'SaveLogic'}
 
     def __init__(self, config, **kwargs):

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -182,8 +182,8 @@ class PulsedMeasurementGui(GUIBase):
         Establish general connectivity and activate the different tabs of the
         GUI.
         """
-        self._pulsed_master_logic = self.get_in_connector('pulsedmasterlogic')
-        self._save_logic = self.get_in_connector('savelogic')
+        self._pulsed_master_logic = self.get_connector('pulsedmasterlogic')
+        self._save_logic = self.get_connector('savelogic')
 
         self._mw = PulsedMeasurementMainWindow()
         self._pa = PulseAnalysisTab()

--- a/gui/qdplotter/qdplottergui.py
+++ b/gui/qdplotter/qdplottergui.py
@@ -78,7 +78,7 @@ class QdplotterGui(GUIBase):
                          had happened.
         """
 
-        self._qdplot_logic = self.get_in_connector('qdplotlogic1')
+        self._qdplot_logic = self.get_connector('qdplotlogic1')
 
         #####################
         # Configuring the dock widgets

--- a/gui/qdplotter/qdplottergui.py
+++ b/gui/qdplotter/qdplottergui.py
@@ -51,7 +51,7 @@ class QdplotterGui(GUIBase):
     _modtype = 'gui'
 
     # declare connectors
-    _in = {'qdplotlogic1': 'QdplotLogic'}
+    _connectors = {'qdplotlogic1': 'QdplotLogic'}
 
     sigStartCounter = QtCore.Signal()
     sigStopCounter = QtCore.Signal()

--- a/gui/simpledatagui/simpledatagui.py
+++ b/gui/simpledatagui/simpledatagui.py
@@ -74,7 +74,7 @@ class SimpleDataGui(GUIBase):
                          of the state which should be reached after the event
                          had happened.
         """
-        self._simple_logic = self.get_in_connector('simplelogic')
+        self._simple_logic = self.get_connector('simplelogic')
 
         #####################
         # Configuring the dock widgets

--- a/gui/simpledatagui/simpledatagui.py
+++ b/gui/simpledatagui/simpledatagui.py
@@ -50,7 +50,7 @@ class SimpleDataGui(GUIBase):
     _modtype = 'gui'
 
     ## declare connectors
-    _in = {'simplelogic': 'SimpleDataLogic'}
+    _connectors = {'simplelogic': 'SimpleDataLogic'}
 
     sigStart = QtCore.Signal()
     sigStop = QtCore.Signal()

--- a/gui/spectrometer/spectrometergui.py
+++ b/gui/spectrometer/spectrometergui.py
@@ -71,7 +71,7 @@ class SpectrometerGui(GUIBase):
                          had happened.
         """
 
-        self._spectrum_logic = self.get_in_connector('spectrumlogic1')
+        self._spectrum_logic = self.get_connector('spectrumlogic1')
 
         # setting up the window
         self._mw = SpectrometerWindow()

--- a/gui/spectrometer/spectrometergui.py
+++ b/gui/spectrometer/spectrometergui.py
@@ -47,7 +47,7 @@ class SpectrometerGui(GUIBase):
     _modtype = 'gui'
 
     # declare connectors
-    _in = {'spectrumlogic1': 'SpectrumLogic'
+    _connectors = {'spectrumlogic1': 'SpectrumLogic'
            }
 
     def __init__(self, config, **kwargs):

--- a/gui/switcher/switchgui.py
+++ b/gui/switcher/switchgui.py
@@ -32,7 +32,7 @@ class SwitchGui(GUIBase):
     _modclass = 'SwitchGui'
     _modtype = 'gui'
     ## declare connectors
-    _in = {'switchlogic': 'SwitchLogic'}
+    _connectors = {'switchlogic': 'SwitchLogic'}
 
     def on_activate(self, e=None):
         """Create all UI objects and show the window.

--- a/gui/switcher/switchgui.py
+++ b/gui/switcher/switchgui.py
@@ -46,7 +46,7 @@ class SwitchGui(GUIBase):
                          had happened.
         """
         self._mw = SwitchMainWindow()
-        lsw =  self.get_in_connector('switchlogic')
+        lsw =  self.get_connector('switchlogic')
         # For each switch that the logic has, add a widget to the GUI to show its state
         for hw in lsw.switches:
             frame = QtWidgets.QGroupBox(hw, self._mw.scrollAreaWidgetContents)

--- a/gui/taskrunner/taskgui.py
+++ b/gui/taskrunner/taskgui.py
@@ -32,7 +32,7 @@ class TaskGui(GUIBase):
     _modclass = 'TaskGui'
     _modtype = 'gui'
     ## declare connectors
-    _in = {'tasklogic': 'TaskRunner'}
+    _connectors = {'tasklogic': 'TaskRunner'}
 
     sigRunTaskFromList = QtCore.Signal(object)
     sigPauseTaskFromList = QtCore.Signal(object)

--- a/gui/taskrunner/taskgui.py
+++ b/gui/taskrunner/taskgui.py
@@ -51,7 +51,7 @@ class TaskGui(GUIBase):
         """
         self._mw = TaskMainWindow()
         self.restoreWindowPos(self._mw)
-        self.logic = self.get_in_connector('tasklogic')
+        self.logic = self.get_connector('tasklogic')
         self._mw.taskTableView.setModel(self.logic.model)
         self._mw.taskTableView.clicked.connect(self.setRunToolState)
         self._mw.actionStart_Task.triggered.connect(self.manualStart)

--- a/gui/wavemeterlogger/wavemeterloggui.py
+++ b/gui/wavemeterlogger/wavemeterloggui.py
@@ -82,8 +82,8 @@ class WavemeterLogGui(GUIBase):
                          had happened.
         """
 
-        self._wm_logger_logic = self.get_in_connector('wavemeterloggerlogic1')
-        self._save_logic = self.get_in_connector('savelogic')
+        self._wm_logger_logic = self.get_connector('wavemeterloggerlogic1')
+        self._save_logic = self.get_connector('savelogic')
 
         # setting up the window
         self._mw = WavemeterLogWindow()

--- a/gui/wavemeterlogger/wavemeterloggui.py
+++ b/gui/wavemeterlogger/wavemeterloggui.py
@@ -54,7 +54,7 @@ class WavemeterLogGui(GUIBase):
     _modtype = 'gui'
 
     ## declare connectors
-    _in = { 'wavemeterloggerlogic1': 'WavemeterLoggerLogic',
+    _connectors = { 'wavemeterloggerlogic1': 'WavemeterLoggerLogic',
             'savelogic': 'SaveLogic'
             }
 

--- a/hardware/CTC100_temperature.py
+++ b/hardware/CTC100_temperature.py
@@ -31,9 +31,6 @@ class CTC100(Base):
     _modclass = 'ctc100'
     _modtype = 'hardware'
 
-    # connectors
-    _out = {'ctc': 'CTC'}
-
     def on_activate(self, e):
         config = self.getConfiguration()
         self.connect(config['interface'])

--- a/hardware/awg/tektronix_awg5002c.py
+++ b/hardware/awg/tektronix_awg5002c.py
@@ -38,9 +38,6 @@ class AWG5002C(Base, PulserInterface):
     _modclass = 'awg5002c'
     _modtype = 'hardware'
 
-    # declare connectors
-    # _out = {'awg5002c': 'PulserInterface'}
-    _out = {'pulser': 'PulserInterface'}
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -203,7 +200,7 @@ class AWG5002C(Base, PulserInterface):
         # If sequencer mode is available then these should be specified
         constraints.repetitions = ScalarConstraint(min=0, max=65536, step=1, default=0, unit='#')
         # ToDo: Check how many external triggers are available
-        constraints.trigger_in = ScalarConstraint(min=0, max=2, step=1, default=0, unit='chnl')
+        constraints.trigger_connectors = ScalarConstraint(min=0, max=2, step=1, default=0, unit='chnl')
         constraints.event_jump_to = ScalarConstraint(min=0, max=8000, step=1, default=0,
                                                      unit='step')
         constraints.go_to = ScalarConstraint(min=0, max=8000, step=1, default=0, unit='step')

--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -42,9 +42,6 @@ class AWG70K(Base, PulserInterface):
     _modclass = 'awg70k'
     _modtype = 'hardware'
 
-    # declare connectors
-    _out = {'pulser': 'PulserInterface'}
-
     def on_activate(self, e):
         """ Initialisation performed during activation of the module.
 
@@ -214,7 +211,7 @@ class AWG70K(Base, PulserInterface):
         # FIXME: This stuff is not yet properly defined
         # If sequencer mode is available then these should be specified
         constraints.repetitions = ScalarConstraint(min=0, max=65536, step=1, default=0, unit='#')
-        constraints.trigger_in = ScalarConstraint(min=0, max=2, step=1, default=0, unit='chnl')
+        constraints.trigger_connectors = ScalarConstraint(min=0, max=2, step=1, default=0, unit='chnl')
         constraints.event_jump_to = ScalarConstraint(min=0, max=8000, step=1, default=0,
                                                      unit='step')
         constraints.go_to = ScalarConstraint(min=0, max=8000, step=1, default=0, unit='step')

--- a/hardware/awg/tektronix_awg7122c.py
+++ b/hardware/awg/tektronix_awg7122c.py
@@ -40,9 +40,6 @@ class AWG7122C(Base, PulserInterface):
     _modclass = 'awg7122c'
     _modtype = 'hardware'
 
-    # declare connectors
-    # _out = {'awg5002c': 'PulserInterface'}
-    _out = {'pulser': 'PulserInterface'}
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -236,7 +233,7 @@ class AWG7122C(Base, PulserInterface):
         # If sequencer mode is available then these should be specified
         constraints.repetitions = ScalarConstraint(min=0, max=65536, step=1, default=0, unit='#')
         # ToDo: Check how many external triggers this device has
-        constraints.trigger_in = ScalarConstraint(min=0, max=2, step=1, default=0, unit='chnl')
+        constraints.trigger_connectors = ScalarConstraint(min=0, max=2, step=1, default=0, unit='chnl')
         constraints.event_jump_to = ScalarConstraint(min=0, max=8000, step=1, default=0,
                                                      unit='step')
         constraints.go_to = ScalarConstraint(min=0, max=8000, step=1, default=0, unit='step')

--- a/hardware/confocal_scanner_dummy.py
+++ b/hardware/confocal_scanner_dummy.py
@@ -34,8 +34,7 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
     _modclass = 'ConfocalScannerDummy'
     _modtype = 'hardware'
     # connectors
-    _in = {'fitlogic': 'FitLogic'}
-    _out = {'confocalscanner': 'ConfocalScannerInterface'}
+    _connectors = {'fitlogic': 'FitLogic'}
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -232,7 +231,7 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
 
     def get_scanner_count_channels(self):
         """ 3 counting channels in dummy confocal: normal, negative and a ramp."""
-        return ['Norm', 'Neg', 'Ramp'] 
+        return ['Norm', 'Neg', 'Ramp']
 
     def set_up_scanner_clock(self, clock_frequency=None, clock_channel=None):
         """ Configures the hardware clock of the NiDAQ card to give the timing.
@@ -421,8 +420,8 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
         b = -(np.sin(2 * theta)) / (4 * sigma_x**2) + (np.sin(2 * theta)) / (4 * sigma_y**2)
         c = (np.sin(theta)**2) / (2 * sigma_x**2) + (np.cos(theta)**2) / (2 * sigma_y**2)
         g = offset + amplitude * np.exp(
-            - (a * ((x - x_zero)**2) 
-                + 2 * b * (x - x_zero) * (y - y_zero) 
+            - (a * ((x - x_zero)**2)
+                + 2 * b * (x - x_zero) * (y - y_zero)
                 + c * ((y - y_zero)**2)))
         return g.ravel()
 

--- a/hardware/confocal_scanner_dummy.py
+++ b/hardware/confocal_scanner_dummy.py
@@ -72,7 +72,7 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
                          has happen.
         """
 
-        self._fit_logic = self.get_in_connector('fitlogic')
+        self._fit_logic = self.get_connector('fitlogic')
 
         # put randomly distributed NVs in the scanner, first the x,y scan
         self._points = np.empty([self._num_points, 7])

--- a/hardware/edwards_vacuum_controller.py
+++ b/hardware/edwards_vacuum_controller.py
@@ -32,9 +32,6 @@ class EdwardsVacuumController(Base):
     _modclass = 'edwards_pump'
     _modtype = 'hardware'
 
-    # connectors
-    _out = {'pump': 'Pump'}
-
     # IDs for communication
     PRIORITY = {
         0: 'OK',

--- a/hardware/fast_counter_dummy.py
+++ b/hardware/fast_counter_dummy.py
@@ -41,8 +41,6 @@ class FastCounterDummy(Base, FastCounterInterface):
     """
     _modclass = 'fastcounterinterface'
     _modtype = 'hardware'
-    # connectors
-    _out = {'fastcounter': 'FastCounterInterface'}
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)

--- a/hardware/fastcomtec/fastcomtecmcs6.py
+++ b/hardware/fastcomtec/fastcomtecmcs6.py
@@ -139,8 +139,6 @@ class FastComtec(Base, FastCounterInterface):
     """
     _modclass = 'FastComtec'
     _modtype = 'hardware'
-    # connectors
-    _out = {'fastcounter': 'FastCounterInterface'}
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)

--- a/hardware/fastcomtec/fastcomtecp7887.py
+++ b/hardware/fastcomtec/fastcomtecp7887.py
@@ -150,8 +150,6 @@ class FastComtec(Base, FastCounterInterface):
     """
     _modclass = 'FastComtec'
     _modtype = 'hardware'
-    # connectors
-    _out = {'fastcounter': 'FastCounterInterface'}
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)

--- a/hardware/fpga_fastcounter/fast_counter_fpga_pi3.py
+++ b/hardware/fpga_fastcounter/fast_counter_fpga_pi3.py
@@ -30,9 +30,6 @@ class FastCounterFGAPiP3(Base, FastCounterInterface):
     _modclass = 'FastCounterFGAPiP3'
     _modtype = 'hardware'
 
-    ## declare connectors
-    _out = {'fastcounter': 'FastCounterInterface'}
-
     def on_activate(self, e):
         """ Connect and configure the access to the FPGA.
 

--- a/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
+++ b/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
@@ -46,8 +46,6 @@ class FastCounterFPGAQO(Base, FastCounterInterface):
     """
     _modclass = 'FastCounterFPGAQO'
     _modtype = 'hardware'
-    # declare connectors
-    _out = {'fastcounter': 'FastCounterInterface'}
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)

--- a/hardware/fpga_pulser/ok_fpga_pulser.py
+++ b/hardware/fpga_pulser/ok_fpga_pulser.py
@@ -44,7 +44,6 @@ class OkFpgaPulser(Base, PulserInterface):
     """
     _modclass = 'pulserinterface'
     _modtype = 'hardware'
-    _out = {'pulser': 'PulserInterface'}
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)

--- a/hardware/high_finesse_wavemeter.py
+++ b/hardware/high_finesse_wavemeter.py
@@ -80,9 +80,6 @@ class HighFinesseWavemeter(Base,WavemeterInterface):
     _modclass = 'HighFinesseWavemeter'
     _modtype = 'hardware'
 
-    ## declare connectors
-    _out = {'highfinessewavemeter': 'WavemeterInterface'}
-
     sig_handle_timer = QtCore.Signal(bool)
 
     #############################################

--- a/hardware/influx_data_client.py
+++ b/hardware/influx_data_client.py
@@ -29,9 +29,6 @@ class InfluxDataClient(Base, ProcessInterface):
     _modclass = 'InfluxDataClient'
     _modtype = 'hardware'
 
-    ## declare connectors
-    _out = {'data': 'ProcessInterface'}
-
     def on_activate(self, e):
         config = self.getConfiguration()
 

--- a/hardware/influx_data_logger.py
+++ b/hardware/influx_data_logger.py
@@ -28,9 +28,6 @@ class InfluxLogger(Base, DataLoggerInterface):
     _modclass = 'InfluxLogger'
     _modtype = 'hardware'
 
-    ## declare connectors
-    _out = {'data': 'ProcessInterface'}
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.log_channels = {}

--- a/hardware/laser/laserquantum_laser.py
+++ b/hardware/laser/laserquantum_laser.py
@@ -44,9 +44,6 @@ class LaserQuantumLaser(Base, SimpleLaserInterface):
     _modclass = 'lqlaser'
     _modtype = 'hardware'
 
-    # connectors
-    _out = {'laser': 'Laser'}
-
     def on_activate(self, e):
         """
 

--- a/hardware/laser/millennia_ev_laser.py
+++ b/hardware/laser/millennia_ev_laser.py
@@ -39,9 +39,6 @@ class MillenniaeVLaser(Base, SimpleLaserInterface):
     _modclass = 'millenniaevlaser'
     _modtype = 'hardware'
 
-    # connectors
-    _out = {'laser': 'Laser'}
-
     def on_activate(self, e):
         """
 

--- a/hardware/laser/simple_laser_dummy.py
+++ b/hardware/laser/simple_laser_dummy.py
@@ -35,9 +35,6 @@ class SimpleLaserDummy(Base, SimpleLaserInterface):
     _modclass = 'laserdummy'
     _modtype = 'hardware'
 
-    # connectors
-    _out = {'laser': 'SimpleLaser'}
-
     def __init__(self, **kwargs):
         """ """
         super().__init__(**kwargs)

--- a/hardware/magnet/magnet_dummy.py
+++ b/hardware/magnet/magnet_dummy.py
@@ -42,8 +42,6 @@ class MagnetDummy(Base, MagnetInterface):
     _modtype = 'MagnetDummy'
     _modclass = 'hardware'
 
-    _out = {'magnetstage': 'MagnetInterface'}
-
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
 

--- a/hardware/microwave/mw_source_agilent.py
+++ b/hardware/microwave/mw_source_agilent.py
@@ -40,8 +40,6 @@ class MicrowaveAgilent(Base, MicrowaveInterface):
 
     _modclass = 'MicrowaveAgilent'
     _modtype = 'hardware'
-    ## declare connectors
-    _out = {'mwsourceagilent': 'MicrowaveInterface'}
 
     def on_activate(self,e):
         """ Initialisation performed during activation of the module.

--- a/hardware/microwave/mw_source_anritsu.py
+++ b/hardware/microwave/mw_source_anritsu.py
@@ -38,9 +38,6 @@ class MicrowaveAnritsu(Base, MicrowaveInterface):
     _modclass = 'MicrowaveAnritsu'
     _modtype = 'hardware'
 
-    # declare connectors
-    _out = {'mwsourceanritsu': 'MicrowaveInterface'}
-
     def on_activate(self,e=None):
         """ Initialisation performed during activation of the module.
 

--- a/hardware/microwave/mw_source_anritsu70GHz.py
+++ b/hardware/microwave/mw_source_anritsu70GHz.py
@@ -39,9 +39,6 @@ class MicrowaveAnritsu70GHz(Base, MicrowaveInterface):
     _modclass = 'MicrowaveAanritsu70GHz'
     _modtype = 'hardware'
 
-    ## declare connectors
-    _out = {'mwsourceanritsu': 'MicrowaveInterface'}
-
     def on_activate(self,e=None):
         # checking for the right configuration
         config = self.getConfiguration()

--- a/hardware/microwave/mw_source_dummy.py
+++ b/hardware/microwave/mw_source_dummy.py
@@ -36,9 +36,6 @@ class MicrowaveDummy(Base, MicrowaveInterface):
     _modclass = 'MicrowaveDummy'
     _modtype = 'mwsource'
 
-    ## declare connectors
-    _out = {'mwsourcedummy': 'MicrowaveInterface'}
-
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
 

--- a/hardware/microwave/mw_source_gigatronics.py
+++ b/hardware/microwave/mw_source_gigatronics.py
@@ -40,9 +40,6 @@ class MicrowaveGigatronics(Base, MicrowaveInterface):
     _modclass = 'MicrowaveInterface'
     _modtype = 'hardware'
 
-    ## declare connectors
-    _out = {'mwsourcegigatronics': 'MicrowaveInterface'}
-
     def on_activate(self, e):
         """ Initialisation performed during activation of the module.
 

--- a/hardware/microwave/mw_source_smiq.py
+++ b/hardware/microwave/mw_source_smiq.py
@@ -40,8 +40,6 @@ class MicrowaveSmiq(Base, MicrowaveInterface):
 
     _modclass = 'MicrowaveSmiq'
     _modtype = 'hardware'
-    # declare connectors
-    _out = {'mwsourcesmiq': 'MicrowaveInterface'}
 
     def on_activate(self, e):
         """ Initialisation performed during activation of the module.

--- a/hardware/microwave/mw_source_smr20.py
+++ b/hardware/microwave/mw_source_smr20.py
@@ -42,9 +42,6 @@ class MicrowaveSMR20(Base, MicrowaveInterface):
     _modclass = 'MicrowaveSMR20'
     _modtype = 'hardware'
 
-    ## declare connectors
-    _out = {'MWSourceSMR20': 'MicrowaveInterface'}
-
     def on_activate(self, e):
         """ Initialisation performed during activation of the module.
 
@@ -90,7 +87,7 @@ class MicrowaveSMR20(Base, MicrowaveInterface):
         # set manually the number of entries in a list, the explanation for that
         # procedure is in the function self.set_list.
         self._MAX_LIST_ENTRIES = 4000
-        
+
         self._gpib_connection.write('*WAI')
         self._FREQ_MAX = float(self._gpib_connection.ask('FREQuency? MAX'))
         self._FREQ_MIN = float(self._gpib_connection.ask('FREQuency? MIN'))
@@ -350,9 +347,9 @@ class MicrowaveSMR20(Base, MicrowaveInterface):
         self._gpib_connection.write(':SYSTem:PRESet')
         self._gpib_connection.write('*RST')
         self._gpib_connection.write(':OUTP OFF')
-        
+
         return 0
-        
+
     def get_limits(self):
         """ Return the device-specific limits in a nested dictionary.
 

--- a/hardware/microwave/mw_source_srssg.py
+++ b/hardware/microwave/mw_source_srssg.py
@@ -35,8 +35,6 @@ class MicrowaveSRSSG(Base, MicrowaveInterface):
     _modclass = 'MicrowaveSRSSG'
     _modtype = 'interface'
 
-    _out = {'mwsourcesrssg': 'MicrowaveInterface'}
-
     def on_activate(self, e):
         """ Initialisation performed during activation of the module.
 

--- a/hardware/motor/aptmotor.py
+++ b/hardware/motor/aptmotor.py
@@ -1146,10 +1146,6 @@ class APTOneAxisStage(APTStage):
     _modclass = 'APTOneAxis'
     _modtype = 'hardware'
 
-    # connectors
-    _out = {'aptmotor': 'MotorInterface'}
-
-
     def custom_activation(self, e):
         """ That activation method can be overwritten in the sub-classed file.
 
@@ -1266,9 +1262,6 @@ class APTThreeAxisStage(APTStage):
 
     _modclass = 'APTThreeAxis'
     _modtype = 'hardware'
-
-    # connectors
-    _out = {'aptmotor': 'MotorInterface'}
 
     def custom_activation(self, e):
         """ That activation method can be overwritten in the sub-classed file.
@@ -1414,9 +1407,6 @@ class APTFourAxisStage(APTStage):
 
     _modclass = 'APTThreeAxis'
     _modtype = 'hardware'
-
-    # connectors
-    _out = {'aptmotor': 'MotorInterface'}
 
     def custom_activation(self, e):
         """ That activation method can be overwritten in the sub-classed file.

--- a/hardware/motor/motor_dummy.py
+++ b/hardware/motor/motor_dummy.py
@@ -38,10 +38,6 @@ class MotorDummy(Base, MotorInterface):
     _modclass = 'MotorDummy'
     _modtype = 'hardware'
 
-    # connectors
-    _out = {'motorstage': 'MotorInterface'}
-
-
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
 

--- a/hardware/motor/motor_stage_micos.py
+++ b/hardware/motor/motor_stage_micos.py
@@ -32,8 +32,6 @@ class MotorStageMicos(Base, MotorInterface):
     """
     _modclass = 'MotorStageMicos'
     _modtype = 'hardware'
-    # connectors
-    _out = {'motorstage': 'MotorInterface'}
 
 #Questions:
 #    Are values put in the right way in config????

--- a/hardware/motor/motor_stage_pi.py
+++ b/hardware/motor/motor_stage_pi.py
@@ -35,8 +35,6 @@ class MotorStagePI(Base, MotorInterface):
     """
     _modclass = 'MotorStagePI'
     _modtype = 'hardware'
-    # connectors
-    _out = {'motorstage': 'MotorInterface'}
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/hardware/motor/zaber_motor_rotation_stage.py
+++ b/hardware/motor/zaber_motor_rotation_stage.py
@@ -34,8 +34,6 @@ class MotorRotationZaber(Base, MotorInterface):
     """
     _modclass = 'MotorRotation'
     _modtype = 'hardware'
-    # connectors
-    _out = {'motorstage': 'MotorInterface'}
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/hardware/ni_card.py
+++ b/hardware/ni_card.py
@@ -138,12 +138,6 @@ class NICard(Base, SlowCounterInterface, ConfocalScannerInterface, ODMRCounterIn
     _modtype = 'NICard'
     _modclass = 'hardware'
 
-    # connectors
-    _out = {'counter': 'SlowCounterInterface',
-            'confocalscanner': 'ConfocalScannerInterface',
-            'odmrcounter': 'ODMRCounterInterface'
-            }
-
     def on_activate(self, e=None):
         """ Starts up the NI Card at activation.
 
@@ -2069,9 +2063,6 @@ class SlowGatedNICard(NICard):
 
     _modtype = 'SlowGatedNICard'
     _modclass = 'hardware'
-
-    # connectors
-    _out = {'gatedslowcounter1' : 'SlowCounterInterface'}
 
     def on_activate(self, e=None):
         """ Starts up the NI Card at activation.

--- a/hardware/ni_pulser.py
+++ b/hardware/ni_pulser.py
@@ -38,8 +38,6 @@ class NIPulser(Base, PulserInterface):
     _modtype = 'PulserInterface'
     _modclass = 'hardware'
 
-    _out = {'pulser': 'PulserInterface'}
-
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
 
@@ -214,7 +212,7 @@ class NIPulser(Base, PulserInterface):
         # empty dictionary.
         sequence_param = OrderedDict()
         constraints['sequence_param'] = sequence_param
-        
+
         activation_config = OrderedDict()
         activation_config['analog_only'] = [k for k in ch_map.keys() if k.startswith('a')]
         activation_config['digital_only'] = [k for k in ch_map.keys() if k.startswith('d')]

--- a/hardware/odmr_counter_dummy.py
+++ b/hardware/odmr_counter_dummy.py
@@ -65,7 +65,7 @@ class ODMRCounterDummy(Base, ODMRCounterInterface):
                          of the state which should be reached after the event
                          had happened.
         """
-        self._fit_logic = self.get_in_connector('fitlogic')
+        self._fit_logic = self.get_connector('fitlogic')
 
     def on_deactivate(self, e):
         """ Deinitialisation performed during deactivation of the module.

--- a/hardware/odmr_counter_dummy.py
+++ b/hardware/odmr_counter_dummy.py
@@ -32,8 +32,7 @@ class ODMRCounterDummy(Base, ODMRCounterInterface):
     _modtype = 'hardware'
 
     # connectors
-    _in = {'fitlogic': 'FitLogic'}
-    _out = {'odmrcounter': 'ODMRCounterInterface'}
+    _connectors = {'fitlogic': 'FitLogic'}
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)

--- a/hardware/pi_pwm.py
+++ b/hardware/pi_pwm.py
@@ -31,9 +31,6 @@ class PiPWM(Base, ProcessControlInterface):
     _modclass = 'ProcessControlInterface'
     _modtype = 'hardware'
 
-    ## declare connectors
-    _out = {'pwm': 'ProcessControlInterface'}
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 

--- a/hardware/picoquant/picoharp300.py
+++ b/hardware/picoquant/picoharp300.py
@@ -94,11 +94,6 @@ class PicoHarp300(Base, SlowCounterInterface, FastCounterInterface):
     _modclass = 'PicoHarp300'
     _modtype = 'hardware'
 
-    # declare connectors
-    _out = {'picocounter': 'PicoHarp300',
-            'counter': 'SlowCounterInterface'
-            }
-
     sigReadoutPicoharp = QtCore.Signal()
     sigAnalyzeData = QtCore.Signal(object, object)
     sigStart = QtCore.Signal()
@@ -1029,7 +1024,7 @@ class PicoHarp300(Base, SlowCounterInterface, FastCounterInterface):
         #FIXME: make the counter channel chooseable in config
         #FIXME: add second photon source either to config or in a better way to file
         return 0
- 
+
     def get_counter_channels(self):
         """ Return one counter channel. """
         return ['Ctr0']

--- a/hardware/process_dummy.py
+++ b/hardware/process_dummy.py
@@ -31,9 +31,6 @@ class ProcessDummy(Base, ProcessInterface, ProcessControlInterface):
     _modclass = 'Process'
     _modtype = 'hardware'
 
-    # connectors
-    _out = {'dummy': 'Process',}
-
     def on_activate(self, e):
         self.temperature = 300.0
         self.pwmpower = 0

--- a/hardware/pulser_dummy.py
+++ b/hardware/pulser_dummy.py
@@ -38,8 +38,6 @@ class PulserDummy(Base, PulserInterface):
     """
     _modclass = 'PulserDummy'
     _modtype = 'hardware'
-    # connectors
-    _out = {'pulser': 'PulserInterface'}
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -185,7 +183,7 @@ class PulserDummy(Base, PulserInterface):
 
         # If sequencer mode is available then these should be specified
         constraints.repetitions = ScalarConstraint(min=0, max=65536, step=1, default=0, unit='#')
-        constraints.trigger_in = ScalarConstraint(min=0, max=2, step=1, default=0, unit='chnl')
+        constraints.trigger_connectors = ScalarConstraint(min=0, max=2, step=1, default=0, unit='chnl')
         constraints.event_jump_to = ScalarConstraint(min=0, max=8000, step=1, default=0,
                                                      unit='step')
         constraints.go_to = ScalarConstraint(min=0, max=8000, step=1, default=0, unit='step')

--- a/hardware/sc_magnet/magnet.py
+++ b/hardware/sc_magnet/magnet.py
@@ -41,9 +41,6 @@ class Magnet(Base, MagnetInterface):
     _modtype = 'Magnet'
     _modclass = 'hardware'
 
-    _out = {'magnetstage': 'magnet_interface'}
-
-
     def __init__(self, **kwargs):
         """Here the connections to the power supplies and to the counter are established"""
         super().__init__(**kwargs)

--- a/hardware/simple_data_acq.py
+++ b/hardware/simple_data_acq.py
@@ -31,9 +31,6 @@ class SimpleAcq(Base, SimpleDataInterface):
     _modclass = 'simple'
     _modtype = 'hardware'
 
-    # connectors
-    _out = {'simple': 'Simple'}
-
     def on_activate(self, e):
         config = self.getConfiguration()
         if 'interface' in config:

--- a/hardware/simple_data_dummy.py
+++ b/hardware/simple_data_dummy.py
@@ -32,9 +32,6 @@ class SimpleDummy(Base, SimpleDataInterface):
     _modclass = 'simple'
     _modtype = 'hardware'
 
-    # connectors
-    _out = {'simple': 'Simple'}
-
     def on_activate(self, e):
         pass
 

--- a/hardware/slow_counter_dummy.py
+++ b/hardware/slow_counter_dummy.py
@@ -37,8 +37,6 @@ class SlowCounterDummy(Base, SlowCounterInterface):
     """
     _modclass = 'SlowCounterDummy'
     _modtype = 'hardware'
-    # connectors
-    _out = {'counter': 'SlowCounterInterface'}
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -175,7 +173,7 @@ class SlowCounterDummy(Base, SlowCounterInterface):
         @return float: the photon counts per second
         """
         count_data = np.array(
-            [self._simulate_counts(samples) + i * self.mean_signal 
+            [self._simulate_counts(samples) + i * self.mean_signal
                 for i, ch in enumerate(self.get_counter_channels())]
             )
 

--- a/hardware/spectrometer/lightfield_spectrometer.py
+++ b/hardware/spectrometer/lightfield_spectrometer.py
@@ -45,8 +45,6 @@ class LFImageMode(Enum):
 
 class Lightfield(Base, SpectrometerInterface):
 
-    _out = {'spec': 'SpectrometerInterface'}
-
     def on_activate(self, e):
 
         lfpath = os.environ['LIGHTFIELD_ROOT']

--- a/hardware/spectrometer/spectrometer_dummy.py
+++ b/hardware/spectrometer/spectrometer_dummy.py
@@ -29,8 +29,7 @@ import numpy as np
 
 
 class SpectrometerInterfaceDummy(Base,SpectrometerInterface):
-    _in = {'fitlogic': 'FitLogic'}
-    _out = {'spec': 'SpectrometerInterface'}
+    _connectors = {'fitlogic': 'FitLogic'}
 
     def on_activate(self, e):
         self._fitLogic = self.get_connector('fitlogic')

--- a/hardware/spectrometer/spectrometer_dummy.py
+++ b/hardware/spectrometer/spectrometer_dummy.py
@@ -33,7 +33,7 @@ class SpectrometerInterfaceDummy(Base,SpectrometerInterface):
     _out = {'spec': 'SpectrometerInterface'}
 
     def on_activate(self, e):
-        self._fitLogic = self.get_in_connector('fitlogic')
+        self._fitLogic = self.get_connector('fitlogic')
         self.exposure = 0.1
 
     def on_deactivate(self, e):

--- a/hardware/spectrometer/winspec_spectrometer.py
+++ b/hardware/spectrometer/winspec_spectrometer.py
@@ -40,8 +40,6 @@ import comtypes.gen.WINX32Lib as WinSpecLib
 
 class WinSpec32(Base, SpectrometerInterface):
 
-    _out = {'spec': 'SpectrometerInterface'}
-
     def on_activate(self, e):
         w32c.pythoncom.CoInitialize()
         self.expt_is_running = WinSpecLib.EXP_RUNNING

--- a/hardware/spincore/pulse_blaster_esrpro.py
+++ b/hardware/spincore/pulse_blaster_esrpro.py
@@ -60,9 +60,6 @@ class PulseBlasterESRPRO(Base, PulserInterface):
     _modclass = 'PulseBlasterESRPRO'
     _modtype = 'hardware'
 
-    # declare connectors
-    _out = {'PulseBlasterESRPRO': 'PulseBlasterESRPRO'}
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 

--- a/hardware/switches/flipmirror.py
+++ b/hardware/switches/flipmirror.py
@@ -32,7 +32,6 @@ class FlipMirror(Base, SwitchInterface):
     """
     _modclass = 'switchinterface'
     _modtype = 'hardware'
-    _out = {'switch':'SwitchInterface'}
 
     def __init__(self, config, **kwargs):
         """ Creae flip mirror control module

--- a/hardware/switches/hbridge.py
+++ b/hardware/switches/hbridge.py
@@ -31,7 +31,6 @@ class HBridge(Base, SwitchInterface):
     """
     _modclass = 'switchinterface'
     _modtype = 'hardware'
-    _out = {'switch': 'SwitchInterface'}
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/hardware/switches/ok_fpga/ok_fpga_switch.py
+++ b/hardware/switches/ok_fpga/ok_fpga_switch.py
@@ -36,7 +36,6 @@ class OkFpgaTtlSwitch(Base, SwitchInterface):
     """
     _modclass = 'switchinterface'
     _modtype = 'hardware'
-    _out = {'switch': 'SwitchInterface'}
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/hardware/switches/ok_fpga/ok_s6_switch.py
+++ b/hardware/switches/ok_fpga/ok_s6_switch.py
@@ -43,8 +43,6 @@ class HardwareSwitchFpga(Base, SwitchInterface):
     """
     _modclass = 'HardwareSwitchFpga'
     _modtype = 'hardware'
-    # declare connectors
-    _out = {'hardwareswitch': 'HardwareSwitchFpga'}
 
     def on_activate(self, e):
         """ Connect and configure the access to the FPGA.

--- a/hardware/switches/switch_dummy.py
+++ b/hardware/switches/switch_dummy.py
@@ -30,9 +30,6 @@ class SwitchDummy(Base, SwitchInterface):
     _modclass = 'switchinterfacedummy'
     _modtype = 'hardware'
 
-    # connectors
-    _out = {'switch': 'SwitchInterface'}
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 

--- a/hardware/timetagger_counter.py
+++ b/hardware/timetagger_counter.py
@@ -34,9 +34,6 @@ class TimeTaggerCounter(Base, SlowCounterInterface):
     _modtype = 'TTCounter'
     _modclass = 'hardware'
 
-    # connectors
-    _out = {'ttcounter': 'SlowCounterInterface'
-            }
 
     def on_activate(self, e=None):
         """ Starts up the NI Card at activation.

--- a/hardware/tsys01_spi.py
+++ b/hardware/tsys01_spi.py
@@ -33,9 +33,6 @@ class TSYS01SPI(Base, ProcessInterface):
     _modclass = 'TSYS01'
     _modtype = 'hardware'
 
-    ## declare connectors
-    _out = {'temperature': 'ProcessInterface'}
-
     # commands to chip (constants)
     READ_ADC  = 0x00
     RESET     = 0x1E

--- a/hardware/wavemeter_dummy.py
+++ b/hardware/wavemeter_dummy.py
@@ -74,9 +74,6 @@ class WavemeterDummy(Base, WavemeterInterface):
     _modclass = 'WavemeterDummy'
     _modtype = 'hardware'
 
-    # declare connectors
-    _out = {'highhinessewavemeter': 'WavemeterInterface'}
-
     sig_handle_timer = QtCore.Signal(bool)
 
     def __init__(self, config, **kwargs):

--- a/logic/automation.py
+++ b/logic/automation.py
@@ -165,8 +165,7 @@ class AutomationLogic(GenericLogic):
     """
     _modclass = 'AutomationLogic'
     _modtype = 'logic'
-    _in = {'taskrunner': 'TaskRunner'}
-    _out = {'automationlogic': 'AutomationLogic'}
+    _connectors = {'taskrunner': 'TaskRunner'}
 
     sigRepeat = QtCore.Signal()
 

--- a/logic/automation.py
+++ b/logic/automation.py
@@ -175,7 +175,7 @@ class AutomationLogic(GenericLogic):
 
           @param object e: Fysom state change notification
         """
-        self._taskrunner = self.get_in_connector('taskrunner')
+        self._taskrunner = self.get_connector('taskrunner')
         #stuff = "a\txyz\n    b\tx\n    c\ty\n        d\tw\ne\tm\n"
         #tr = OrderedDict([
         #    ('a', OrderedDict([

--- a/logic/confocal_logic.py
+++ b/logic/confocal_logic.py
@@ -253,11 +253,10 @@ class ConfocalLogic(GenericLogic):
     _modtype = 'logic'
 
     # declare connectors
-    _in = {
+    _connectors = {
         'confocalscanner1': 'ConfocalScannerInterface',
         'savelogic': 'SaveLogic'
         }
-    _out = {'scannerlogic': 'ConfocalLogic'}
 
     # signals
     signal_start_scanning = QtCore.Signal(str)
@@ -671,7 +670,7 @@ class ConfocalLogic(GenericLogic):
 
         for i, ch in enumerate(self.get_scanner_axes()):
             pos_dict[ch_array[i]] = pos_array[i]
- 
+
         self._scanning_device.scanner_set_position(**pos_dict)
         return 0
 
@@ -727,7 +726,7 @@ class ConfocalLogic(GenericLogic):
 
         try:
             if self._scan_counter == 0:
-                # make a line from the current cursor position to 
+                # make a line from the current cursor position to
                 # the starting position of the first scan line of the scan
                 rs = self.return_slowness
                 lsx = np.linspace(self._current_x, image[self._scan_counter, 0, 0], rs)
@@ -796,7 +795,7 @@ class ConfocalLogic(GenericLogic):
                     image[self._scan_counter, 0, 2] * np.ones(self._return_YL.shape),
                         np.ones(self._return_YL.shape) * self._current_a
                         ])
- 
+
             # return the scanner to the start of next line, counts are thrown away
             return_line_counts = self._scanning_device.scan_line(return_line)
             if np.any(return_line_counts == -1):

--- a/logic/confocal_logic.py
+++ b/logic/confocal_logic.py
@@ -303,8 +303,8 @@ class ConfocalLogic(GenericLogic):
 
         @param e: error code
         """
-        self._scanning_device = self.get_in_connector('confocalscanner1')
-        self._save_logic = self.get_in_connector('savelogic')
+        self._scanning_device = self.get_connector('confocalscanner1')
+        self._save_logic = self.get_connector('savelogic')
 
         #default values for clock frequency and slowness
         #slowness: steps during retrace line

--- a/logic/counter_logic.py
+++ b/logic/counter_logic.py
@@ -58,10 +58,9 @@ class CounterLogic(GenericLogic):
     _modtype = 'logic'
 
     ## declare connectors
-    _in = {'counter1': 'SlowCounterInterface',
-           'savelogic': 'SaveLogic'}
-
-    _out = {'counterlogic': 'CounterLogic'}
+    _connectors = {
+        'counter1': 'SlowCounterInterface',
+        'savelogic': 'SaveLogic'}
 
     def __init__(self, config, **kwargs):
         """ Create CounterLogic object with connectors.
@@ -328,7 +327,7 @@ class CounterLogic(GenericLogic):
             header = 'Time (s)'
             for i, detector in enumerate(self.get_channels()):
                 header = header + ',Signal{0} (counts/s)'.format(i)
- 
+
             data = {header: self._data_to_save}
             filepath = self._save_logic.get_path_for_module(module_name='Counter')
 

--- a/logic/counter_logic.py
+++ b/logic/counter_logic.py
@@ -105,8 +105,8 @@ class CounterLogic(GenericLogic):
                          has happen.
         """
         # Connect to hardware and save logic
-        self._counting_device = self.get_in_connector('counter1')
-        self._save_logic = self.get_in_connector('savelogic')
+        self._counting_device = self.get_connector('counter1')
+        self._save_logic = self.get_connector('savelogic')
 
         # Recall saved app-parameters
         if 'count_length' in self._statusVariables:

--- a/logic/fit_logic.py
+++ b/logic/fit_logic.py
@@ -43,8 +43,6 @@ class FitLogic(GenericLogic):
     """
     _modclass = 'fitlogic'
     _modtype = 'logic'
-    # declare connectors
-    _out = {'fitlogic': 'FitLogic'}
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/logic/interfuse/confocal_scanner_spectrometer_interfuse.py
+++ b/logic/interfuse/confocal_scanner_spectrometer_interfuse.py
@@ -34,10 +34,11 @@ class SpectrometerScannerInterfuse(Base, ConfocalScannerInterface):
     _modclass = 'confocalscannerinterface'
     _modtype = 'hardware'
     # connectors
-    _in = {'fitlogic': 'FitLogic',
-           'confocalscanner1': 'ConfocalScannerInterface',
-           'spectrometer1': 'SpectrometerInterface'}
-    _out = {'spectrometerscanner': 'ConfocalScannerInterface'}
+    _connectors = {
+        'fitlogic': 'FitLogic',
+        'confocalscanner1': 'ConfocalScannerInterface',
+        'spectrometer1': 'SpectrometerInterface'
+    }
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)

--- a/logic/interfuse/confocal_scanner_spectrometer_interfuse.py
+++ b/logic/interfuse/confocal_scanner_spectrometer_interfuse.py
@@ -70,9 +70,9 @@ class SpectrometerScannerInterfuse(Base, ConfocalScannerInterface):
         """ Initialisation performed during activation of the module.
         """
 
-        self._fit_logic = self.get_in_connector('fitlogic')
-        self._scanner_hw = self.get_in_connector('confocalscanner1')
-        self._spectrometer_hw = self.get_in_connector('spectrometer1')
+        self._fit_logic = self.get_connector('fitlogic')
+        self._scanner_hw = self.get_connector('confocalscanner1')
+        self._spectrometer_hw = self.get_connector('spectrometer1')
 
 
     def on_deactivate(self, e):

--- a/logic/interfuse/magnet_motor_interfuse.py
+++ b/logic/interfuse/magnet_motor_interfuse.py
@@ -32,11 +32,8 @@ class MagnetMotorInterfuse(GenericLogic, MagnetInterface):
     # declare connectors, here you can see the interfuse action: the in
     # connector will cope a motor hardware, that means a motor device can
     # connect to the in connector of the logic.
-    _in = {'motorstage': 'MotorInterface'}
+    _connectors = {'motorstage': 'MotorInterface'}
 
-    # And as a result, you will have an out connector, which is compatible to a
-    # magnet interface, and which can be plug in to an appropriated magnet logic
-    _out = {'magnetstage': 'MagnetInterface'}
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/logic/interfuse/magnet_motor_interfuse.py
+++ b/logic/interfuse/magnet_motor_interfuse.py
@@ -58,7 +58,7 @@ class MagnetMotorInterfuse(GenericLogic, MagnetInterface):
                          had happened.
         """
 
-        self._motor_device = self.get_in_connector('motorstage')
+        self._motor_device = self.get_connector('motorstage')
 
 
     def on_deactivate(self, e):

--- a/logic/interfuse/magnet_motor_xyz_rot_interfuse.py
+++ b/logic/interfuse/magnet_motor_xyz_rot_interfuse.py
@@ -74,8 +74,8 @@ class MagnetMotorXYZROTInterfuse(GenericLogic, MagnetInterface):
                          of the state which should be reached after the event
                          had happened.
         """
-        self._motor_device_rot = self.get_in_connector('motorstage_rot')
-        self._motor_device_xyz = self.get_in_connector('motorstage_xyz')
+        self._motor_device_rot = self.get_connector('motorstage_rot')
+        self._motor_device_xyz = self.get_connector('motorstage_xyz')
 
 
 

--- a/logic/interfuse/magnet_motor_xyz_rot_interfuse.py
+++ b/logic/interfuse/magnet_motor_xyz_rot_interfuse.py
@@ -48,12 +48,10 @@ class MagnetMotorXYZROTInterfuse(GenericLogic, MagnetInterface):
     # declare connectors, here you can see the interfuse action: the in
     # connector will cope a motor hardware, that means a motor device can
     # connect to the in connector of the logic.
-    _in = {'motorstage_xyz': 'MotorInterface',
-           'motorstage_rot': 'MotorInterface'}
-
-    # And as a result, you will have an out connector, which is compatible to a
-    # magnet interface, and which can be plug in to an appropriated magnet logic
-    _out = {'magnetstage': 'MagnetInterface'}
+    _connectors = {
+        'motorstage_xyz': 'MotorInterface',
+        'motorstage_rot': 'MotorInterface'
+    }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/logic/interfuse/mw_differential_scanner.py
+++ b/logic/interfuse/mw_differential_scanner.py
@@ -67,7 +67,7 @@ class ConfocalScannerInterfaceDummy(Base, ConfocalScannerInterface):
         """ Initialisation performed during activation of the module.
         """
 
-        self._fit_logic = self.get_in_connector('fitlogic')
+        self._fit_logic = self.get_connector('fitlogic')
 
         # put randomly distributed NVs in the scanner, first the x,y scan
         self._points = np.empty([self._num_points, 7])

--- a/logic/interfuse/mw_differential_scanner.py
+++ b/logic/interfuse/mw_differential_scanner.py
@@ -33,8 +33,7 @@ class ConfocalScannerInterfaceDummy(Base, ConfocalScannerInterface):
     _modclass = 'confocalscannerinterface'
     _modtype = 'hardware'
     # connectors
-    _in = {'fitlogic': 'FitLogic'}
-    _out = {'confocalscanner': 'ConfocalScannerInterface'}
+    _connectors = {'fitlogic': 'FitLogic'}
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)

--- a/logic/interfuse/scanner_tilt_interfuse.py
+++ b/logic/interfuse/scanner_tilt_interfuse.py
@@ -28,8 +28,7 @@ class ScannerTiltInterfuse(GenericLogic, ConfocalScannerInterface):
     _modclass = 'ScannerTiltInterfuse'
     _modtype = 'interfuse'
 
-    _in = {'confocalscanner1': 'ConfocalScannerInterface'}
-    _out = {'confocalscanner1': 'ConfocalScannerInterface'}
+    _connectors = {'confocalscanner1': 'ConfocalScannerInterface'}
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/logic/interfuse/scanner_tilt_interfuse.py
+++ b/logic/interfuse/scanner_tilt_interfuse.py
@@ -45,7 +45,7 @@ class ScannerTiltInterfuse(GenericLogic, ConfocalScannerInterface):
                          of the state which should be reached after the event
                          had happened.
         """
-        self._scanning_device = self.get_in_connector('confocalscanner1')
+        self._scanning_device = self.get_connector('confocalscanner1')
 
         self.tilt_variable_ax = 1
         self.tilt_variable_ay = 1

--- a/logic/jupyterkernel/kernellogic.py
+++ b/logic/jupyterkernel/kernellogic.py
@@ -35,7 +35,6 @@ class QudiKernelLogic(GenericLogic):
     """ Logic module providing a Jupyer-compatible kernel connected via ZMQ."""
     _modclass = 'QudiKernelLogic'
     _modtype = 'logic'
-    _out = {'kernel': 'QudiKernelLogic'}
 
     sigStartKernel = QtCore.Signal(str)
     sigStopKernel = QtCore.Signal(int)

--- a/logic/laser_logic.py
+++ b/logic/laser_logic.py
@@ -32,8 +32,7 @@ class LaserLogic(GenericLogic):
     """
     _modclass = 'laser'
     _modtype = 'logic'
-    _in = {'laser': 'SimpleLaserInterface'}
-    _out = {'laserlogic': 'LaserLogic'}
+    _connectors = {'laser': 'SimpleLaserInterface'}
 
     sigUpdate = QtCore.Signal()
 

--- a/logic/laser_logic.py
+++ b/logic/laser_logic.py
@@ -42,7 +42,7 @@ class LaserLogic(GenericLogic):
 
           @param object e: Fysom state change notification
         """
-        self._laser = self.get_in_connector('laser')
+        self._laser = self.get_connector('laser')
         self.stopRequest = False
         self.bufferLength = 100
         self.data = {}

--- a/logic/laser_scanner_logic.py
+++ b/logic/laser_scanner_logic.py
@@ -70,8 +70,8 @@ class LaserScannerLogic(GenericLogic):
 
           @param object e: Fysom state change event
         """
-        self._scanning_device = self.get_in_connector('confocalscanner1')
-        self._save_logic = self.get_in_connector('savelogic')
+        self._scanning_device = self.get_connector('confocalscanner1')
+        self._save_logic = self.get_connector('savelogic')
 
         # Reads in the maximal scanning range. The unit of that scan range is
         # micrometer!

--- a/logic/laser_scanner_logic.py
+++ b/logic/laser_scanner_logic.py
@@ -45,10 +45,10 @@ class LaserScannerLogic(GenericLogic):
     _modtype = 'logic'
 
     # declare connectors
-    _in = {'confocalscanner1': 'ConfocalScannerInterface',
-           'savelogic': 'SaveLogic',
-           }
-    _out = {'laserscannerlogic': 'LaserScannerLogic'}
+    _connectors = {
+        'confocalscanner1': 'ConfocalScannerInterface',
+        'savelogic': 'SaveLogic',
+    }
 
     signal_change_voltage = QtCore.Signal(float)
     signal_scan_next_line = QtCore.Signal()

--- a/logic/magnet_logic.py
+++ b/logic/magnet_logic.py
@@ -67,16 +67,17 @@ class MagnetLogic(GenericLogic):
     _modtype = 'logic'
 
     ## declare connectors
-    _in = {'magnetstage': 'MagnetInterface',
-           'optimizerlogic': 'OptimizerLogic',
-           'counterlogic': 'CounterLogic',
-           'odmrlogic': 'ODMRLogic',
-           'savelogic': 'SaveLogic',
-           'scannerlogic':'ScannerLogic',
-           'traceanalysis':'TraceAnalysisLogic',
-           'gatedcounterlogic': 'GatedCounterLogic',
-           'sequencegeneratorlogic': 'SequenceGeneratorLogic'}
-    _out = {'magnetlogic': 'MagnetLogic'}
+    _connectors = {
+        'magnetstage': 'MagnetInterface',
+        'optimizerlogic': 'OptimizerLogic',
+        'counterlogic': 'CounterLogic',
+        'odmrlogic': 'ODMRLogic',
+        'savelogic': 'SaveLogic',
+        'scannerlogic':'ScannerLogic',
+        'traceanalysis':'TraceAnalysisLogic',
+        'gatedcounterlogic': 'GatedCounterLogic',
+        'sequencegeneratorlogic': 'SequenceGeneratorLogic'
+    }
 
     # General Signals, used everywhere:
     sigIdleStateChanged = QtCore.Signal(bool)

--- a/logic/magnet_logic.py
+++ b/logic/magnet_logic.py
@@ -151,8 +151,8 @@ class MagnetLogic(GenericLogic):
                          of the state which should be reached after the event
                          had happened.
         """
-        self._magnet_device = self.get_in_connector('magnetstage')
-        self._save_logic = self.get_in_connector('savelogic')
+        self._magnet_device = self.get_connector('magnetstage')
+        self._save_logic = self.get_connector('savelogic')
 
         self.log.info('The following configuration was found.')
         # checking for the right configuration
@@ -162,16 +162,16 @@ class MagnetLogic(GenericLogic):
 
         #FIXME: THAT IS JUST A TEMPORARY SOLUTION! Implement the access on the
         #       needed methods via the TaskRunner!
-        self._optimizer_logic = self.get_in_connector('optimizerlogic')
-        self._confocal_logic = self.get_in_connector('scannerlogic')
-        self._counter_logic = self.get_in_connector('counterlogic')
-        self._odmr_logic = self.get_in_connector('odmrlogic')
+        self._optimizer_logic = self.get_connector('optimizerlogic')
+        self._confocal_logic = self.get_connector('scannerlogic')
+        self._counter_logic = self.get_connector('counterlogic')
+        self._odmr_logic = self.get_connector('odmrlogic')
 
-        self._gc_logic = self.get_in_connector('gatedcounterlogic')
-        self._ta_logic = self.get_in_connector('traceanalysis')
-        #self._odmr_logic = self.get_in_connector('odmrlogic')
+        self._gc_logic = self.get_connector('gatedcounterlogic')
+        self._ta_logic = self.get_connector('traceanalysis')
+        #self._odmr_logic = self.get_connector('odmrlogic')
 
-        self._seq_gen_logic = self.get_in_connector('sequencegeneratorlogic')
+        self._seq_gen_logic = self.get_connector('sequencegeneratorlogic')
 
         # EXPERIMENTAL:
         # connect now directly signals to the interface methods, so that

--- a/logic/measurement_simulator/polarisation_dependence_sim.py
+++ b/logic/measurement_simulator/polarisation_dependence_sim.py
@@ -48,7 +48,7 @@ class PolarizationDependenceSim(Base, SlowCounterInterface, MotorInterface):
         """ Activation of the class
         """
         # name connected modules
-        self._counter_hw = self.get_in_connector('counter1')
+        self._counter_hw = self.get_connector('counter1')
 
         # Required class variables to pretend to be the counter hardware
         self._photon_source2 = None

--- a/logic/measurement_simulator/polarisation_dependence_sim.py
+++ b/logic/measurement_simulator/polarisation_dependence_sim.py
@@ -38,9 +38,7 @@ class PolarizationDependenceSim(Base, SlowCounterInterface, MotorInterface):
     _modtype = 'hardware'
 
     # Connectors
-    _in = {'counter1': 'SlowCounterInterface'}
-
-    _out = {'polarizationdependencesim': 'PolarizationDependenceSim'}
+    _connectors = {'counter1': 'SlowCounterInterface'}
 
     _move_signal = QtCore.Signal()
 

--- a/logic/nuclear_operations_logic.py
+++ b/logic/nuclear_operations_logic.py
@@ -61,15 +61,15 @@ class NuclearOperationsLogic(GenericLogic):
     # declare connectors
     #TODO: Use rather the task runner instead directly the module!
 
-    _in = {'sequencegenerationlogic': 'SequenceGenerationLogic',
-           'traceanalysislogic': 'TraceAnalysisLogic',
-           'gatedcounterlogic': 'CounterLogic',
-           'odmrlogic': 'ODMRLogic',
-           'optimizerlogic': 'OptimizerLogic',
-           'scannerlogic':'ScannerLogic',
-           'savelogic': 'SaveLogic'}
-
-    _out = {'nuclearoperationlogic': 'NuclearOperationsLogic'}
+    _connectors = {
+        'sequencegenerationlogic': 'SequenceGenerationLogic',
+        'traceanalysislogic': 'TraceAnalysisLogic',
+        'gatedcounterlogic': 'CounterLogic',
+        'odmrlogic': 'ODMRLogic',
+        'optimizerlogic': 'OptimizerLogic',
+        'scannerlogic':'ScannerLogic',
+        'savelogic': 'SaveLogic'
+    }
 
     sigNextMeasPoint = QtCore.Signal()
     sigCurrMeasPointUpdated = QtCore.Signal()

--- a/logic/nuclear_operations_logic.py
+++ b/logic/nuclear_operations_logic.py
@@ -307,16 +307,16 @@ class NuclearOperationsLogic(GenericLogic):
         self.initialize_meas_param()
 
         # establish the access to all connectors:
-        self._save_logic = self.get_in_connector('savelogic')
+        self._save_logic = self.get_connector('savelogic')
 
         #FIXME: THAT IS JUST A TEMPORARY SOLUTION! Implement the access on the
         #       needed methods via the TaskRunner!
-        self._seq_gen_logic = self.get_in_connector('sequencegenerationlogic')
-        self._trace_ana_logic = self.get_in_connector('traceanalysislogic')
-        self._gc_logic = self.get_in_connector('gatedcounterlogic')
-        self._odmr_logic = self.get_in_connector('odmrlogic')
-        self._optimizer_logic = self.get_in_connector('optimizerlogic')
-        self._confocal_logic = self.get_in_connector('scannerlogic')
+        self._seq_gen_logic = self.get_connector('sequencegenerationlogic')
+        self._trace_ana_logic = self.get_connector('traceanalysislogic')
+        self._gc_logic = self.get_connector('gatedcounterlogic')
+        self._odmr_logic = self.get_connector('odmrlogic')
+        self._optimizer_logic = self.get_connector('optimizerlogic')
+        self._confocal_logic = self.get_connector('scannerlogic')
 
 
         # connect signals:

--- a/logic/odmr_logic.py
+++ b/logic/odmr_logic.py
@@ -90,11 +90,11 @@ class ODMRLogic(GenericLogic):
                          had happened.
         """
 
-        self._mw_device = self.get_in_connector('microwave1')
-        self._fit_logic = self.get_in_connector('fitlogic')
-        self._odmr_counter = self.get_in_connector('odmrcounter')
-        self._save_logic = self.get_in_connector('savelogic')
-        self._taskrunner = self.get_in_connector('taskrunner')
+        self._mw_device = self.get_connector('microwave1')
+        self._fit_logic = self.get_connector('fitlogic')
+        self._odmr_counter = self.get_connector('odmrcounter')
+        self._save_logic = self.get_connector('savelogic')
+        self._taskrunner = self.get_connector('taskrunner')
 
         config = self.getConfiguration()
         self.limits = self._mw_device.get_limits()

--- a/logic/odmr_logic.py
+++ b/logic/odmr_logic.py
@@ -39,13 +39,13 @@ class ODMRLogic(GenericLogic):
     _modclass = 'odmrlogic'
     _modtype = 'logic'
     # declare connectors
-    _in = {'odmrcounter': 'ODMRCounterInterface',
-           'fitlogic': 'FitLogic',
-           'microwave1': 'mwsourceinterface',
-           'savelogic': 'SaveLogic',
-           'taskrunner': 'TaskRunner'
-           }
-    _out = {'odmrlogic': 'ODMRLogic'}
+    _connectors = {
+        'odmrcounter': 'ODMRCounterInterface',
+        'fitlogic': 'FitLogic',
+        'microwave1': 'mwsourceinterface',
+        'savelogic': 'SaveLogic',
+        'taskrunner': 'TaskRunner'
+    }
 
     sigNextLine = QtCore.Signal()
     sigOdmrStarted = QtCore.Signal()

--- a/logic/optimizer_logic.py
+++ b/logic/optimizer_logic.py
@@ -82,8 +82,8 @@ class OptimizerLogic(GenericLogic):
 
         @return int: error code (0:OK, -1:error)
         """
-        self._scanning_device = self.get_in_connector('confocalscanner1')
-        self._fit_logic = self.get_in_connector('fitlogic')
+        self._scanning_device = self.get_connector('confocalscanner1')
+        self._fit_logic = self.get_connector('fitlogic')
 
         # default values for clock frequency and slowness
         # slowness: steps during retrace line

--- a/logic/optimizer_logic.py
+++ b/logic/optimizer_logic.py
@@ -36,10 +36,10 @@ class OptimizerLogic(GenericLogic):
     _modtype = 'logic'
 
     # declare connectors
-    _in = {'confocalscanner1': 'ConfocalScannerInterface',
-           'fitlogic': 'FitLogic'
-           }
-    _out = {'optimizerlogic': 'OptimizerLogic'}
+    _connectors = {
+        'confocalscanner1': 'ConfocalScannerInterface',
+        'fitlogic': 'FitLogic'
+    }
 
     # "private" signals to keep track of activities here in the optimizer logic
     _sigScanNextXyLine = QtCore.Signal()

--- a/logic/pid_logic.py
+++ b/logic/pid_logic.py
@@ -34,11 +34,10 @@ class PIDLogic(GenericLogic):
     _modclass = 'pidlogic'
     _modtype = 'logic'
     ## declare connectors
-    _in = {
+    _connectors = {
         'controller': 'PIDControllerInterface',
         'savelogic': 'SaveLogic'
-        }
-    _out = {'pidlogic': 'PIDLogic'}
+    }
 
     sigUpdateDisplay = QtCore.Signal()
 

--- a/logic/pid_logic.py
+++ b/logic/pid_logic.py
@@ -57,8 +57,8 @@ class PIDLogic(GenericLogic):
     def on_activate(self, e):
         """ Initialisation performed during activation of the module.
         """
-        self._controller = self.get_in_connector('controller')
-        self._save_logic = self.get_in_connector('savelogic')
+        self._controller = self.get_connector('controller')
+        self._save_logic = self.get_connector('savelogic')
 
         config = self.getConfiguration()
 

--- a/logic/poi_manager_logic.py
+++ b/logic/poi_manager_logic.py
@@ -174,11 +174,11 @@ class PoiManagerLogic(GenericLogic):
     _modclass = 'poimanagerlogic'
     _modtype = 'logic'
     # declare connectors
-    _in = {'optimizer1': 'OptimizerLogic',
-           'scannerlogic': 'ConfocalLogic',
-           'savelogic': 'SaveLogic',
-           }
-    _out = {'poimanagerlogic': 'PoiManagerLogic'}
+    _connectors = {
+        'optimizer1': 'OptimizerLogic',
+        'scannerlogic': 'ConfocalLogic',
+        'savelogic': 'SaveLogic',
+    }
 
     signal_timer_updated = QtCore.Signal()
     signal_poi_updated = QtCore.Signal()

--- a/logic/poi_manager_logic.py
+++ b/logic/poi_manager_logic.py
@@ -210,9 +210,9 @@ class PoiManagerLogic(GenericLogic):
         """ Initialisation performed during activation of the module.
         """
 
-        self._optimizer_logic = self.get_in_connector('optimizer1')
-        self._confocal_logic = self.get_in_connector('scannerlogic')
-        self._save_logic = self.get_in_connector('savelogic')
+        self._optimizer_logic = self.get_connector('optimizer1')
+        self._confocal_logic = self.get_connector('scannerlogic')
+        self._save_logic = self.get_connector('savelogic')
 
         # initally add crosshair to the pois
         crosshair = PoI(point=[0, 0, 0], name='crosshair')

--- a/logic/polarisation_dep_logic.py
+++ b/logic/polarisation_dep_logic.py
@@ -32,11 +32,11 @@ class PolarisationDepLogic(GenericLogic):
     _modtype = 'logic'
 
     ## declare connectors
-    _in = { 'counterlogic': 'CounterLogic',
-            'savelogic': 'SaveLogic',
-            'motor':'MotorInterface'
-            }
-    _out = {'polarisationdeplogic': 'PolarisationDepLogic'}
+    _connectors = {
+        'counterlogic': 'CounterLogic',
+        'savelogic': 'SaveLogic',
+        'motor':'MotorInterface'
+    }
 
     signal_rotation_finished = QtCore.Signal()
     signal_start_rotation = QtCore.Signal()

--- a/logic/polarisation_dep_logic.py
+++ b/logic/polarisation_dep_logic.py
@@ -47,12 +47,12 @@ class PolarisationDepLogic(GenericLogic):
           @param object e: Fysom state change event
         """
 
-        self._counter_logic = self.get_in_connector('counterlogic')
+        self._counter_logic = self.get_connector('counterlogic')
 #        print("Counting device is", self._counting_device)
 
-        self._save_logic = self.get_in_connector('savelogic')
+        self._save_logic = self.get_connector('savelogic')
 
-        self._hwpmotor = self.get_in_connector('motor')
+        self._hwpmotor = self.get_connector('motor')
 
         # Initialise measurement parameters
         self.scan_length = 360

--- a/logic/pulse_analysis_logic.py
+++ b/logic/pulse_analysis_logic.py
@@ -34,9 +34,6 @@ class PulseAnalysisLogic(GenericLogic):
     _modclass = 'PulseAnalysisLogic'
     _modtype = 'logic'
 
-    # declare connectors
-    _out = {'pulseanalysislogic': 'PulseAnalysisLogic'}
-
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
 

--- a/logic/pulse_extraction_logic.py
+++ b/logic/pulse_extraction_logic.py
@@ -34,9 +34,6 @@ class PulseExtractionLogic(GenericLogic):
     _modclass = 'PulseExtractionLogic'
     _modtype = 'logic'
 
-    # declare connectors
-    _out = {'pulseextractionlogic': 'PulseExtractionLogic'}
-
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
 

--- a/logic/pulsed_extraction_external_logic.py
+++ b/logic/pulsed_extraction_external_logic.py
@@ -43,10 +43,11 @@ class PulsedExtractionExternalLogic(GenericLogic):
     _modtype = 'logic'
 
     # declare connectors
-    _in = {'savelogic': 'SaveLogic',
-           'pulseextractionlogic': 'PulseExtractionLogic',
-           'pulseanalysislogic': 'PulseAnalysisLogic'}
-    _out = {'pulsedextractionexternallogic': 'PulsedExtractionExternalLogic'}
+    _connectors = {
+        'savelogic': 'SaveLogic',
+        'pulseextractionlogic': 'PulseExtractionLogic',
+        'pulseanalysislogic': 'PulseAnalysisLogic'
+    }
 
     def __init__(self, **kwargs):
         """ Create QdplotLogic object with connectors.

--- a/logic/pulsed_extraction_external_logic.py
+++ b/logic/pulsed_extraction_external_logic.py
@@ -71,9 +71,9 @@ class PulsedExtractionExternalLogic(GenericLogic):
         """
 
 
-        self._save_logic = self.get_in_connector('savelogic')
-        self._pe_logic = self.get_in_connector('pulseextractionlogic')
-        self._pa_logic = self.get_in_connector('pulseanalysislogic')
+        self._save_logic = self.get_connector('savelogic')
+        self._pe_logic = self.get_connector('pulseextractionlogic')
+        self._pa_logic = self.get_connector('pulseanalysislogic')
 
     def on_deactivate(self, e):
         """ Deinitialisation performed during deactivation of the module.

--- a/logic/pulsed_master_logic.py
+++ b/logic/pulsed_master_logic.py
@@ -148,8 +148,8 @@ class PulsedMasterLogic(GenericLogic):
 
           @param object e: Fysom state change event
         """
-        self._measurement_logic = self.get_in_connector('pulsedmeasurementlogic')
-        self._generator_logic = self.get_in_connector('sequencegeneratorlogic')
+        self._measurement_logic = self.get_connector('pulsedmeasurementlogic')
+        self._generator_logic = self.get_connector('sequencegeneratorlogic')
 
         # Recall status variables
         if 'invoke_settings' in self._statusVariables:

--- a/logic/pulsed_master_logic.py
+++ b/logic/pulsed_master_logic.py
@@ -111,10 +111,10 @@ class PulsedMasterLogic(GenericLogic):
     _modtype = 'logic'
 
     # declare connectors
-    _in = {'pulsedmeasurementlogic': 'PulsedMeasurementLogic',
-           'sequencegeneratorlogic': 'SequenceGeneratorLogic',
-           }
-    _out = {'pulsedmasterlogic': 'PulsedMasterLogic'}
+    _connectors = {
+        'pulsedmeasurementlogic': 'PulsedMeasurementLogic',
+        'sequencegeneratorlogic': 'SequenceGeneratorLogic',
+    }
 
     def __init__(self, config, **kwargs):
         """ Create PulsedMasterLogic object with connectors.

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -158,13 +158,13 @@ class PulsedMeasurementLogic(GenericLogic):
                          had happened.
         """
         # get all the connectors:
-        self._pulse_analysis_logic = self.get_in_connector('pulseanalysislogic')
-        self._pulse_extraction_logic = self.get_in_connector('pulseextractionlogic')
-        self._fast_counter_device = self.get_in_connector('fastcounter')
-        self._save_logic = self.get_in_connector('savelogic')
-        self._fit_logic = self.get_in_connector('fitlogic')
-        self._pulse_generator_device = self.get_in_connector('pulsegenerator')
-        self._mycrowave_source_device = self.get_in_connector('microwave')
+        self._pulse_analysis_logic = self.get_connector('pulseanalysislogic')
+        self._pulse_extraction_logic = self.get_connector('pulseextractionlogic')
+        self._fast_counter_device = self.get_connector('fastcounter')
+        self._save_logic = self.get_connector('savelogic')
+        self._fit_logic = self.get_connector('fitlogic')
+        self._pulse_generator_device = self.get_connector('pulsegenerator')
+        self._mycrowave_source_device = self.get_connector('microwave')
 
         # Recall saved status variables
         if 'number_of_lasers' in self._statusVariables:

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -39,15 +39,15 @@ class PulsedMeasurementLogic(GenericLogic):
     _modtype = 'logic'
 
     ## declare connectors
-    _in = {'pulseanalysislogic': 'PulseAnalysisLogic',
-           'pulseextractionlogic': 'PulseExtractionLogic',
-           'fitlogic': 'FitLogic',
-           'savelogic': 'SaveLogic',
-           'fastcounter': 'FastCounterInterface',
-           'microwave': 'MWInterface',
-           'pulsegenerator': 'PulserInterface',
-           }
-    _out = {'pulsedmeasurementlogic': 'PulsedMeasurementLogic'}
+    _connectors = {
+        'pulseanalysislogic': 'PulseAnalysisLogic',
+        'pulseextractionlogic': 'PulseExtractionLogic',
+        'fitlogic': 'FitLogic',
+        'savelogic': 'SaveLogic',
+        'fastcounter': 'FastCounterInterface',
+        'microwave': 'MWInterface',
+        'pulsegenerator': 'PulserInterface',
+    }
 
     sigSignalDataUpdated = QtCore.Signal(np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray,
                                          np.ndarray, np.ndarray, np.ndarray)

--- a/logic/qdplot_logic.py
+++ b/logic/qdplot_logic.py
@@ -79,7 +79,7 @@ class QdplotLogic(GenericLogic):
         self.set_hlabel()
         self.set_vlabel()
 
-        self._save_logic = self.get_in_connector('savelogic')
+        self._save_logic = self.get_connector('savelogic')
 
     def on_deactivate(self, e):
         """ Deinitialisation performed during deactivation of the module.

--- a/logic/qdplot_logic.py
+++ b/logic/qdplot_logic.py
@@ -45,9 +45,9 @@ class QdplotLogic(GenericLogic):
     _modtype = 'logic'
 
     # declare connectors
-    _in = {'savelogic': 'SaveLogic'
-           }
-    _out = {'qdplotlogic': 'QdplotLogic'}
+    _connectors = {
+        'savelogic': 'SaveLogic'
+    }
 
     def __init__(self, **kwargs):
         """ Create QdplotLogic object with connectors.

--- a/logic/save_logic.py
+++ b/logic/save_logic.py
@@ -122,9 +122,6 @@ class SaveLogic(GenericLogic):
     _modclass = 'savelogic'
     _modtype = 'logic'
 
-    # declare connectors
-    _out = {'savelogic': 'SaveLogic'}
-
     # Matplotlib style definition for saving plots
     mpl_qd_style = {'axes.prop_cycle': cycler('color', ['#1f17f4',
                                                         '#ffa40e',

--- a/logic/sequence_generator_logic.py
+++ b/logic/sequence_generator_logic.py
@@ -59,9 +59,6 @@ class SequenceGeneratorLogic(GenericLogic, SamplingFunctions, SamplesWriteMethod
     _modclass = 'sequencegeneratorlogic'
     _modtype = 'logic'
 
-    ## declare connectors
-    _out = {'sequencegenerator': 'SequenceGeneratorLogic'}
-
 
     # define signals
     sigBlockDictUpdated = QtCore.Signal(dict)

--- a/logic/simple_data_logic.py
+++ b/logic/simple_data_logic.py
@@ -30,8 +30,7 @@ class SimpleDataLogic(GenericLogic):
     """
     _modclass = 'smple_data'
     _modtype = 'logic'
-    _in = {'simpledata': 'SimpleData'}
-    _out = {'simplelogic': 'SimpleDataLogic'}
+    _connectors = {'simpledata': 'SimpleData'}
 
     sigRepeat = QtCore.Signal()
 

--- a/logic/simple_data_logic.py
+++ b/logic/simple_data_logic.py
@@ -40,7 +40,7 @@ class SimpleDataLogic(GenericLogic):
 
           @param object e: Fysom state change notification
         """
-        self._data_logic = self.get_in_connector('simpledata')
+        self._data_logic = self.get_connector('simpledata')
         self.stopRequest = False
         self.bufferLength = 10000
         self.sigRepeat.connect(self.measureLoop, QtCore.Qt.QueuedConnection)

--- a/logic/singleshot_logic.py
+++ b/logic/singleshot_logic.py
@@ -40,20 +40,19 @@ class SingleShotLogic(GenericLogic):
     _modtype = 'logic'
 
     # declare connectors
-    _in = {'savelogic': 'SaveLogic',
-           'fitlogic': 'FitLogic',
-           'fastcounter': 'FastCounterInterface',
-           'pulseextractionlogic': 'PulseExtractionLogic',
-           'pulsedmeasurementlogic': 'PulsedMeasurementLogic',
-           'traceanalysislogic1': 'TraceAnalysisLogic',
-           'pulsegenerator': 'PulserInterface',
-           'scannerlogic': 'ScannerLogic',
-           'optimizerlogic': 'OptimizerLogic',
-           'pulsedmasterlogic': 'PulsedMasterLogic',
-           'odmrlogic': 'ODMRLogic'
-            }
-
-    _out = {'singleshotlogic1': 'SingleShotLogic'}
+    _connectors = {
+        'savelogic': 'SaveLogic',
+        'fitlogic': 'FitLogic',
+        'fastcounter': 'FastCounterInterface',
+        'pulseextractionlogic': 'PulseExtractionLogic',
+        'pulsedmeasurementlogic': 'PulsedMeasurementLogic',
+        'traceanalysislogic1': 'TraceAnalysisLogic',
+        'pulsegenerator': 'PulserInterface',
+        'scannerlogic': 'ScannerLogic',
+        'optimizerlogic': 'OptimizerLogic',
+        'pulsedmasterlogic': 'PulsedMasterLogic',
+        'odmrlogic': 'ODMRLogic'
+    }
 
     # add possible signals here
     sigHistogramUpdated = QtCore.Signal()

--- a/logic/singleshot_logic.py
+++ b/logic/singleshot_logic.py
@@ -92,17 +92,17 @@ class SingleShotLogic(GenericLogic):
                          had happened.
         """
 
-        self._fast_counter_device = self.get_in_connector('fastcounter')
-        self._pulse_generator_device = self.get_in_connector('pulsegenerator')
-        self._save_logic = self.get_in_connector('savelogic')
-        self._fit_logic = self.get_in_connector('fitlogic')
-        self._traceanalysis_logic = self.get_in_connector('traceanalysislogic1')
-        self._pe_logic = self.get_in_connector('pulseextractionlogic')
-        self._pm_logic = self.get_in_connector('pulsedmeasurementlogic')
-        self._odmr_logic = self.get_in_connector('odmrlogic')
-        self._pulsed_master_logic = self.get_in_connector('pulsedmasterlogic')
-        self._confocal_logic = self.get_in_connector('scannerlogic')
-        self._optimizer_logic = self.get_in_connector('optimizerlogic')
+        self._fast_counter_device = self.get_connector('fastcounter')
+        self._pulse_generator_device = self.get_connector('pulsegenerator')
+        self._save_logic = self.get_connector('savelogic')
+        self._fit_logic = self.get_connector('fitlogic')
+        self._traceanalysis_logic = self.get_connector('traceanalysislogic1')
+        self._pe_logic = self.get_connector('pulseextractionlogic')
+        self._pm_logic = self.get_connector('pulsedmeasurementlogic')
+        self._odmr_logic = self.get_connector('odmrlogic')
+        self._pulsed_master_logic = self.get_connector('pulsedmasterlogic')
+        self._confocal_logic = self.get_connector('scannerlogic')
+        self._optimizer_logic = self.get_connector('optimizerlogic')
 
         self.hist_data = None
         self.trace = None

--- a/logic/software_pid_controller.py
+++ b/logic/software_pid_controller.py
@@ -59,8 +59,8 @@ class SoftPIDController(GenericLogic, PIDControllerInterface):
     def on_activate(self, e):
         """ Initialisation performed during activation of the module.
         """
-        self._process = self.get_in_connector('process')
-        self._control = self.get_in_connector('control')
+        self._process = self.get_connector('process')
+        self._control = self.get_connector('control')
 
         self.previousdelta = 0
         self.cv = self._control.getControlValue()

--- a/logic/software_pid_controller.py
+++ b/logic/software_pid_controller.py
@@ -35,11 +35,10 @@ class SoftPIDController(GenericLogic, PIDControllerInterface):
     _modclass = 'pidlogic'
     _modtype = 'logic'
     ## declare connectors
-    _in = {
+    _connectors = {
         'process': 'ProcessInterface',
         'control': 'ProcessControlInterface',
         }
-    _out = {'controller': 'SoftPIDController'}
 
     sigNewValue = QtCore.Signal(float)
 

--- a/logic/spectrum.py
+++ b/logic/spectrum.py
@@ -41,11 +41,11 @@ class SpectrumLogic(GenericLogic):
     _modtype = 'logic'
 
     # declare connectors
-    _in = {'spectrometer': 'SpectrometerInterface',
-           'odmrlogic1': 'ODMRLogic',
-           'savelogic': 'SaveLogic'
-           }
-    _out = {'spectrumlogic': 'SpectrumLogic'}
+    _connectors = {
+        'spectrometer': 'SpectrometerInterface',
+        'odmrlogic1': 'ODMRLogic',
+        'savelogic': 'SaveLogic'
+    }
 
     def __init__(self, **kwargs):
         """ Create SpectrometerLogic object with connectors.

--- a/logic/spectrum.py
+++ b/logic/spectrum.py
@@ -67,9 +67,9 @@ class SpectrumLogic(GenericLogic):
         self.diff_spec_data_mod_off = np.array([])
         self.repetition_count = 0    # count loops for differential spectrum
 
-        self._spectrometer_device = self.get_in_connector('spectrometer')
-        self._odmr_logic = self.get_in_connector('odmrlogic1')
-        self._save_logic = self.get_in_connector('savelogic')
+        self._spectrometer_device = self.get_connector('spectrometer')
+        self._odmr_logic = self.get_connector('odmrlogic1')
+        self._save_logic = self.get_connector('savelogic')
 
         self.sig_next_diff_loop.connect(self._loop_differential_spectrum)
 

--- a/logic/switch_logic.py
+++ b/logic/switch_logic.py
@@ -28,7 +28,6 @@ class SwitchLogic(GenericLogic):
     """
     _modclass = 'switch'
     _modtype = 'logic'
-    _out = {'switchlogic': 'SwitchLogic'}
 
     def __init__(self, config, **kwargs):
         """ Create logic object

--- a/logic/switch_logic.py
+++ b/logic/switch_logic.py
@@ -41,9 +41,9 @@ class SwitchLogic(GenericLogic):
         # dynamic number of 'in' connectors depending on config
         if 'connect' in config:
             for connector in config['connect']:
-                self.connector['in'][connector] = OrderedDict()
-                self.connector['in'][connector]['class'] = 'SwitchInterface'
-                self.connector['in'][connector]['object'] = None
+                self.connectors[connector] = OrderedDict()
+                self.connectors[connector]['class'] = 'SwitchInterface'
+                self.connectors[connector]['object'] = None
 
     def on_activate(self, e):
         """ Prepare logic module for work.
@@ -51,11 +51,11 @@ class SwitchLogic(GenericLogic):
           @param object e: Fysom state change notification
         """
         self.switches = dict()
-        for connector in self.connector['in']:
-            hwname = self.get_in_connector(connector)._name
+        for connector in self.connectors:
+            hwname = self.get_connector(connector)._name
             self.switches[hwname] = dict()
-            for i in range(self.get_in_connector(connector).getNumberOfSwitches()):
-                self.switches[hwname][i] = self.get_in_connector(connector)
+            for i in range(self.get_connector(connector).getNumberOfSwitches()):
+                self.switches[hwname][i] = self.get_connector(connector)
 
     def on_deactivate(self, e):
         """ Deactivate modeule.

--- a/logic/taskrunner.py
+++ b/logic/taskrunner.py
@@ -90,7 +90,6 @@ class TaskRunner(GenericLogic):
     """
     _modclass = 'TaskRunner'
     _modtype = 'Logic'
-    _out = {'runner': 'TaskRunner'}
 
     sigLoadTasks = QtCore.Signal()
     sigCheckTasks = QtCore.Signal()

--- a/logic/trace_analysis_logic.py
+++ b/logic/trace_analysis_logic.py
@@ -77,9 +77,9 @@ class TraceAnalysisLogic(GenericLogic):
                          had happened.
         """
 
-        self._counter_logic = self.get_in_connector('counterlogic1')
-        self._save_logic = self.get_in_connector('savelogic')
-        self._fit_logic = self.get_in_connector('fitlogic')
+        self._counter_logic = self.get_connector('counterlogic1')
+        self._save_logic = self.get_connector('savelogic')
+        self._fit_logic = self.get_connector('fitlogic')
 
         self._counter_logic.sigGatedCounterFinished.connect(self.do_calculate_histogram)
 

--- a/logic/trace_analysis_logic.py
+++ b/logic/trace_analysis_logic.py
@@ -38,12 +38,11 @@ class TraceAnalysisLogic(GenericLogic):
     _modtype = 'logic'
 
     # declare connectors
-    _in = {'counterlogic1': 'CounterLogic',
-           'savelogic': 'SaveLogic',
-           'fitlogic': 'FitLogic',
-            }
-
-    _out = {'traceanalysislogic1': 'TraceAnalysisLogic'}
+    _connectors = {
+        'counterlogic1': 'CounterLogic',
+        'savelogic': 'SaveLogic',
+        'fitlogic': 'FitLogic',
+    }
 
     sigHistogramUpdated = QtCore.Signal()
 

--- a/logic/wavemeter_logger_logic.py
+++ b/logic/wavemeter_logger_logic.py
@@ -102,11 +102,11 @@ class WavemeterLoggerLogic(GenericLogic):
     _modtype = 'logic'
 
     # declare connectors
-    _in = {'wavemeter1': 'WavemeterInterface',
-           'savelogic': 'SaveLogic',
-           'counterlogic': 'CounterLogic'
-           }
-    _out = {'wavemeterloggerlogic': 'WavemeterLoggerLogic'}
+    _connectors = {
+        'wavemeter1': 'WavemeterInterface',
+        'savelogic': 'SaveLogic',
+        'counterlogic': 'CounterLogic'
+    }
 
     def __init__(self, config, **kwargs):
         """ Create WavemeterLoggerLogic object with connectors.

--- a/logic/wavemeter_logger_logic.py
+++ b/logic/wavemeter_logger_logic.py
@@ -158,11 +158,11 @@ class WavemeterLoggerLogic(GenericLogic):
 
         self.stopRequested = False
 
-        self._wavemeter_device = self.get_in_connector('wavemeter1')
+        self._wavemeter_device = self.get_connector('wavemeter1')
 #        print("Counting device is", self._counting_device)
 
-        self._save_logic = self.get_in_connector('savelogic')
-        self._counter_logic = self.get_in_connector('counterlogic')
+        self._save_logic = self.get_connector('savelogic')
+        self._counter_logic = self.get_connector('counterlogic')
 
         # create a new x axis from xmin to xmax with bins points
         self.histogram_axis = np.arange(self._xmin,


### PR DESCRIPTION
This pull request removes out connectors.

I made the experience that the whole connector business is very complicated to explain to a novice and very difficult for them to understand the concept. Thus, a simplification will help tremendously. All currently used functionality can be implemented without out connectors and type checking could still be implemented. I have discussed the proposal of removing out connectors with Alexander Stark.

With the removal of out connectors, a connector is connected to any another module. The connector itself is defined - as it was before - by a name and a type. The module that is connected to the connector has to have that type, i.e. it has to implement a certain interface (either defined by an abc abstractclass or a regular class). Due to multiple inheritance a module can implement multiple interfaces. Type checking is not implemented yet and is left for another pull request (type checking was never implemented in qudi before, so no regression here).

Main Changes:
- removal of out connectors
- renamed "_in" dictionary in modules with "_connectors" (though "_in" still works right now and can be deprecated later)
- renamed "get_in_connector" to "get_connector" (no legacy method right now)
- old config files still work and just produce a warning. The second part in the definition of the connectee after the "." is ignored. New style configuration files simply point to a suitable module by the name of the inheritance defined in the config file.