### PR TITLE
Savelogic improvement

### DIFF
--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -234,7 +234,6 @@ class ConfocalGui(GUIBase):
         self._scanning_logic = self.get_in_connector('confocallogic1')
         self._save_logic = self.get_in_connector('savelogic')
         self._optimizer_logic = self.get_in_connector('optimizerlogic1')
-        self._save_logic = self.get_in_connector('savelogic')
 
         self._hardware_state = True
 

--- a/logic/confocal_logic.py
+++ b/logic/confocal_logic.py
@@ -22,7 +22,8 @@ top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi
 from qtpy import QtCore
 from collections import OrderedDict
 from copy import copy
-from datetime import datetime
+import time
+import datetime
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -849,10 +850,8 @@ class ConfocalLogic(GenericLogic):
 
         @param: list percentile_range (optional) The percentile range [min, max] of the color scale
         """
-        save_time = datetime.now()
-
-        filepath = self._save_logic.get_path_for_module(module_name='Confocal')
-
+        filepath = self._save_logic.get_path_for_module('Confocal')
+        timestamp = datetime.datetime.now()
         # Prepare the metadata parameters (common to both saved files):
         parameters = OrderedDict()
 
@@ -870,51 +869,41 @@ class ConfocalLogic(GenericLogic):
         parameters['Clock frequency of scanner (Hz)'] = self._clock_frequency
         parameters['Return Slowness (Steps during retrace line)'] = self.return_slowness
 
-
         # Prepare a figure to be saved
         figure_data = self.xy_image[:, :, 3]
-        image_extent = [
-            self.image_x_range[0],
-            self.image_x_range[1],
-            self.image_y_range[0],
-            self.image_y_range[1]
-            ]
+        image_extent = [self.image_x_range[0],
+                        self.image_x_range[1],
+                        self.image_y_range[0],
+                        self.image_y_range[1]]
         axes = ['X', 'Y']
         crosshair_pos = [self.get_position()[0], self.get_position()[1]]
 
-        figs = {
-            ch: self.draw_figure(
-                    data=self.xy_image[:, :, 3 + n],
-                    image_extent=image_extent,
-                    scan_axis=axes,
-                    cbar_range=colorscale_range,
-                    percentile_range=percentile_range,
-                    crosshair_pos=crosshair_pos
-                )
-            for n, ch in enumerate(self.get_scanner_count_channels())
-            }
+        figs = {ch: self.draw_figure(data=self.xy_image[:, :, 3 + n],
+                                     image_extent=image_extent,
+                                     scan_axis=axes,
+                                     cbar_range=colorscale_range,
+                                     percentile_range=percentile_range,
+                                     crosshair_pos=crosshair_pos)
+                for n, ch in enumerate(self.get_scanner_count_channels())}
 
         # Save the image data and figure
         for n, ch in enumerate(self.get_scanner_count_channels()):
             # data for the text-array "image":
             image_data = OrderedDict()
             image_data['Confocal pure XY scan image data without axis.\n'
-                '# The upper left entry represents the signal at the upper left pixel position.\n'
-                '# A pixel-line in the image corresponds to a row '
+                'The upper left entry represents the signal at the upper left pixel position.\n'
+                'A pixel-line in the image corresponds to a row '
                 'of entries where the Signal is in counts/s:'] = self.xy_image[:, :, 3 + n]
 
             filelabel = 'confocal_xy_image_{0}'.format(ch.replace('/', ''))
-            self._save_logic.save_data(
-                image_data,
-                filepath,
-                parameters=parameters,
-                filelabel=filelabel,
-                as_text=True,
-                timestamp=save_time,
-                precision='%.6e',
-                plotfig=figs[ch]
-                )
-            plt.close(figs[ch])
+            self._save_logic.save_data(image_data,
+                                       filepath=filepath,
+                                       timestamp=timestamp,
+                                       parameters=parameters,
+                                       filelabel=filelabel,
+                                       fmt='%.6e',
+                                       delimiter='\t',
+                                       plotfig=figs[ch])
 
         # prepare the full raw data in an OrderedDict:
         data = OrderedDict()
@@ -927,18 +916,17 @@ class ConfocalLogic(GenericLogic):
 
         # Save the raw data to file
         filelabel = 'confocal_xy_data'
-        self._save_logic.save_data(
-            data,
-            filepath,
-            parameters=parameters,
-            filelabel=filelabel,
-            as_text=True,
-            precision='%.6e',
-            timestamp=save_time
-            )
+        self._save_logic.save_data(data,
+                                   filepath=filepath,
+                                   timestamp=timestamp,
+                                   parameters=parameters,
+                                   filelabel=filelabel,
+                                   fmt='%.6e',
+                                   delimiter='\t')
 
-        self.log.debug('Confocal Image saved to:\n{0}'.format(filepath))
+        self.log.debug('Confocal Image saved.')
         self.signal_xy_data_saved.emit()
+        return
 
     def save_depth_data(self, colorscale_range=None, percentile_range=None):
         """ Save the current confocal depth data to file.
@@ -948,10 +936,8 @@ class ConfocalLogic(GenericLogic):
 
         The second file saves the full raw data with x, y, z, and counts at every pixel.
         """
-        save_time = datetime.now()
-
-        filepath = self._save_logic.get_path_for_module(module_name='Confocal')
-
+        filepath = self._save_logic.get_path_for_module('Confocal')
+        timestamp = datetime.datetime.now()
         # Prepare the metadata parameters (common to both saved files):
         parameters = OrderedDict()
 
@@ -980,46 +966,37 @@ class ConfocalLogic(GenericLogic):
             axes = ['Y', 'Z']
             crosshair_pos = [self.get_position()[1], self.get_position()[2]]
 
-        image_extent = [
-            horizontal_range[0],
-            horizontal_range[1],
-            self.image_z_range[0],
-            self.image_z_range[1]
-            ]
+        image_extent = [horizontal_range[0],
+                        horizontal_range[1],
+                        self.image_z_range[0],
+                        self.image_z_range[1]]
 
-        figs = {
-            ch: self.draw_figure(
-                    data=self.depth_image[:, :, 3 + n],
-                    image_extent=image_extent,
-                    scan_axis=axes,
-                    cbar_range=colorscale_range,
-                    percentile_range=percentile_range,
-                    crosshair_pos=crosshair_pos
-                )
-            for n, ch in enumerate(self.get_scanner_count_channels())
-            }
+        figs = {ch: self.draw_figure(data=self.depth_image[:, :, 3 + n],
+                                     image_extent=image_extent,
+                                     scan_axis=axes,
+                                     cbar_range=colorscale_range,
+                                     percentile_range=percentile_range,
+                                     crosshair_pos=crosshair_pos)
+                for n, ch in enumerate(self.get_scanner_count_channels())}
 
         # Save the image data and figure
         for n, ch in enumerate(self.get_scanner_count_channels()):
             # data for the text-array "image":
             image_data = OrderedDict()
             image_data['Confocal pure depth scan image data without axis.\n'
-                '# The upper left entry represents the signal at the upper left pixel position.\n'
-                '# A pixel-line in the image corresponds to a row in '
+                'The upper left entry represents the signal at the upper left pixel position.\n'
+                'A pixel-line in the image corresponds to a row in '
                 'of entries where the Signal is in counts/s:'] = self.depth_image[:, :, 3 + n]
 
             filelabel = 'confocal_depth_image_{0}'.format(ch.replace('/', ''))
-            self._save_logic.save_data(
-                image_data,
-                filepath,
-                parameters=parameters,
-                filelabel=filelabel,
-                as_text=True,
-                timestamp=save_time,
-                precision='%.6e',
-                plotfig=figs[ch]
-                )
-            plt.close(figs[ch])
+            self._save_logic.save_data(image_data,
+                                       filepath=filepath,
+                                       timestamp=timestamp,
+                                       parameters=parameters,
+                                       filelabel=filelabel,
+                                       fmt='%.6e',
+                                       delimiter='\t',
+                                       plotfig=figs[ch])
 
         # prepare the full raw data in an OrderedDict:
         data = OrderedDict()
@@ -1032,18 +1009,17 @@ class ConfocalLogic(GenericLogic):
 
         # Save the raw data to file
         filelabel = 'confocal_depth_data'
-        self._save_logic.save_data(
-            data,
-            filepath,
-            parameters=parameters,
-            filelabel=filelabel,
-            as_text=True,
-            precision='%.6e',
-            timestamp=save_time
-            )
+        self._save_logic.save_data(data,
+                                   filepath=filepath,
+                                   timestamp=timestamp,
+                                   parameters=parameters,
+                                   filelabel=filelabel,
+                                   fmt='%.6e',
+                                   delimiter='\t')
 
-        self.log.debug('Confocal Image saved to:\n{0}'.format(filepath))
+        self.log.debug('Confocal Image saved.')
         self.signal_depth_data_saved.emit()
+        return
 
     def draw_figure(self, data, image_extent, scan_axis=None, cbar_range=None, percentile_range=None,  crosshair_pos=None):
         """ Create a 2-D color map figure of the scan image.

