### PR TITLE
Fix error with import due to file move

### DIFF
--- a/hardware/swabian_instruments/pulse_streamer.py
+++ b/hardware/swabian_instruments/pulse_streamer.py
@@ -31,7 +31,7 @@ from collections import OrderedDict
 
 import grpc
 import os
-import hardware.fpga_pulser.pulse_streamer_pb2 as pulse_streamer_pb2
+import hardware.swabian_instruments.pulse_streamer_pb2 as pulse_streamer_pb2
 import dill
 
 class PulseStreamer(Base, PulserInterface):


### PR DESCRIPTION
Swabian Instruments pulse streamer import error due to file move