### PR TITLE
Use Swabian Instruments TimeTagger as a slow counter

### DIFF
--- a/hardware/timetagger_counter.py
+++ b/hardware/timetagger_counter.py
@@ -20,12 +20,14 @@ Copyright (c) the Qudi Developers. See the COPYRIGHT.txt file at the
 top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi/>
 """
 
-from TimeTagger import createTimeTagger, Counter
+import TimeTagger as tt
 import time
+import numpy as np
 
 from core.base import Base
 from interface.slow_counter_interface import SlowCounterInterface
-
+from interface.slow_counter_interface import SlowCounterConstraints
+from interface.slow_counter_interface import CountingMode
 
 class TimeTaggerCounter(Base, SlowCounterInterface):
 
@@ -36,7 +38,7 @@ class TimeTaggerCounter(Base, SlowCounterInterface):
 
 
     def on_activate(self, e=None):
-        """ Starts up the NI Card at activation.
+        """ Start up TimeTagger interface
 
         @param object e: Event class object from Fysom.
                          An object created by the state machine module Fysom,
@@ -47,21 +49,44 @@ class TimeTaggerCounter(Base, SlowCounterInterface):
                          had happened.
         """
 
-        self._tagger = createTimeTagger()
+        self._tagger = tt.createTimeTagger()
 
-        self._count_frequency = 10  # Hz
+        self._count_frequency = 50  # Hz
 
         config = self.getConfiguration()
 
-        if 'photon_source' in config.keys():
-            self._photon_source = config['photon_source']
+        if 'timetagger_channel_apd_0' in config.keys():
+            self._channel_apd_0 = config['timetagger_channel_apd_0']
         else:
-            self.log.error('No parameter "photon_source" configured.\n'
-                    'Assign to that parameter an appropriated channel '
-                    'from your NI Card!')
+            self.log.error('No parameter "timetagger_channel_apd_0" configured.\n')
+
+        if 'timetagger_channel_apd_1' in config.keys():
+            self._channel_apd_1 = config['timetagger_channel_apd_1']
+        else:
+            self._channel_apd_1 = None
+
+        if 'timetagger_sum_channels' in config.keys():
+            self._sum_channels = config['timetagger_sum_channels']
+        else:
+            self.log.warning('No indication whether or not to sum apd channels for timetagger. Assuming false.')
+            self._sum_channels = False
+
+        if self._sum_channels and ('timetagger_channel_apd_1' in config.keys()):
+            self.log.error('Cannot sum channels when only one apd channel given')
+
+        ## self._mode can take 3 values:
+        # 0: single channel, no summing
+        # 1: single channel, summed over apd_0 and apd_1
+        # 2: dual channel for apd_0 and apd_1
+        if self._sum_channels:
+            self._mode = 1
+        elif self._channel_apd_1 is None:
+            self._mode = 0
+        else:
+            self._mode = 2
 
     def on_deactivate(self, e=None):
-        """ Shut down the NI card.
+        """ Shut down the TimeTagger.
 
         @param object e: Event class object from Fysom. A more detailed
                          explanation can be found in method activation.
@@ -70,7 +95,7 @@ class TimeTaggerCounter(Base, SlowCounterInterface):
         pass
 
     def set_up_clock(self, clock_frequency=None, clock_channel=None):
-        """ Configures the hardware clock of the NiDAQ card to give the timing.
+        """ Configures the hardware clock of the TimeTagger for timing
 
         @param float clock_frequency: if defined, this sets the frequency of
                                       the clock
@@ -104,30 +129,63 @@ class TimeTaggerCounter(Base, SlowCounterInterface):
 
         @return int: error code (0:OK, -1:error)
         """
-        self.counter = Counter(
-            self._tagger,
-            channels=[self._photon_source],
-            binwidth=int((1/self._count_frequency)*1e12),
-            n_values=1)
+
+        # currently, parameters passed to this function are ignored -- the channels used and clock frequency are
+        # set at startup
+        if self._mode == 1:
+            channel_combined = tt.Combiner(self._tagger, channels = [self._channel_apd_0, self._channel_apd_1])
+            self._channel_apd = channel_combined.getChannel()
+
+            self.counter = tt.Counter(
+                self._tagger,
+                channels=[self._channel_apd],
+                binwidth=int((1 / self._count_frequency) * 1e12),
+                n_values=1
+            )
+        elif self._mode == 2:
+            self.counter0 = tt.Counter(
+                self._tagger,
+                channels=[self._channel_apd_0],
+                binwidth=int((1 / self._count_frequency) * 1e12),
+                n_values=1
+            )
+
+            self.counter1 = tt.Counter(
+                self._tagger,
+                channels=[self._channel_apd_1],
+                binwidth=int((1 / self._count_frequency) * 1e12),
+                n_values=1
+            )
+        else:
+            self._channel_apd = self._channel_apd_0
+            self.counter = tt.Counter(
+                self._tagger,
+                channels=[self._channel_apd],
+                binwidth=int((1 / self._count_frequency) * 1e12),
+                n_values=1
+            )
+
         self.log.info('set up counter with {0}'.format(self._count_frequency))
         return 0
 
     def get_counter_channels(self):
-        """ Return one channel for now. """
-        return ['Ctr0']
+        if self._mode < 2:
+            return self._channel_apd
+        else:
+            return [self._channel_apd_0, self._channel_apd_1]
 
     def get_constraints(self):
-        """ Get hardware limits of NI device.
+        """ Get hardware limits the device
 
         @return SlowCounterConstraints: constraints class for slow counter
 
         FIXME: ask hardware for limits when module is loaded
         """
         constraints = SlowCounterConstraints()
-        constraints.max_detectors = 1
+        constraints.max_detectors = 2
         constraints.min_count_frequency = 1e-3
         constraints.max_count_frequency = 10e9
-        conetraints.counting_mode = [CountingMode.CONTINUOUS]
+        constraints.counting_mode = [CountingMode.CONTINUOUS]
         return constraints
 
     def get_counter(self, samples=None):
@@ -139,13 +197,18 @@ class TimeTaggerCounter(Base, SlowCounterInterface):
         """
 
         time.sleep(2 / self._count_frequency)
-        return [self.counter.getData()]
+        if self._mode < 2:
+            return self.counter.getData() * self._count_frequency
+        else:
+            return np.array([self.counter0.getData() * self._count_frequency,
+                             self.counter1.getData() * self._count_frequency])
 
     def close_counter(self):
         """ Closes the counter and cleans up afterwards.
 
         @return int: error code (0:OK, -1:error)
         """
+        self._tagger.reset()
         return 0
 
     def close_clock(self):


### PR DESCRIPTION
Update TimeTagger hardware module to current commercial Swabian Instruments version. Incompatible with original pi3 version -- can be spun out as a separate hardware module if required.