--- a/logic/confocal_logic.py
+++ b/logic/confocal_logic.py
@@ -911,7 +911,7 @@ class ConfocalLogic(GenericLogic):
                 filelabel=filelabel,
                 as_text=True,
                 timestamp=save_time,
-                precision=':.3e',
+                precision='%.6e',
                 plotfig=figs[ch]
                 )
             plt.close(figs[ch])
@@ -933,7 +933,7 @@ class ConfocalLogic(GenericLogic):
             parameters=parameters,
             filelabel=filelabel,
             as_text=True,
-            precision=':.3e',
+            precision='%.6e',
             timestamp=save_time
             )
 
@@ -1016,7 +1016,7 @@ class ConfocalLogic(GenericLogic):
                 filelabel=filelabel,
                 as_text=True,
                 timestamp=save_time,
-                precision=':.3e',
+                precision='%.6e',
                 plotfig=figs[ch]
                 )
             plt.close(figs[ch])
@@ -1038,7 +1038,7 @@ class ConfocalLogic(GenericLogic):
             parameters=parameters,
             filelabel=filelabel,
             as_text=True,
-            precision=':.3e',
+            precision='%.6e',
             timestamp=save_time
             )
 

--- a/logic/counter_logic.py
+++ b/logic/counter_logic.py
@@ -333,9 +333,8 @@ class CounterLogic(GenericLogic):
             filepath = self._save_logic.get_path_for_module(module_name='Counter')
 
             fig = self.draw_figure(data=np.array(self._data_to_save))
-            self._save_logic.save_data(data, filepath, parameters=parameters, filelabel=filelabel,
-                                       as_text=True, plotfig=fig)
-            plt.close(fig)
+            self._save_logic.save_data(data, filepath=filepath, parameters=parameters,
+                                       filelabel=filelabel, plotfig=fig, delimiter='\t')
             self.log.info('Counter Trace saved to:\n{0}'.format(filepath))
 
         self.sigSavingStatusChanged.emit(self._saving)
@@ -554,12 +553,8 @@ class CounterLogic(GenericLogic):
         parameters['Smooth Window Length (# of events)'] = self._smooth_window_length
 
         filepath = self._save_logic.get_path_for_module(module_name='Counter')
-        self._save_logic.save_data(
-            data,
-            filepath,
-            parameters=parameters,
-            filelabel=filelabel,
-            as_text=True)
+        self._save_logic.save_data(data, filepath=filepath, parameters=parameters,
+                                   filelabel=filelabel, delimiter='\t')
 
         self.log.debug('Current Counter Trace saved to: {0}'.format(filepath))
         return data, filepath, parameters, filelabel

--- a/logic/laser_scanner_logic.py
+++ b/logic/laser_scanner_logic.py
@@ -432,7 +432,8 @@ class LaserScannerLogic(GenericLogic):
 
         # prepare the data in a dict or in an OrderedDict:
         data = OrderedDict()
-        data = {'Wavelength (nm), Signal (counts/s)': np.array([self.histogram_axis, self.histogram]).transpose()}
+        data['Wavelength (nm)'] = np.array(self.histogram_axis)
+        data['Signal (counts/s)'] = np.array(self.histogram)
 
         # write the parameters:
         parameters = OrderedDict()
@@ -444,14 +445,14 @@ class LaserScannerLogic(GenericLogic):
 
         self._save_logic.save_data(data, filepath, parameters=parameters,
                                    filelabel=filelabel, timestamp=timestamp,
-                                   as_text=True, precision=':.6f')  # , as_xml=False, precision=None, delimiter=None)
+                                   as_text=True, precision='%.6e')  # , as_xml=False, precision=None, delimiter=None)
 
         filepath = self._save_logic.get_path_for_module(module_name='LaserScanning')
         filelabel = 'laser_scan_wavemeter'
 
         # prepare the data in a dict or in an OrderedDict:
         data = OrderedDict()
-        data = {'Time (s), Wavelength (nm)': self._wavelength_data}
+        data['Time (s), Wavelength (nm)'] = self._wavelength_data
         # write the parameters:
         parameters = OrderedDict()
         parameters['Acquisition Timing (ms)'] = self._logic_acquisition_timing
@@ -460,14 +461,14 @@ class LaserScannerLogic(GenericLogic):
 
         self._save_logic.save_data(data, filepath, parameters=parameters,
                                    filelabel=filelabel, timestamp=timestamp,
-                                   as_text=True, precision=':.6f')  # , as_xml=False, precision=None, delimiter=None)
+                                   as_text=True, precision='%.6e')  # , as_xml=False, precision=None, delimiter=None)
 
         filepath = self._save_logic.get_path_for_module(module_name='LaserScanning')
         filelabel = 'laser_scan_counts'
 
         # prepare the data in a dict or in an OrderedDict:
         data = OrderedDict()
-        data = {'Time (s),Signal (counts/s)': self._counter_logic._data_to_save}
+        data['Time (s),Signal (counts/s)'] = self._counter_logic._data_to_save
 
         # write the parameters:
         parameters = OrderedDict()
@@ -480,7 +481,7 @@ class LaserScannerLogic(GenericLogic):
 
         self._save_logic.save_data(data, filepath, parameters=parameters,
                                    filelabel=filelabel, timestamp=timestamp,
-                                   as_text=True, precision=':.6f')  # , as_xml=False, precision=None, delimiter=None)
+                                   as_text=True, precision='%.6e')  # , as_xml=False, precision=None, delimiter=None)
 
         self.log.debug('Laser Scan saved to:\n{0}'.format(filepath))
 

--- a/logic/laser_scanner_logic.py
+++ b/logic/laser_scanner_logic.py
@@ -443,9 +443,8 @@ class LaserScannerLogic(GenericLogic):
         parameters['Start Time (s)'] = time.strftime('%d.%m.%Y %Hh:%Mmin:%Ss', time.localtime(self._acqusition_start_time))
         parameters['Stop Time (s)'] = time.strftime('%d.%m.%Y %Hh:%Mmin:%Ss', time.localtime(self._saving_stop_time))
 
-        self._save_logic.save_data(data, filepath, parameters=parameters,
-                                   filelabel=filelabel, timestamp=timestamp,
-                                   as_text=True, precision='%.6e')  # , as_xml=False, precision=None, delimiter=None)
+        self._save_logic.save_data(data, filepath=filepath, parameters=parameters, fmt='%.6e',
+                                   filelabel=filelabel, timestamp=timestamp, delimiter='\t')
 
         filepath = self._save_logic.get_path_for_module(module_name='LaserScanning')
         filelabel = 'laser_scan_wavemeter'
@@ -459,9 +458,8 @@ class LaserScannerLogic(GenericLogic):
         parameters['Start Time (s)'] = time.strftime('%d.%m.%Y %Hh:%Mmin:%Ss', time.localtime(self._acqusition_start_time))
         parameters['Stop Time (s)'] = time.strftime('%d.%m.%Y %Hh:%Mmin:%Ss', time.localtime(self._saving_stop_time))
 
-        self._save_logic.save_data(data, filepath, parameters=parameters,
-                                   filelabel=filelabel, timestamp=timestamp,
-                                   as_text=True, precision='%.6e')  # , as_xml=False, precision=None, delimiter=None)
+        self._save_logic.save_data(data, filepath=filepath, parameters=parameters, delimiter='\t',
+                                   filelabel=filelabel, timestamp=timestamp, fmt='%.6e')
 
         filepath = self._save_logic.get_path_for_module(module_name='LaserScanning')
         filelabel = 'laser_scan_counts'
@@ -479,9 +477,8 @@ class LaserScannerLogic(GenericLogic):
         parameters['Oversampling (Samples)'] = self._counter_logic._counting_samples
         parameters['Smooth Window Length (# of events)'] = self._counter_logic._smooth_window_length
 
-        self._save_logic.save_data(data, filepath, parameters=parameters,
-                                   filelabel=filelabel, timestamp=timestamp,
-                                   as_text=True, precision='%.6e')  # , as_xml=False, precision=None, delimiter=None)
+        self._save_logic.save_data(data, filepath=filepath, parameters=parameters, fmt='%.6e',
+                                   filelabel=filelabel, timestamp=timestamp, delimiter='\t')
 
         self.log.debug('Laser Scan saved to:\n{0}'.format(filepath))
 

--- a/logic/magnet_logic.py
+++ b/logic/magnet_logic.py
@@ -2064,9 +2064,8 @@ class MagnetLogic(GenericLogic):
 
 
 
-        self._save_logic.save_data(matrix_data, filepath, parameters=parameters,
-                                   filelabel=filelabel, timestamp=timestamp,
-                                   as_text=True)
+        self._save_logic.save_data(matrix_data, filepath=filepath, parameters=parameters,
+                                   filelabel=filelabel, timestamp=timestamp)
 
         self.log.debug('Magnet 2D data saved to:\n{0}'.format(filepath))
 
@@ -2091,9 +2090,8 @@ class MagnetLogic(GenericLogic):
 
 
 
-        self._save_logic.save_data(add_data, filepath,
-                                   filelabel=filelabel2, timestamp=timestamp,
-                                   as_text=True)
+        self._save_logic.save_data(add_data, filepath=filepath, filelabel=filelabel2,
+                                   timestamp=timestamp)
         # save the data table
 
         count_data = self._2D_data_matrix
@@ -2119,34 +2117,30 @@ class MagnetLogic(GenericLogic):
 
         # making saveable dictionaries
 
-        self._save_logic.save_data(save_dict, filepath,
-                                   filelabel=filelabel3, timestamp=timestamp,
-                                   as_text=True, precision='%.6e')
+        self._save_logic.save_data(save_dict, filepath=filepath, filelabel=filelabel3,
+                                   timestamp=timestamp, fmt='%.6e')
         keys = self._2d_intended_fields[0].keys()
         intended_fields = OrderedDict()
         for key in keys:
             field_values = [coord_dict[key] for coord_dict in self._2d_intended_fields]
             intended_fields[key] = field_values
 
-        self._save_logic.save_data(intended_fields, filepath,
-                                   filelabel=filelabel4, timestamp=timestamp,
-                                   as_text=True)
+        self._save_logic.save_data(intended_fields, filepath=filepath, filelabel=filelabel4,
+                                   timestamp=timestamp)
 
         measured_fields = OrderedDict()
         for key in keys:
             field_values = [coord_dict[key] for coord_dict in self._2d_measured_fields]
             measured_fields[key] = field_values
 
-        self._save_logic.save_data(measured_fields, filepath,
-                                   filelabel=filelabel5, timestamp=timestamp,
-                                   as_text=True)
+        self._save_logic.save_data(measured_fields, filepath=filepath, filelabel=filelabel5,
+                                   timestamp=timestamp)
 
         error = OrderedDict()
         error['quadratic error'] = self._2d_error
 
-        self._save_logic.save_data(error, filepath,
-                                   filelabel=filelabel6, timestamp=timestamp,
-                                   as_text=True)
+        self._save_logic.save_data(error, filepath=filepath, filelabel=filelabel6,
+                                   timestamp=timestamp)
 
     def _move_to_index(self, pathway_index, pathway):
 

--- a/logic/magnet_logic.py
+++ b/logic/magnet_logic.py
@@ -2113,12 +2113,15 @@ class MagnetLogic(GenericLogic):
                 save_dict[axis0_key].append(x_val[ii])
                 save_dict[axis1_key].append(y_val[jj])
                 save_dict[counts_key].append(col_counts)
+        save_dict[axis0_key] = np.array(save_dict[axis0_key])
+        save_dict[axis1_key] = np.array(save_dict[axis1_key])
+        save_dict[counts_key] = np.array(save_dict[counts_key])
 
         # making saveable dictionaries
 
         self._save_logic.save_data(save_dict, filepath,
                                    filelabel=filelabel3, timestamp=timestamp,
-                                   as_text=True, precision=':.6e')
+                                   as_text=True, precision='%.6e')
         keys = self._2d_intended_fields[0].keys()
         intended_fields = OrderedDict()
         for key in keys:

--- a/logic/nuclear_operations_logic.py
+++ b/logic/nuclear_operations_logic.py
@@ -1164,29 +1164,25 @@ class NuclearOperationsLogic(GenericLogic):
         param['Start of measurement'] = self.start_time.strftime('%Y-%m-%d %H:%M:%S')
 
         self._save_logic.save_data(data1,
-                                   filepath,
+                                   filepath=filepath,
                                    parameters=param,
                                    filelabel=filelabel1,
-                                   timestamp=timestamp,
-                                   as_text=True)
+                                   timestamp=timestamp)
 
         self._save_logic.save_data(data2,
-                                   filepath,
+                                   filepath=filepath,
                                    filelabel=filelabel2,
-                                   timestamp=timestamp,
-                                   as_text=True)
+                                   timestamp=timestamp)
 
         self._save_logic.save_data(data4,
-                                   filepath,
+                                   filepath=filepath,
                                    filelabel=filelabel4,
-                                   timestamp=timestamp,
-                                   as_text=True)
+                                   timestamp=timestamp)
 
         # self._save_logic.save_data(data3,
-        #                            filepath,
+        #                            filepath=filepath,
         #                            filelabel=filelabel3,
-        #                            timestamp=timestamp,
-        #                            as_text=True)
+        #                            timestamp=timestamp)
 
         self.log.info('Nuclear Operation data saved to:\n{0}'.format(filepath))
 

--- a/logic/odmr_logic.py
+++ b/logic/odmr_logic.py
@@ -889,9 +889,9 @@ class ODMRLogic(GenericLogic):
         freq_data = self.ODMR_plot_x
         count_data = self.ODMR_plot_y
         matrix_data = self.ODMR_plot_xy  # the data in the matrix plot
-        data['frequency values (Hz)'] = freq_data
-        data['count data (counts/s)'] = count_data
-        data2['count data (counts/s)'] = matrix_data  # saves the raw data used in the matrix NOT all only the size of the matrix
+        data['frequency values (Hz)'] = np.array(freq_data)
+        data['count data (counts/s)'] = np.array(count_data)
+        data2['count data (counts/s)'] = np.array(matrix_data)  # saves the raw data used in the matrix NOT all only the size of the matrix
 
         parameters = OrderedDict()
         parameters['Microwave Power (dBm)'] = self.mw_power
@@ -936,7 +936,7 @@ class ODMRLogic(GenericLogic):
 
         if self.saveRawData:
             raw_data = self.ODMR_raw_data  # array cotaining ALL messured data
-            data3['count data'] = raw_data  # saves the raw data, ALL of it so keep an eye on performance
+            data3['count data'] = np.array(raw_data)  # saves the raw data, ALL of it so keep an eye on performance
             self._save_logic.save_data(
                 data3,
                 filepath3,

--- a/logic/odmr_logic.py
+++ b/logic/odmr_logic.py
@@ -914,36 +914,29 @@ class ODMRLogic(GenericLogic):
                                percentile_range=percentile_range
                                )
 
-        self._save_logic.save_data(
-            data,
-            filepath,
-            parameters=parameters,
-            filelabel=filelabel,
-            timestamp=timestamp,
-            plotfig=fig,
-            as_text=True)
-        plt.close(fig)
+        self._save_logic.save_data(data,
+                                   filepath=filepath,
+                                   parameters=parameters,
+                                   filelabel=filelabel,
+                                   timestamp=timestamp,
+                                   plotfig=fig)
 
-        self._save_logic.save_data(
-            data2,
-            filepath2,
-            parameters=parameters,
-            filelabel=filelabel2,
-            timestamp=timestamp,
-            as_text=True)
+        self._save_logic.save_data(data2,
+                                   filepath=filepath2,
+                                   parameters=parameters,
+                                   filelabel=filelabel2,
+                                   timestamp=timestamp)
 
         self.log.info('ODMR data saved to:\n{0}'.format(filepath))
 
         if self.saveRawData:
             raw_data = self.ODMR_raw_data  # array cotaining ALL messured data
             data3['count data'] = np.array(raw_data)  # saves the raw data, ALL of it so keep an eye on performance
-            self._save_logic.save_data(
-                data3,
-                filepath3,
-                parameters=parameters,
-                filelabel=filelabel3,
-                timestamp=timestamp,
-                as_text=True)
+            self._save_logic.save_data(data3,
+                                       filepath=filepath3,
+                                       parameters=parameters,
+                                       filelabel=filelabel3,
+                                       timestamp=timestamp)
 
             self.log.info('Raw data succesfully saved.')
         else:

--- a/logic/poi_manager_logic.py
+++ b/logic/poi_manager_logic.py
@@ -721,12 +721,7 @@ class PoiManagerLogic(GenericLogic):
         data['Y'] = np.array(y_coords)
         data['Z'] = np.array(z_coords)
 
-        self._save_logic.save_data(
-            data,
-            filepath,
-            filelabel=self.roi_name,
-            precision='%.6e',
-            as_text=True)
+        self._save_logic.save_data(data, filepath=filepath, filelabel=self.roi_name, fmt='%.6e')
 
         self.log.debug('ROI saved to:\n{0}'.format(filepath))
 

--- a/logic/poi_manager_logic.py
+++ b/logic/poi_manager_logic.py
@@ -715,17 +715,17 @@ class PoiManagerLogic(GenericLogic):
                 y_coords.append(thispoi.get_coords_in_sample()[1])
                 z_coords.append(thispoi.get_coords_in_sample()[2])
 
-        data['POI Name'] = poinames
-        data['POI Key'] = poikeys
-        data['X'] = x_coords
-        data['Y'] = y_coords
-        data['Z'] = z_coords
+        data['POI Name'] = np.array(poinames)
+        data['POI Key'] = np.array(poikeys)
+        data['X'] = np.array(x_coords)
+        data['Y'] = np.array(y_coords)
+        data['Z'] = np.array(z_coords)
 
         self._save_logic.save_data(
             data,
             filepath,
             filelabel=self.roi_name,
-            precision=':.3e',
+            precision='%.6e',
             as_text=True)
 
         self.log.debug('ROI saved to:\n{0}'.format(filepath))

--- a/logic/pulsed_extraction_external_logic.py
+++ b/logic/pulsed_extraction_external_logic.py
@@ -155,14 +155,8 @@ class PulsedExtractionExternalLogic(GenericLogic):
         filelabel='result'
         filepath = self._save_logic.get_path_for_module(module_name='Counter')
 
-        self._save_logic.save_data(data,
-                                       filepath,
-                                       parameters=parameters,
-                                       filelabel=filelabel,
-                                       as_text=True,
-                                       plotfig=fig
-                                       )
-        plt.close(fig)
+        self._save_logic.save_data(data, filepath=filepath, parameters=parameters,
+                                   filelabel=filelabel, plotfig=fig, delimiter='\t')
 
         return self._data_to_save, parameters
 

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -1020,14 +1020,15 @@ class PulsedMeasurementLogic(GenericLogic):
             filelabel = 'laser_pulses'
         # prepare the data in a dict or in an OrderedDict:
         data = OrderedDict()
-        data['Signal (counts)'] = self.laser_data.transpose()
+        laser_trace = self.laser_data.astype(int)
+        data['Signal (counts)'] = laser_trace.transpose()
         # write the parameters:
         parameters = OrderedDict()
         parameters['Bin size (s)'] = self.fast_counter_binwidth
         parameters['laser length (s)'] = self.fast_counter_binwidth * self.laser_plot_x.size
 
         self._save_logic.save_data(data, filepath, parameters=parameters, filelabel=filelabel,
-                                   timestamp=timestamp, as_text=True, precision=':.6e')
+                                   timestamp=timestamp, as_text=True, precision='%d')
 
         #####################################################################
         ####                Save measurement data                        ####
@@ -1039,32 +1040,14 @@ class PulsedMeasurementLogic(GenericLogic):
 
         # prepare the data in a dict or in an OrderedDict:
         data = OrderedDict()
+        data['Controlled variable (' + controlled_val_unit + ')'] = self.signal_plot_x
+        data['Signal (norm.)'] = self.signal_plot_y
         if self.alternating:
-            if with_error:
-                data_array = np.zeros([5, len(self.signal_plot_x)], dtype=float)
-                data_key = 'Controlled variable (' + controlled_val_unit + '), Signal (norm.), Signal2 (norm.), Error (norm.), Error2(norm.)'
-            else:
-                data_array = np.zeros([3, len(self.signal_plot_x)], dtype=float)
-                data_key = 'Controlled variable (' + controlled_val_unit + '), Signal (norm.), Signal2 (norm.)'
-            data_array[0, :] = self.signal_plot_x
-            data_array[1, :] = self.signal_plot_y
-            data_array[2, :] = self.signal_plot_y2
-            if with_error:
-                data_array[3, :] = self.measuring_error_plot_y
-                data_array[4, :] = self.measuring_error_plot_y2
-        else:
-            if with_error:
-                data_array = np.zeros([3, len(self.signal_plot_x)], dtype=float)
-                data_key = 'Controlled variable (' + controlled_val_unit + '), Signal (norm.), Error (norm.)'
-            else:
-                data_array = np.zeros([2, len(self.signal_plot_x)], dtype=float)
-                data_key = 'Controlled variable (' + controlled_val_unit + '), Signal (norm.)'
-            data_array[0, :] = self.signal_plot_x
-            data_array[1, :] = self.signal_plot_y
-            if with_error:
-                data_array[2, :] = self.measuring_error_plot_y
-
-        data[data_key] = data_array.transpose()
+            data['Signal2 (norm.)'] = self.signal_plot_y2
+        if with_error:
+            data['Error (norm.)'] = self.measuring_error_plot_y
+            if self.alternating:
+                data['Error2 (norm.)'] = self.measuring_error_plot_y2
 
         # write the parameters:
         parameters = OrderedDict()
@@ -1087,6 +1070,7 @@ class PulsedMeasurementLogic(GenericLogic):
             ax1.plot(self.signal_plot_x, self.signal_plot_y)
             if self.alternating:
                 ax1.plot(self.signal_plot_x, self.signal_plot_y2)
+        ax1.ticklabel_format(style='sci', axis='x', scilimits=(0, 0))
         ax1.set_xlabel('controlled variable (' + controlled_val_unit + ')')
         ax1.set_ylabel('norm. sig (a.u.)')
         # ax1.set_xlim(self.plot_domain)
@@ -1094,7 +1078,7 @@ class PulsedMeasurementLogic(GenericLogic):
         fig.tight_layout()
 
         self._save_logic.save_data(data, filepath, parameters=parameters, filelabel=filelabel,
-                                   timestamp=timestamp, as_text=True, plotfig=fig, precision=':.6e')
+                                   timestamp=timestamp, as_text=True, plotfig=fig, precision='%.12e')
         plt.close(fig)
 
         #####################################################################
@@ -1107,7 +1091,8 @@ class PulsedMeasurementLogic(GenericLogic):
 
         # prepare the data in a dict or in an OrderedDict:
         data = OrderedDict()
-        data['Signal (counts)'] = self.raw_data.transpose()
+        raw_trace = self.raw_data.astype(int)
+        data['Signal (counts)'] = raw_trace.transpose()
         # write the parameters:
         parameters = OrderedDict()
         parameters['Is counter gated?'] = self.fast_counter_gated
@@ -1121,7 +1106,7 @@ class PulsedMeasurementLogic(GenericLogic):
                                                     len(self.controlled_vals) - 1)
 
         self._save_logic.save_data(data, filepath, parameters=parameters, filelabel=filelabel,
-                                   timestamp=timestamp, as_text=True, precision=':.6e')
+                                   timestamp=timestamp, as_text=True, precision='%d')
         return
 
     def _compute_fft(self):

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -1008,12 +1008,12 @@ class PulsedMeasurementLogic(GenericLogic):
         @param with_error:
         @return:
         """
+        filepath = self._save_logic.get_path_for_module('PulsedMeasurement')
+        timestamp = datetime.datetime.now()
+
         #####################################################################
         ####                Save extracted laser pulses                  ####
         #####################################################################
-        filepath = self._save_logic.get_path_for_module(module_name='PulsedMeasurement')
-        timestamp = datetime.datetime.now()
-
         if tag is not None and len(tag) > 0:
             filelabel = tag + '_laser_pulses'
         else:
@@ -1021,14 +1021,14 @@ class PulsedMeasurementLogic(GenericLogic):
         # prepare the data in a dict or in an OrderedDict:
         data = OrderedDict()
         laser_trace = self.laser_data.astype(int)
-        data['Signal (counts)'] = laser_trace.transpose()
+        data['Signal (counts)\nLaser'.format()] = laser_trace.transpose()
         # write the parameters:
         parameters = OrderedDict()
         parameters['Bin size (s)'] = self.fast_counter_binwidth
         parameters['laser length (s)'] = self.fast_counter_binwidth * self.laser_plot_x.size
 
-        self._save_logic.save_data(data, filepath, parameters=parameters, filelabel=filelabel,
-                                   timestamp=timestamp, as_text=True, precision='%d')
+        self._save_logic.save_data(data, timestamp=timestamp, parameters=parameters,
+                                   filepath=filepath, filelabel=filelabel, fmt='%d', delimiter='\t')
 
         #####################################################################
         ####                Save measurement data                        ####
@@ -1073,13 +1073,11 @@ class PulsedMeasurementLogic(GenericLogic):
         ax1.ticklabel_format(style='sci', axis='x', scilimits=(0, 0))
         ax1.set_xlabel('controlled variable (' + controlled_val_unit + ')')
         ax1.set_ylabel('norm. sig (a.u.)')
-        # ax1.set_xlim(self.plot_domain)
-        # ax1.set_ylim(self.plot_range)
         fig.tight_layout()
 
-        self._save_logic.save_data(data, filepath, parameters=parameters, filelabel=filelabel,
-                                   timestamp=timestamp, as_text=True, plotfig=fig, precision='%.12e')
-        plt.close(fig)
+        self._save_logic.save_data(data, timestamp=timestamp, parameters=parameters, fmt='%.15e',
+                                   filepath=filepath, filelabel=filelabel, delimiter='\t',
+                                   plotfig=fig)
 
         #####################################################################
         ####                Save raw data timetrace                      ####
@@ -1100,13 +1098,10 @@ class PulsedMeasurementLogic(GenericLogic):
         parameters['Bin size (s)'] = self.fast_counter_binwidth
         parameters['Number of laser pulses'] = self.number_of_lasers
         parameters['laser length (s)'] = self.fast_counter_binwidth * self.laser_plot_x.size
-        parameters['Controlled variable start'] = self.controlled_vals[0]
-        parameters['Controlled variable increment'] = (self.controlled_vals[-1] -
-                                                     self.controlled_vals[0]) / (
-                                                    len(self.controlled_vals) - 1)
+        parameters['Controlled variable values'] = list(self.controlled_vals)
 
-        self._save_logic.save_data(data, filepath, parameters=parameters, filelabel=filelabel,
-                                   timestamp=timestamp, as_text=True, precision='%d')
+        self._save_logic.save_data(data, timestamp=timestamp, parameters=parameters, fmt='%d',
+                                   filepath=filepath, filelabel=filelabel, delimiter='\t')
         return
 
     def _compute_fft(self):

--- a/logic/qdplot_logic.py
+++ b/logic/qdplot_logic.py
@@ -216,11 +216,10 @@ class QdplotLogic(GenericLogic):
 
         # Call save logic to write everything to file
         self._save_logic.save_data(data,
-                                   filepath,
+                                   filepath=filepath,
                                    parameters=parameters,
                                    filelabel=filelabel,
-                                   as_text=True,
-                                   plotfig=fig
-                                   )
+                                   plotfig=fig,
+                                   delimiter='\t')
         plt.close(fig)
         self.log.debug('Data saved to:\n{0}'.format(filepath))

--- a/logic/save_logic.py
+++ b/logic/save_logic.py
@@ -247,99 +247,78 @@ class SaveLogic(GenericLogic):
         """
         self._daily_loghandler.setLevel(level)
 
-    def save_data(self, data, filepath, parameters=None, filename=None, filelabel=None,
-                  timestamp=None, as_text=True, as_xml=False, precision='%.3e', delimiter='\t',
-                  plotfig=None):
-        """ General save routine for data.
+    def save_data(self, data, filepath=None, parameters=None, filename=None, filelabel=None,
+                  timestamp=None, filetype='text', fmt='%.15e', delimiter='\t', plotfig=None):
+        """
+        General save routine for data.
 
-        @param dict or OrderedDict data:
-                                  Any dictonary with a keyword of the data
-                                  and a corresponding list, where the data
-                                  are situated. E.g. like:
+        @param dictionary data: Dictionary containing the data to be saved. The keys should be
+                                strings containing the data header/description. The corresponding
+                                items are 1D or 2D arrays containing the data (list or
+                                numpy.ndarray). Example:
 
-                     data = {'Frequency (MHz)':[1,2,4,5,6]}
-                     data = {'Frequency':[1,2,4,5,6],'Counts':[234,894,743,423,235]}
-                     data = {'Frequency (MHz),Counts':[ [1,234],[2,894],...[30,504] ]}
+                                    data = {'Frequency (MHz)': [1,2,4,5,6]}
+                                    data = {'Frequency': [1, 2, 4], 'Counts': [234, 894, 743, 423]}
+                                    data = {'Frequency (MHz),Counts':[[1,234], [2,894],...[30,504]]}
 
-        @param string filepath: The path to the directory, where the data
-                                  will be saved.
-                                  If filepath is corrupt, the saving routine
-                                  will retrieve the basic filepath for the
-                                  data from the inherited base module
-                                  'get_data_dir' and saves the data in the
-                                  directory .../UNSPECIFIED_<module_name>/
-        @param dict or OrderedDict parameters:
-                                  optional, a dictionary
-                                  with all parameters you want to pass to
-                                  the saving routine.
-        @parem string filename: optional, if you really want to fix an own
-                                filename. BUT THIS IS NOT RECOMMENDED! If
-                                passed the whole file will have the name
+        @param string filepath: optional, the path to the directory, where the data will be saved.
+                                If the specified path does not exist yet, the saving routine will
+                                try to create it.
+                                If no path is passed (default filepath=None) the saving routine will
+                                create a directory by the name of the calling module inside the
+                                daily data directory.
+                                If no calling module can be inferred and/or the requested path can
+                                not be created the data will be saved in a subfolder of the daily
+                                data directory called UNSPECIFIED
+        @param dictionary parameters: optional, a dictionary with all parameters you want to save in
+                                      the header of the created file.
+        @parem string filename: optional, if you really want to fix your own filename. If passed,
+                                the whole file will have the name
 
                                     <filename>
 
-                                If nothing is specified the save logic will
-                                generate a filename either based on the
-                                class, from which this method was called,
-                                or it will use the passed filelabel if that
-                                is speficied.
-                                Keep in mind that you have also to specify
-                                the ending of the filename!
-        @parem string filelabel: optional, if filelabel is set and no
-                                 filename was specified, the savelogic will
-                                 create a name which looks like
+                                If nothing is specified the save logic will generate a filename
+                                either based on the module name from which this method was called,
+                                or it will use the passed filelabel if that is speficied.
+                                You also need to specify the ending of the filename!
+        @parem string filelabel: optional, if filelabel is set and no filename was specified, the
+                                 savelogic will create a name which looks like
 
                                      YYYY-MM-DD_HHh-MMm-SSs_<filelabel>.dat
 
-                                The timestamp will be created at runtime if
-                                no user defined timestamp was passed.
-        @param datetime timestamp: optional, a datetime.datetime object,
-                                   which saves the timestamp in a general
-                                   way. Create a datetime.datetime.now()
-                                   object from the module datetime if you
-                                   want to fix the timestamp for the
-                                   filename. The filename will like in the
-                                   description of the filelabel parameter.
-                                   Be careful if you pass a filename and a
-                                   timestamp, because then the timestamp
-                                   will be not considered.
-        @param bool as_text: specify how the saved data are saved to file.
-        @param bool as_xml: specify how the saved data are saved to file.
-
-        @param int precision: optional, specifies the number of digits
-                              after the comma for the saving precision. All
-                              number, which follows afterwards are cut off.
-                              A c-like format should be used.
-                              For 'precision=3' a number like
-                                   '323.423842' is saved as '323.423'.
-                                   Default is precision = 3.
-
-        @param string delimiter: optional, insert here the delimiter, like
-                                 \n for new line,  \t for tab, , for a
-                                 comma, ect.
-
-        This method should be called from the modules and it will call all
-        the needed methods for the saving routine. This module guarentees
-        that if the passing of the data is correct, the data are saved
-        always.
+                                 The timestamp will be created at runtime if no user defined
+                                 timestamp was passed.
+        @param datetime timestamp: optional, a datetime.datetime object. You can create this object
+                                   with datetime.datetime.now() in the calling module if you want to
+                                   fix the timestamp for the filename. Be careful when passing a
+                                   filename and a timestamp, because then the timestamp will be
+                                   ignored.
+        @param string filetype: optional, the file format the data should be saved in. Valid inputs
+                                are 'text', 'xml' and 'npz'. Default is 'text'.
+        @param string fmt: optional, format specifier for saved data. See python documentation
+                              for "Format Specification Mini-Language". If you want for example save
+                              a float in scientific notation with 6 decimals this would look like
+                              '%.6e'. For saving integers you could use '%d', '%s' for strings.
+                              The default is '%.15e'.
+        @param string delimiter: optional, insert here the delimiter, like '\n' for new line, '\t'
+                                 for tab, ',' for a comma ect.
 
         1D data
         =======
-        1D data should be passed in a dictionary where the data trace
-        should be assigned to one identifier like
+        1D data should be passed in a dictionary where the data trace should be assigned to one
+        identifier like
 
             {'<identifier>':[list of values]}
             {'Numbers of counts':[1.4, 4.2, 5, 2.0, 5.9 , ... , 9.5, 6.4]}
 
         You can also pass as much 1D arrays as you want:
+
             {'Frequency (MHz)':list1, 'signal':list2, 'correlations': list3, ...}
-
-
 
         2D data
         =======
-        2D data should be passed in a dictionary where the matrix like data
-        should be assigned to one identifier like
+        2D data should be passed in a dictionary where the matrix like data should be assigned to
+        one identifier like
 
             {'<identifier>':[[1,2,3],[4,5,6],[7,8,9]]}
 
@@ -349,21 +328,32 @@ class SaveLogic(GenericLogic):
             4   5   6
             7   8   9
 
-        3-X data
+        3D-ND data
         ========
-        There is no specific implementation to save 3D or higher dimension
-        data arrays. If you split the N-dimensional data in N one
-        dimensional data traces, which have a length of M (see last example
-        in 1D data) then the savelogic will handle them. If the save logic
-        cannot identify the passed data as 1D or 2D data, the data will be
-        saved in a raw fashion.
-
+        There is no generic style to save 3D or higher dimension data arrays. If you split the
+        N-dimensional data in N one dimensional data traces by flattening them for example, the
+        savelogic will handle them. If you are still trying to pass multidimensional (N>2) data, it
+        will get saved as a binary numpy .npz-file.
 
         YOU ARE RESPONSIBLE FOR THE IDENTIFIER! DO NOT FORGET THE UNITS FOR THE
         SAVED TIME TRACE/MATRIX.
         """
+        # Create timestamp if none is present
+        if timestamp is None:
+            timestamp = datetime.datetime.now()
+
+        # Try to cast data array into numpy.ndarray if it is not already one
+        for keyname in data:
+            if not isinstance(data[keyname], np.ndarray):
+                try:
+                    data[keyname] = np.array(data[keyname])
+                except:
+                    self.log.error('Casting data array of type "{0}" into numpy.ndarray failed. '
+                                   'Could not save data.'.format(type(data[keyname])))
+                    return -1
+
+        # try to trace back the functioncall to the class which was calling it.
         try:
-            # try to trace back the functioncall to the class which was calling it.
             frm = inspect.stack()[1]
             # this will get the object, which called the save_data function.
             mod = inspect.getmodule(frm[0])
@@ -372,66 +362,69 @@ class SaveLogic(GenericLogic):
         except:
             # Sometimes it is not possible to get the object which called the save_data function
             # (such as when calling this from the console).
-            module_name = 'NaN'
+            module_name = 'UNSPECIFIED'
 
-        # check whether the given directory path does exist. If not, the
-        # file will be saved anyway in the unspecified directory.
-        if not os.path.exists(filepath):
-            filepath = os.path.join(self.get_daily_directory(), 'UNSPECIFIED_' + str(module_name))
-            if not os.path.exists(filepath):
-                os.mkdir(filepath)
-            self.log.warning('No Module name specified! Please correct this! Data are saved in the '
-                             '\'UNSPECIFIED_<module_name>\' folder.')
+        # determine proper file path
+        if filepath is None:
+            filepath = self.get_path_for_module(module_name)
+        elif not os.path.exists(filepath):
+            os.makedirs(filepath)
+            self.log.info('Custom filepath does not exist. Created directory "{0}"'
+                          ''.format(filepath))
 
-        # Try to cast data array into numpy ndarray if it is not already one
-        for key in data:
-            if not isinstance(data[key], np.ndarray):
-                try:
-                    data[key] = np.array(data[key])
-                except:
-                    self.log.error('Casting data array of type "{0}" into numpy.ndarray failed. '
-                                   'Could not save data.'.format(type(data[key])))
+        # create filelabel if none has been passed
+        if filelabel is None:
+            filelabel = module_name
+        if self.active_poi_name != '':
+            filelabel = self.active_poi_name.replace(' ', '_') + '_' + filelabel
 
-        # Produce a filename tag from the active POI name
-        if self.active_poi_name == '':
-            poi_tag = ''
-        else:
-            poi_tag = '_' + self.active_poi_name.replace(" ", "_")
-
-        # Create timestamp if none is present
-        if timestamp is None:
-            timestamp = datetime.datetime.now()
-
-        # create a unique name for the file, if no name was passed:
+        # determine proper unique filename to save if none has been passed
         if filename is None:
-            # use the filelabel if that is specified:
-            if filelabel is None:
-                filename = timestamp.strftime('%Y%m%d-%H%M-%S' + poi_tag + '_' + module_name + '.dat')
-            else:
-                filename = timestamp.strftime('%Y%m%d-%H%M-%S' + poi_tag + '_' + filelabel + '.dat')
+            filename = timestamp.strftime('%Y%m%d-%H%M-%S' + '_' + filelabel + '.dat')
 
         # Create header string for the file
-        header = 'Saved Data from the class {0} on {1}.\n'.format(module_name,
-                                                                  time.strftime('%d.%m.%Y at %Hh%Mm%Ss'))
-        header = header + '\nParameters:\n===========\n\n'
+        header = 'Saved Data from the class {0} on {1}.\n' \
+                 ''.format(module_name, timestamp.strftime('%d.%m.%Y at %Hh%Mm%Ss'))
+        header += '\nParameters:\n===========\n\n'
         # Include the active POI name (if not empty) as a parameter in the header
         if self.active_poi_name != '':
-            header = header + 'Measured at POI: {0}\n'.format(self.active_poi_name)
-        # add the paramters if specified:
+            header += 'Measured at POI: {0}\n'.format(self.active_poi_name)
+        # add the parameters if specified:
         if parameters is not None:
             # check whether the format for the parameters have a dict type:
             if isinstance(parameters, dict):
                 for entry, param in parameters.items():
                     if isinstance(param, float):
-                        header = header + ('{0}:{1}{2' + ':.16e}\n').format(entry, delimiter, param)
+                        header += '{0}: {1:.16e}\n'.format(entry, param)
                     else:
-                        header = header + '{0}:{1}{2}\n'.format(entry, delimiter, param)
+                        header += '{0}: {1}\n'.format(entry, param)
             # make a hardcore string conversion and try to save the parameters directly:
             else:
                 self.log.error('The parameters are not passed as a dictionary! The SaveLogic will '
-                               'try to save the parameters directly.')
-                header = header + 'not specified parameters: {0}\n'.format(parameters)
-        header = header + '\nData:\n=====\n'
+                               'try to save the parameters nevertheless.')
+                header += 'not specified parameters: {0}\n'.format(parameters)
+        header += '\nData:\n=====\n'
+
+        # Reorganise data arrays if necessary and save them. Also check if arrays have equal length.
+        found_1d = False
+        found_2d = False
+        found_xd = False
+        unequal_length = False
+        for keyname in data:
+            if data[keyname].ndim == 1:
+                found_1d = True
+            elif data[keyname].ndim == 2:
+                found_2d = True
+            elif data[keyname].ndim > 2:
+                found_xd = True
+        if found_xd:
+            if filetype != 'npz':
+                self.log.error('Passed multidimensional (N>2) array(s). These can only be saved in '
+                               'binary .npz format. Filetype ignored.')
+            data['header'] = np.array(header)
+            np.savez(os.path.join(filepath, filename), **data)
+        elif found_1d and found_2d:
+            self.log.warning('Passed mixture of 1D and 2D arrays. Morph 2D into 1D arrays.')
 
         # write data to file
         if len(data) == 1:
@@ -716,33 +709,14 @@ class SaveLogic(GenericLogic):
 
         return current_dir
 
-    def get_path_for_module(self, module_name=None):
+    def get_path_for_module(self, module_name):
         """
         Method that creates a path for 'module_name' where data are stored.
 
-          @param string module_name: Specify the folder, which should be
-                                     created in the daily directory. The
-                                     module_name can be e.g. 'Confocal'.
-          @retun string: absolute path to the module name
-
-        This method should be called directly in the saving routine and NOT in
-        the init method of the specified module! This prevents to create empty
-        folders!
-
+        @param string module_name: Specify the folder, which should be created in the daily
+                                   directory. The module_name can be e.g. 'Confocal'.
+        @return string: absolute path to the module name
         """
-        if module_name is None:
-            self.log.warning('No Module name specified! Please correct this! '
-                    'Data is saved in the \'UNSPECIFIED_<module_name>\' '
-                    'folder.')
-
-            frm = inspect.stack()[1]    # try to trace back the functioncall to
-                                        # the class which was calling it.
-            mod = inspect.getmodule(frm[0]) # this will get the object, which
-                                            # called the save_data function.
-            module_name =  mod.__name__.split('.')[-1]  # that will extract the
-                                                        # name of the class.
-            module_name = 'UNSPECIFIED_' + module_name
-
         dir_path = os.path.join(self.get_daily_directory(), module_name)
 
         if not os.path.exists(dir_path):

--- a/logic/save_logic.py
+++ b/logic/save_logic.py
@@ -32,6 +32,7 @@ import numpy as np
 from logic.generic_logic import GenericLogic
 from core.util.mutex import Mutex
 from core.util import units
+import matplotlib.pyplot as plt
 # Use the PDF backend to attach metadata
 from matplotlib.backends.backend_pdf import PdfPages
 # Use Pillow (active fork from PIL) to attach metadata to PNG files
@@ -339,6 +340,7 @@ class SaveLogic(GenericLogic):
         YOU ARE RESPONSIBLE FOR THE IDENTIFIER! DO NOT FORGET THE UNITS FOR THE SAVED TIME
         TRACE/MATRIX.
         """
+        start_time = time.time()
         # Create timestamp if none is present
         if timestamp is None:
             timestamp = datetime.datetime.now()
@@ -558,8 +560,11 @@ class SaveLogic(GenericLogic):
 
             # save the picture again, this time including the metadata
             png_image.save(fig_fname_image, "png", pnginfo=png_metadata)
-            #----------------------------------------------------------------------------------
 
+            # close matplotlib figure
+            plt.close(plotfig)
+            self.log.debug('Time needed to save data: {0:.2f}s'.format(time.time()-start_time))
+            #----------------------------------------------------------------------------------
 
     def save_array_as_text(self, data, filename, filepath='', fmt='%.15e', header='',
                            delimiter='\t', comments='#', append=False):

--- a/logic/save_logic.py
+++ b/logic/save_logic.py
@@ -26,6 +26,7 @@ import os
 import sys
 import inspect
 import time
+import datetime
 import numpy as np
 
 from logic.generic_logic import GenericLogic
@@ -397,21 +398,17 @@ class SaveLogic(GenericLogic):
         else:
             poi_tag = '_' + self.active_poi_name.replace(" ", "_")
 
+        # Create timestamp if none is present
+        if timestamp is None:
+            timestamp = datetime.datetime.now()
+
         # create a unique name for the file, if no name was passed:
         if filename is None:
-            # use the timestamp if that is specified:
-            if timestamp is not None:
-                # use the filelabel if that is specified:
-                if filelabel is None:
-                    filename = timestamp.strftime('%Y%m%d-%H%M-%S' + poi_tag + '_' + module_name + '.dat')
-                else:
-                    filename = timestamp.strftime('%Y%m%d-%H%M-%S' + poi_tag + '_' + filelabel + '.dat')
+            # use the filelabel if that is specified:
+            if filelabel is None:
+                filename = timestamp.strftime('%Y%m%d-%H%M-%S' + poi_tag + '_' + module_name + '.dat')
             else:
-                # use the filelabel if that is specified:
-                if filelabel is None:
-                    filename = time.strftime('%Y%m%d-%H%M-%S' + poi_tag + '_' + module_name + '.dat')
-                else:
-                    filename = time.strftime('%Y%m%d-%H%M-%S' + poi_tag + '_' + filelabel + '.dat')
+                filename = timestamp.strftime('%Y%m%d-%H%M-%S' + poi_tag + '_' + filelabel + '.dat')
 
         # Create header string for the file
         header = 'Saved Data from the class {0} on {1}.\n'.format(module_name,
@@ -516,7 +513,6 @@ class SaveLogic(GenericLogic):
                 # We can also set the file's metadata via the PdfPages object:
                 pdf_metadata = pdf.infodict()
                 for x in metadata:
-                    print(metadata[x])
                     pdf_metadata[x] = metadata[x]
 
             # determine the PNG-Filename and save the plain PNG

--- a/logic/singleshot_logic.py
+++ b/logic/singleshot_logic.py
@@ -482,7 +482,7 @@ class SingleShotLogic(GenericLogic):
         np.save(meta_path,meta_data_dict)
         for key in meta_data_dict:
             meta_data_dict[key] = [meta_data_dict[key]]
-        self._save_logic.save_data(meta_data_dict, filepath, filelabel='meta_data')
+        self._save_logic.save_data(meta_data_dict, filepath=filepath, filelabel='meta_data')
 
 
         return

--- a/logic/spectrum.py
+++ b/logic/spectrum.py
@@ -213,11 +213,8 @@ class SpectrumLogic(GenericLogic):
 
         # Save to file
         self._save_logic.save_data(data,
-                                   filepath,
+                                   filepath=filepath,
                                    parameters=parameters,
                                    filelabel=filelabel,
-                                   as_text=True,
-                                   plotfig=fig
-                                   )
-        plt.close(fig)
+                                   plotfig=fig)
         self.log.debug('Spectrum saved to:\n{0}'.format(filepath))

--- a/logic/wavemeter_logger_logic.py
+++ b/logic/wavemeter_logger_logic.py
@@ -434,9 +434,8 @@ class WavemeterLoggerLogic(GenericLogic):
 
         # prepare the data in a dict or in an OrderedDict:
         data = OrderedDict()
-        data = {'Wavelength (nm), Signal (counts/s)': np.array(
-                [self.histogram_axis, self.histogram]
-                ).transpose()}
+        data['Wavelength (nm)'] = np.array(self.histogram_axis)
+        data['Signal (counts/s)'] = np.array(self.histogram)
 
         # write the parameters:
         parameters = OrderedDict()
@@ -456,14 +455,14 @@ class WavemeterLoggerLogic(GenericLogic):
                                    filelabel=filelabel,
                                    timestamp=timestamp,
                                    as_text=True,
-                                   precision=':.6f'
+                                   precision='%.6e'
                                    )
 
         filelabel = 'wavemeter_log_wavelength'
 
         # prepare the data in a dict or in an OrderedDict:
         data = OrderedDict()
-        data = {'Time (s), Wavelength (nm)': self._wavelength_data}
+        data['Time (s), Wavelength (nm)'] = self._wavelength_data
         # write the parameters:
         parameters = OrderedDict()
         parameters['Acquisition Timing (ms)'] = self._logic_acquisition_timing
@@ -480,14 +479,14 @@ class WavemeterLoggerLogic(GenericLogic):
                                    filelabel=filelabel,
                                    timestamp=timestamp,
                                    as_text=True,
-                                   precision=':.6f'
+                                   precision='%.6e'
                                    )
 
         filelabel = 'wavemeter_log_counts'
 
         # prepare the data in a dict or in an OrderedDict:
         data = OrderedDict()
-        data = {'Time (s),Signal (counts/s)': self._counter_logic._data_to_save}
+        data['Time (s),Signal (counts/s)'] = self._counter_logic._data_to_save
 
         # write the parameters:
         parameters = OrderedDict()
@@ -504,7 +503,7 @@ class WavemeterLoggerLogic(GenericLogic):
                                    filelabel=filelabel,
                                    timestamp=timestamp,
                                    as_text=True,
-                                   precision=':.6f'
+                                   precision='%.6e'
                                    )
 
         self.log.debug('Laser Scan saved to:\n{0}'.format(filepath))
@@ -513,7 +512,7 @@ class WavemeterLoggerLogic(GenericLogic):
 
         # prepare the data in a dict or in an OrderedDict:
         data = OrderedDict()
-        data = {'Measurement Time (s), Signal (counts/s), Interpolated Wavelength (nm)': np.array(self.counts_with_wavelength)}
+        data['Measurement Time (s), Signal (counts/s), Interpolated Wavelength (nm)'] = np.array(self.counts_with_wavelength)
 
         fig = self.draw_figure()
         # write the parameters:
@@ -532,7 +531,7 @@ class WavemeterLoggerLogic(GenericLogic):
                                    timestamp=timestamp,
                                    as_text=True,
                                    plotfig=fig,
-                                   precision=':.6f')
+                                   precision='%.6e')
         plt.close(fig)
         return 0
 

--- a/logic/wavemeter_logger_logic.py
+++ b/logic/wavemeter_logger_logic.py
@@ -450,13 +450,11 @@ class WavemeterLoggerLogic(GenericLogic):
                                                     )
 
         self._save_logic.save_data(data,
-                                   filepath,
+                                   filepath=filepath,
                                    parameters=parameters,
                                    filelabel=filelabel,
                                    timestamp=timestamp,
-                                   as_text=True,
-                                   precision='%.6e'
-                                   )
+                                   fmt='%.6e')
 
         filelabel = 'wavemeter_log_wavelength'
 
@@ -474,13 +472,11 @@ class WavemeterLoggerLogic(GenericLogic):
                                                     )
 
         self._save_logic.save_data(data,
-                                   filepath,
+                                   filepath=filepath,
                                    parameters=parameters,
                                    filelabel=filelabel,
                                    timestamp=timestamp,
-                                   as_text=True,
-                                   precision='%.6e'
-                                   )
+                                   fmt='%.6e')
 
         filelabel = 'wavemeter_log_counts'
 
@@ -498,13 +494,11 @@ class WavemeterLoggerLogic(GenericLogic):
         parameters['Smooth Window Length (# of events)'] = self._counter_logic._smooth_window_length
 
         self._save_logic.save_data(data,
-                                   filepath,
+                                   filepath=filepath,
                                    parameters=parameters,
                                    filelabel=filelabel,
                                    timestamp=timestamp,
-                                   as_text=True,
-                                   precision='%.6e'
-                                   )
+                                   fmt='%.6e')
 
         self.log.debug('Laser Scan saved to:\n{0}'.format(filepath))
 
@@ -525,13 +519,12 @@ class WavemeterLoggerLogic(GenericLogic):
                                                     )
 
         self._save_logic.save_data(data,
-                                   filepath,
+                                   filepath=filepath,
                                    parameters=parameters,
                                    filelabel=filelabel,
                                    timestamp=timestamp,
-                                   as_text=True,
                                    plotfig=fig,
-                                   precision='%.6e')
+                                   fmt='%.6e')
         plt.close(fig)
         return 0
 


### PR DESCRIPTION
Changed the savelogic from saving each entry of a list/array explicitly element-wise to something more efficient. Now the input arrays get converted to numpy.ndarrays and are saved by the numpy.savetxt.
Saving of the text files is now much faster (matplotlib plots still slow as hell (txt-saving: 0.2s, matplotlib: 6s)... but that's another story).
Also refined the definition of the save_data method to be more explicit with respect to what it expects from the logic programmer. You can now either pass (multiple) 1D arrays or a single 2D array (most efficient) but no mixture of both. Unequal 1D array length is handled in that way that the shorter arrays will be padded with "nan". This can lead to problems when using integer type arrays since for this type "nan" is not defined.
Tried to adapt all measurement logics to the changes and so far encountered no problems. Please test and merge.