### PR TITLE
remove fysom event parameter from on_activate and on_deactivate

### DIFF
--- a/core/base.py
+++ b/core/base.py
@@ -69,8 +69,8 @@ class Base(QtCore.QObject, Fysom):
             callbacks = {}
 
         default_callbacks = {
-            'onactivate': self.on_activate,
-            'ondeactivate': self.on_deactivate
+            'onactivate': lambda e: self.on_activate(),
+            'ondeactivate': lambda e: self.on_deactivate()
             }
         default_callbacks.update(callbacks)
 
@@ -165,20 +165,17 @@ class Base(QtCore.QObject, Fysom):
             return False
         return True
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Method called when module is activated. If not overridden
             this method returns an error.
 
-        @param object e: Fysom state change descriptor
         """
         self.log.error('Please implement and specify the activation method '
                          'for {0}.'.format(self.__class__.__name__))
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Method called when module is deactivated. If not overridden
             this method returns an error.
-
-        @param object e: Fysom state change descriptor
         """
         self.log.error('Please implement and specify the deactivation '
                          'method {0}.'.format(self.__class__.__name__))

--- a/core/mapper.py
+++ b/core/mapper.py
@@ -97,7 +97,7 @@ class Mapper():
     In the on_activate method of the GUI module, we define the following
     mapping between the line edit and the logic property:
     ```
-    def on_activate(self, e):
+    def on_activate(self):
         self.mapper = Mapper()
         self.mapper.add_mapping(self.lineedit, self.logic_module,
                 'some_value', 'some_value_changed')
@@ -108,7 +108,7 @@ class Mapper():
 
     If the GUI module is deactivated we should delete all mappings:
     ```
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         self.mapper.clear_mapping()
     ```
     """

--- a/documentation/statemachines.md
+++ b/documentation/statemachines.md
@@ -38,6 +38,25 @@ unexpected behaviour!
 * runlock:
   * locked -> running
 
+## Default event handler and fysom event objects
+
+In a module the default event handler called after the state has transitioned to activate or deactivate are the methods called `on_activate` and `on_deactivate`. Both methods don't take any parameters as default. For debugging purposes it is sometimes useful to access to the fysom event object. This is possible by defining new callback methods in the constructor:
+
+```python
+def __init__(self, **kwargs):
+    super().__init__(
+        self,
+        callbacks={'onactivate': self.on_activate}, 
+        **kwargs)
+```
+
+and adding the fysom event object as parameter to the event handler:
+
+```python
+def on_activate(self, e):
+    do_something_with_fysom_event_object(e)
+```
+
 ## Interruptable task state machine
 
 

--- a/gui/automation/automationgui.py
+++ b/gui/automation/automationgui.py
@@ -37,16 +37,8 @@ class AutomationGui(GUIBase):
     sigPauseTaskFromList = QtCore.Signal(object)
     sigStopTaskFromList = QtCore.Signal(object)
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """Create all UI objects and show the window.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self._mw = AutomationMainWindow()
         self.restoreWindowPos(self._mw)
@@ -67,11 +59,8 @@ class AutomationGui(GUIBase):
         """
         self._mw.show()
 
-    def on_deactivate(self, e=None):
+    def on_deactivate(self):
         """ Hide window and stop ipython console.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self.saveWindowPos(self._mw)
         self._mw.close()

--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -165,7 +165,7 @@ class ConfocalSettingDialog(QtWidgets.QDialog):
 
 class OptimizerSettingDialog(QtWidgets.QDialog):
     """ User configurable settings for the optimizer embedded in cofocal gui"""
-    
+
     def __init__(self):
         # Get the path to the *.ui file
         this_dir = os.path.dirname(__file__)
@@ -209,16 +209,8 @@ class ConfocalGui(GUIBase):
         self.slider_small_step = 10e-9         # initial value in meter
         self.slider_big_step = 100e-9          # initial value in meter
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Initializes all needed UI files and establishes the connectors.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
 
         This method executes the all the inits for the differnt GUIs and passes
         the event argument from fysom to the methods.
@@ -231,15 +223,12 @@ class ConfocalGui(GUIBase):
 
         self._hardware_state = True
 
-        self.initMainUI(e)      # initialize the main GUI
-        self.initSettingsUI(e)  # initialize the settings GUI
-        self.initOptimizerSettingsUI(e)  # initialize the optimizer settings GUI
+        self.initMainUI()      # initialize the main GUI
+        self.initSettingsUI()  # initialize the settings GUI
+        self.initOptimizerSettingsUI()  # initialize the optimizer settings GUI
 
-    def initMainUI(self, e=None):
+    def initMainUI(self):
         """ Definition, configuration and initialisation of the confocal GUI.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
 
         This init connects all the graphic modules, which were created in the
         *.ui file and configures the event handling between the modules.
@@ -711,11 +700,8 @@ class ConfocalGui(GUIBase):
 
         self.show()
 
-    def initSettingsUI(self, e=None):
+    def initSettingsUI(self):
         """ Definition, configuration and initialisation of the settings GUI.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
 
         This init connects all the graphic modules, which were created in the
         *.ui file and configures the event handling between the modules.
@@ -732,11 +718,8 @@ class ConfocalGui(GUIBase):
         # write the configuration to the settings window of the GUI.
         self.keep_former_settings()
 
-    def initOptimizerSettingsUI(self, e=None):
+    def initOptimizerSettingsUI(self):
         """ Definition, configuration and initialisation of the optimizer settings GUI.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
 
         This init connects all the graphic modules, which were created in the
         *.ui file and configures the event handling between the modules.
@@ -761,11 +744,8 @@ class ConfocalGui(GUIBase):
         # write the configuration to the settings window of the GUI.
         self.keep_former_optimizer_settings()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Reverse steps of activation
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
 
         @return int: error code (0:OK, -1:error)
         """
@@ -1488,7 +1468,7 @@ class ConfocalGui(GUIBase):
 
     def update_xy_channel(self, index):
         """ The displayed channel for the XY image was changed, refresh the displayed image.
-            
+
             @param index int: index of selected channel item in combo box
         """
         self.xy_channel = int(self._mw.xy_channel_ComboBox.itemData(index, QtCore.Qt.UserRole))
@@ -1496,7 +1476,7 @@ class ConfocalGui(GUIBase):
 
     def update_depth_channel(self, index):
         """ The displayed channel for the X-depth image was changed, refresh the displayed image.
-            
+
             @param index int: index of selected channel item in combo box
         """
         self.depth_channel = int(self._mw.depth_channel_ComboBox.itemData(index, QtCore.Qt.UserRole))

--- a/gui/counter/countergui.py
+++ b/gui/counter/countergui.py
@@ -69,16 +69,8 @@ class CounterGui(GUIBase):
         for key in config.keys():
             self.log.info('{0}: {1}'.format(key, config[key]))
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Definition and initialisation of the GUI.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         self._counting_logic = self.get_connector('counterlogic1')
@@ -180,12 +172,9 @@ class CounterGui(GUIBase):
         self._mw.raise_()
         return
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         # FIXME: !
         """ Deactivate the module
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         # disconnect signals
         self._mw.start_counter_Action.triggered.disconnect()

--- a/gui/gated_counter/gated_counter_gui.py
+++ b/gui/gated_counter/gated_counter_gui.py
@@ -160,11 +160,8 @@ class GatedCounterGui(GUIBase):
         self._mw.fit_PushButton.clicked.connect(self.fit_clicked)
 
 
-    def on_deactivate(self, e=None):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self._mw.close()
 

--- a/gui/laser/laser.py
+++ b/gui/laser/laser.py
@@ -78,16 +78,8 @@ class LaserGUI(GUIBase):
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Definition and initialisation of the GUI plus staring the measurement.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self._laser_logic = self.get_connector('laserlogic')
 
@@ -148,11 +140,8 @@ class LaserGUI(GUIBase):
         self._mw.setValueDoubleSpinBox.editingFinished.connect(self.updateFromSpinBox)
         self._laser_logic.sigUpdate.connect(self.updateGui)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate the module properly.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self._mw.close()
 
@@ -227,7 +216,7 @@ class LaserGUI(GUIBase):
             self.sigCtrlMode.emit(ControlMode.CURRENT)
         else:
             self.log.error('How did you mess up the radio button group?')
-        
+
     @QtCore.Slot()
     def updateButtonsEnabled(self):
         """ Logic told us to update our button states, so set the buttons accordingly. """

--- a/gui/laserscanner/laserscangui.py
+++ b/gui/laserscanner/laserscangui.py
@@ -65,16 +65,8 @@ class LaserScanningGui(GUIBase):
             self.log.info('{0}: {1}'.format(key,config[key]))
 
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Definition and initialisation of the GUI.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         self._scanning_logic = self.get_connector('laserscanninglogic1')
@@ -158,11 +150,8 @@ class LaserScanningGui(GUIBase):
 
         self._scanning_logic.sig_data_updated.connect(self.updateData)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate the module properly.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self._mw.close()
 

--- a/gui/laserscanner/laserscannergui.py
+++ b/gui/laserscanner/laserscannergui.py
@@ -64,21 +64,16 @@ class VoltScanGui(GUIBase):
         for key in config.keys():
             self.log.info('{0}: {1}'.format(key,config[key]))
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Reverse steps of activation
-
-        @param e: error code
 
         @return int: error code (0:OK, -1:error)
         """
         self._mw.close()
         return 0
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Definition, configuration and initialisation of the ODMR GUI.
-
-          @param class e: event class from Fysom
-
 
         This init connects all the graphic modules, which were created in the
         *.ui file and configures the event handling between the modules.

--- a/gui/magnet/magnet_gui.py
+++ b/gui/magnet/magnet_gui.py
@@ -179,16 +179,8 @@ class MagnetGui(GUIBase):
         self._continue_2d_fluorescence_alignment = False
 
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Definition and initialisation of the GUI.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self._magnet_logic = self.get_connector('magnetlogic1')
         self._save_logic = self.get_connector('savelogic')
@@ -241,7 +233,7 @@ class MagnetGui(GUIBase):
         # written by someone who has no clue what he is doing). Eventually with
         # that you have the possibility of stopping an ongoing movement!
         self._interactive_mode = True
-        self._activate_magnet_settings(e)
+        self._activate_magnet_settings()
 
         # connect the actions of the toolbar:
         self._mw.magnet_settings_Action.triggered.connect(self.open_magnet_settings)
@@ -491,11 +483,8 @@ class MagnetGui(GUIBase):
         return 0
 
 
-    def _activate_magnet_settings(self, e):
+    def _activate_magnet_settings(self):
         """ Activate magnet settings.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self._ms = MagnetSettingsWindow()
         # default config is normal_mode
@@ -529,11 +518,8 @@ class MagnetGui(GUIBase):
 
 
 
-    def on_deactivate(self, e=None):
+    def on_deactivate(self):
         """ Deactivate the module properly.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self._statusVariables['measurement_type'] = self.measurement_type
         self._statusVariables['alignment_2d_cb_GraphicsView_text'] =  self._mw.alignment_2d_cb_GraphicsView.plotItem.axes['right']['item'].labelText

--- a/gui/manager/managergui.py
+++ b/gui/manager/managergui.py
@@ -79,16 +79,8 @@ class ManagerGui(GUIBase):
         self.modlist = list()
         self.modules = set()
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Activation method called on change to active state.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look
-                         in the Base Class). This object contains the passed
-                         event, the state before the event happened and the
-                         destination of the state which should be reached
-                         after the event had happened.
 
         This method creates the Manager main window.
         """
@@ -176,11 +168,8 @@ class ManagerGui(GUIBase):
         self._mw.threadDockWidget.hide()
         self._mw.show()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """Close window and remove connections.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method activation.
         """
         self.stopIPythonWidget()
         self.stopIPython()

--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -94,16 +94,8 @@ class ODMRGui(GUIBase):
         for key in config.keys():
             self.log.info('{0}: {1}'.format(key, config[key]))
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Definition, configuration and initialisation of the ODMR GUI.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
 
         This init connects all the graphic modules, which were created in the
         *.ui file and configures the event handling between the modules.
@@ -321,11 +313,8 @@ class ODMRGui(GUIBase):
         # Show the Main ODMR GUI:
         self._mw.show()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Reverse steps of activation
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
 
         @return int: error code (0:OK, -1:error)
         """

--- a/gui/pidgui/pidgui.py
+++ b/gui/pidgui/pidgui.py
@@ -65,16 +65,9 @@ class PIDGui(GUIBase):
         for key in config.keys():
             self.log.info('{0}: {1}'.format(key,config[key]))
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Definition and initialisation of the GUI plus staring the measurement.
 
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self._pid_logic = self.get_connector('pidlogic')
 
@@ -192,11 +185,8 @@ class PIDGui(GUIBase):
         self._mw.activateWindow()
         self._mw.raise_()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate the module properly.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         # FIXME: !
         self._mw.close()

--- a/gui/poimanager/poimangui.py
+++ b/gui/poimanager/poimangui.py
@@ -235,19 +235,10 @@ class PoiManagerGui(GUIBase):
         for key in config.keys():
             self.log.info('{0}: {1}'.format(key, config[key]))
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Initializes the overall GUI, and establishes the connectors.
 
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
-
-        This method executes the init methods for each of the GUIs and passes
-        the event argument from fysom to these methods.
+        This method executes the init methods for each of the GUIs.
         """
 
         # Connectors
@@ -257,8 +248,8 @@ class PoiManagerGui(GUIBase):
         self.log.debug("Confocal logic is {0}".format(self._confocal_logic))
 
         # Initializing the GUIs
-        self.initMainUI(e)
-        self.initReorientRoiDialogUI(e)
+        self.initMainUI()
+        self.initReorientRoiDialogUI()
 
         # There could be POIs created in the logic already, so update lists and map
         self.populate_poi_list()
@@ -287,12 +278,8 @@ class PoiManagerGui(GUIBase):
                 mouse_point.x()* 1e-6 - cur_poi_pos[0],
                 mouse_point.y()* 1e-6 - cur_poi_pos[1]))
 
-    def initMainUI(self, e=None):
+    def initMainUI(self):
         """ Definition, configuration and initialisation of the POI Manager GUI.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
-
         This init connects all the graphic modules, which were created in the
         *.ui file and configures the event handling between the modules.
         """
@@ -495,11 +482,8 @@ class PoiManagerGui(GUIBase):
 
         self._mw.show()
 
-    def initReorientRoiDialogUI(self, e):
+    def initReorientRoiDialogUI(self):
         """ Definition, configuration and initialization fo the Reorient ROI Dialog GUI.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
 
         This init connects all the graphic modules which were created in the
         *.ui file and configures event handling.
@@ -531,11 +515,8 @@ class PoiManagerGui(GUIBase):
         self._rrd.ref_c_y_pos_DoubleSpinBox.valueChanged.connect(self.reorientation_sanity_check)
         self._rrd.ref_c_z_pos_DoubleSpinBox.valueChanged.connect(self.reorientation_sanity_check)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self._mw.close()
 
@@ -782,7 +763,7 @@ class PoiManagerGui(GUIBase):
         # Set the new maximum for the progress bar
         self._mw.time_till_next_update_ProgressBar.setMaximum(new_track_period)
 
-        # If the tracker is not active, then set the value of the progress bar to the 
+        # If the tracker is not active, then set the value of the progress bar to the
         # new maximum
         if not self._mw.track_poi_Action.isChecked():
             self._mw.time_till_next_update_ProgressBar.setValue(new_track_period)

--- a/gui/pulsed/pulsed_extraction_external_gui.py
+++ b/gui/pulsed/pulsed_extraction_external_gui.py
@@ -77,16 +77,8 @@ class PulsedExtractionExternalGui(GUIBase):
             self.log.info('{0}: {1}'.format(key, config[key]))
 
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Definition and initialisation of the GUI.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         #####################
         # Configuring the dock widgets
@@ -137,12 +129,9 @@ class PulsedExtractionExternalGui(GUIBase):
         self._mw.activateWindow()
         self._mw.raise_()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         # FIXME: !
         """ Deactivate the module
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self._mw.close()
 

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -168,16 +168,8 @@ class PulsedMeasurementGui(GUIBase):
         for key in config.keys():
             self.log.info('{}: {}'.format(key,config[key]))
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Initialize, connect and configure the pulsed measurement GUI.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
 
         Establish general connectivity and activate the different tabs of the
         GUI.
@@ -199,32 +191,29 @@ class PulsedMeasurementGui(GUIBase):
         self._mw.tabWidget.addTab(self._pm, 'Predefined Methods')
 
         self.setup_toolbar()
-        self._activate_analysis_settings_ui(e)
-        self._activate_analysis_ui(e)
+        self._activate_analysis_settings_ui()
+        self._activate_analysis_ui()
         self.setup_extraction_ui()
 
-        self._activate_generator_settings_ui(e)
-        self._activate_pulse_generator_ui(e)
+        self._activate_generator_settings_ui()
+        self._activate_pulse_generator_ui()
 
         self.show()
 
         self._pa.ext_control_mw_freq_DoubleSpinBox.setMaximum(999999999999)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Undo the Definition, configuration and initialisation of the pulsed
             measurement GUI.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
 
         This deactivation disconnects all the graphic modules, which were
         connected in the initUI method.
         """
-        self._deactivate_analysis_settings_ui(e)
-        self._deactivate_analysis_ui(e)
+        self._deactivate_analysis_settings_ui()
+        self._deactivate_analysis_ui()
 
-        self._deactivate_generator_settings_ui(e)
-        self._deactivate_pulse_generator_ui(e)
+        self._deactivate_generator_settings_ui()
+        self._deactivate_pulse_generator_ui()
 
         self._mw.close()
 
@@ -237,12 +226,9 @@ class PulsedMeasurementGui(GUIBase):
     ###########################################################################
     ###   Methods related to Settings for the 'Pulse Generator' tab:        ###
     ###########################################################################
-    def _activate_generator_settings_ui(self, e):
+    def _activate_generator_settings_ui(self):
         """ Initialize, connect and configure the pulse generator settings to be displayed in the
         editor.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self._gs = GeneratorSettingsDialog()
         self._gs.accepted.connect(self.apply_generator_settings)
@@ -281,11 +267,8 @@ class PulsedMeasurementGui(GUIBase):
         self._create_function_config()
         return
 
-    def _deactivate_generator_settings_ui(self, e):
+    def _deactivate_generator_settings_ui(self):
         """ Disconnects the configuration of the Settings for the 'Pulse Generator' Tab.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self._statusVariables['predefined_methods_to_show'] = self._predefined_methods_to_show
         self._statusVariables['functions_to_show'] = self._functions_to_show
@@ -520,11 +503,8 @@ class PulsedMeasurementGui(GUIBase):
     ###########################################################################
     ###   Methods related to Tab 'Pulse Generator' in the Pulsed Window:    ###
     ###########################################################################
-    def _activate_pulse_generator_ui(self, e):
+    def _activate_pulse_generator_ui(self):
         """ Initialize, connect and configure the 'Pulse Generator' Tab.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         # connect signals of input widgets
         self._pg.gen_sample_freq_DSpinBox.editingFinished.connect(self.generator_settings_changed, QtCore.Qt.QueuedConnection)
@@ -585,11 +565,8 @@ class PulsedMeasurementGui(GUIBase):
         self._pulsed_master_logic.request_generator_init_values()
         return
 
-    def _deactivate_pulse_generator_ui(self, e):
+    def _deactivate_pulse_generator_ui(self):
         """ Disconnects the configuration for 'Pulse Generator Tab.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         # disconnect signals of input widgets
         self._pg.gen_sample_freq_DSpinBox.editingFinished.disconnect()
@@ -1132,11 +1109,8 @@ class PulsedMeasurementGui(GUIBase):
     ###        Methods related to Settings for the 'Analysis' Tab:          ###
     ###########################################################################
     #FIXME: Implement the setting for 'Analysis' tab.
-    def _activate_analysis_settings_ui(self, e):
+    def _activate_analysis_settings_ui(self):
         """ Initialize, connect and configure the Settings of 'Analysis' Tab.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self._as = AnalysisSettingDialog()
         self._as.accepted.connect(self.update_analysis_settings)
@@ -1163,11 +1137,8 @@ class PulsedMeasurementGui(GUIBase):
         self.update_analysis_settings()
         return
 
-    def _deactivate_analysis_settings_ui(self, e):
+    def _deactivate_analysis_settings_ui(self):
         """ Disconnects the configuration of the Settings for 'Analysis' Tab.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self._statusVariables['ana_param_x_axis_name_LineEdit'] = self._as.ana_param_x_axis_name_LineEdit.text()
         self._statusVariables['ana_param_x_axis_unit_LineEdit'] = self._as.ana_param_x_axis_unit_LineEdit.text()
@@ -1271,11 +1242,8 @@ class PulsedMeasurementGui(GUIBase):
         self._pe.laserpulses_PlotWidget.addItem(self.ref_end_line)
         self._pe.laserpulses_PlotWidget.setLabel('bottom', 'bins')
 
-    def _activate_analysis_ui(self, e):
+    def _activate_analysis_ui(self):
         """ Initialize, connect and configure the 'Analysis' Tab.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         if 'ana_param_errorbars_CheckBox' in self._statusVariables:
             self._pa.ana_param_errorbars_CheckBox.setChecked(self._statusVariables['ana_param_errorbars_CheckBox'])
@@ -1432,11 +1400,8 @@ class PulsedMeasurementGui(GUIBase):
         self._pulsed_master_logic.request_measurement_init_values()
         return
 
-    def _deactivate_analysis_ui(self, e):
+    def _deactivate_analysis_ui(self):
         """ Disconnects the configuration for 'Analysis' Tab.
-
-       @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self.measurement_run_stop_clicked(False)
 

--- a/gui/qdplotter/qdplottergui.py
+++ b/gui/qdplotter/qdplottergui.py
@@ -66,16 +66,8 @@ class QdplotterGui(GUIBase):
             self.log.info('{0}: {1}'.format(key, config[key]))
 
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Definition and initialisation of the GUI.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         self._qdplot_logic = self.get_connector('qdplotlogic1')
@@ -122,7 +114,7 @@ class QdplotterGui(GUIBase):
         self._mw.horizontal_units_lineEdit.editingFinished.connect(self.h_label_changed)
         self._mw.vertical_label_lineEdit.editingFinished.connect(self.v_label_changed)
         self._mw.vertical_units_lineEdit.editingFinished.connect(self.v_label_changed)
-        
+
         self._mw.fit_domain_to_data_PushButton.clicked.connect(self.fit_domain_to_data)
         self._mw.fit_range_to_data_PushButton.clicked.connect(self.fit_range_to_data)
 
@@ -141,12 +133,9 @@ class QdplotterGui(GUIBase):
         self._mw.activateWindow()
         self._mw.raise_()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         # FIXME: !
         """ Deactivate the module
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self._mw.close()
 

--- a/gui/simpledatagui/simpledatagui.py
+++ b/gui/simpledatagui/simpledatagui.py
@@ -63,16 +63,8 @@ class SimpleDataGui(GUIBase):
         for key in config.keys():
             self.log.info('{0}: {1}'.format(key,config[key]))
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Definition and initialisation of the GUI.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self._simple_logic = self.get_connector('simplelogic')
 
@@ -126,11 +118,8 @@ class SimpleDataGui(GUIBase):
         self._mw.activateWindow()
         self._mw.raise_()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate the module properly.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         # FIXME: !
         self._mw.close()

--- a/gui/spectrometer/spectrometergui.py
+++ b/gui/spectrometer/spectrometergui.py
@@ -59,16 +59,8 @@ class SpectrometerGui(GUIBase):
         for key in config.keys():
             self.log.info('{0}: {1}'.format(key, config[key]))
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Definition and initialisation of the GUI.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         self._spectrum_logic = self.get_connector('spectrumlogic1')
@@ -122,11 +114,8 @@ class SpectrometerGui(GUIBase):
 
         self._save_PNG = True
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self._mw.close()
 

--- a/gui/switcher/switchgui.py
+++ b/gui/switcher/switchgui.py
@@ -34,16 +34,8 @@ class SwitchGui(GUIBase):
     ## declare connectors
     _connectors = {'switchlogic': 'SwitchLogic'}
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """Create all UI objects and show the window.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self._mw = SwitchMainWindow()
         lsw =  self.get_connector('switchlogic')
@@ -66,11 +58,8 @@ class SwitchGui(GUIBase):
         """
         self._mw.show()
 
-    def on_deactivate(self, e=None):
+    def on_deactivate(self):
         """ Hide window and stop ipython console.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self.saveWindowPos(self._mw)
         self._mw.close()

--- a/gui/taskrunner/taskgui.py
+++ b/gui/taskrunner/taskgui.py
@@ -38,16 +38,8 @@ class TaskGui(GUIBase):
     sigPauseTaskFromList = QtCore.Signal(object)
     sigStopTaskFromList = QtCore.Signal(object)
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """Create all UI objects and show the window.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self._mw = TaskMainWindow()
         self.restoreWindowPos(self._mw)
@@ -68,11 +60,8 @@ class TaskGui(GUIBase):
         """
         self._mw.show()
 
-    def on_deactivate(self, e=None):
+    def on_deactivate(self):
         """ Hide window and stop ipython console.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self.saveWindowPos(self._mw)
         self._mw.close()

--- a/gui/testgui.py
+++ b/gui/testgui.py
@@ -43,9 +43,8 @@ class TestGui(GUIBase):
         if 'text' in config:
             self.buttonText = config['text']
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """This creates all the necessary UI elements.
-          @param object e: Fysom state change
         """
         self._mw = QtWidgets.QMainWindow()
         self._mw.setGeometry(300,300,500,100)
@@ -65,9 +64,8 @@ class TestGui(GUIBase):
         self._mw.setCentralWidget(self.cwdget)
         self._mw.show()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """
-          @param object e: Fysom state change
         """
         pass
 

--- a/gui/trayicon.py
+++ b/gui/trayicon.py
@@ -32,22 +32,16 @@ class TrayIcon(GUIBase):
     Right-clicking this icon will bring up a Quit button that will colse the whole application.
     """
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Set up tray icon UI .
-
-          @param e: Fysom state change
-
-            This method is automatically called by changing the Base state through activate().
         """
         self._tray = SystemTrayIcon()
         self._tray.show()
         self._tray.quitAction.triggered.connect(self._manager.quit)
         self._tray.managerAction.triggered.connect(lambda: self._manager.sigShowManager.emit())
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Remove all the stuff that we set up.
-
-          @param object e: Fysom state change notification
         """
         self._tray.hide()
         self._tray.quitAction.triggered.disconnect()

--- a/gui/wavemeterlogger/wavemeterloggui.py
+++ b/gui/wavemeterlogger/wavemeterloggui.py
@@ -70,16 +70,8 @@ class WavemeterLogGui(GUIBase):
         for key in config.keys():
             self.log.info('{0}: {1}'.format(key,config[key]))
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Definition and initialisation of the GUI.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         self._wm_logger_logic = self.get_connector('wavemeterloggerlogic1')
@@ -173,11 +165,8 @@ class WavemeterLogGui(GUIBase):
 
         self._wm_logger_logic.sig_data_updated.connect(self.updateData)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate the module properly.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method initUI.
         """
         self._mw.close()
 

--- a/hardware/CTC100_temperature.py
+++ b/hardware/CTC100_temperature.py
@@ -32,18 +32,14 @@ class CTC100(Base):
     _modclass = 'ctc100'
     _modtype = 'hardware'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate modeule
-
-            @param object e: fysom state transition information
         """
         config = self.getConfiguration()
         self.connect(config['interface'])
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate modeule
-
-            @param object e: fysom state transition information
         """
         self.disconnect()
 

--- a/hardware/awg/tektronix_awg5002c.py
+++ b/hardware/awg/tektronix_awg5002c.py
@@ -50,16 +50,8 @@ class AWG5002C(Base, PulserInterface):
         self._marker_byte_dict = { 0:b'\x00',1:b'\x01', 2:b'\x02', 3:b'\x03'}
         self.current_loaded_asset = ''
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         config = self.getConfiguration()
@@ -133,11 +125,8 @@ class AWG5002C(Base, PulserInterface):
         self.host_waveform_directory = self._get_dir_for_name('sampled_hardware_files')
 
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         self.connected = False
         self.soc.close()

--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -41,16 +41,8 @@ class AWG70K(Base, PulserInterface):
     _modclass = 'awg70k'
     _modtype = 'hardware'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         config = self.getConfiguration()
 
@@ -131,11 +123,8 @@ class AWG70K(Base, PulserInterface):
         self._init_loaded_asset()
         self.current_status = 0
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Required tasks to be performed during deactivation of the module.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in method activation.
         """
         # Closes the connection to the AWG
         try:

--- a/hardware/awg/tektronix_awg7122c.py
+++ b/hardware/awg/tektronix_awg7122c.py
@@ -112,16 +112,8 @@ class AWG7122C(Base, PulserInterface):
 
         self._marker_byte_dict = {0: b'\x00', 1: b'\x01', 2: b'\x02', 3: b'\x03'}
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         self.connected = True
@@ -150,11 +142,8 @@ class AWG7122C(Base, PulserInterface):
         #Set current directory on AWG
         self.tell('MMEMORY:CDIRECTORY "{0}"\n'.format(self.ftp_path+self.asset_directory))
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         self.connected = False
         self.soc.close()

--- a/hardware/confocal_scanner_dummy.py
+++ b/hardware/confocal_scanner_dummy.py
@@ -59,16 +59,8 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
         self._current_position = [0, 0, 0, 0][0:len(self.get_scanner_axes())]
         self._num_points = 500
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event
-                         the state before the event happens and the destination
-                         of the state which should be reached after the event
-                         has happen.
         """
 
         self._fit_logic = self.get_connector('fitlogic')
@@ -130,11 +122,8 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
         # offset
         self._points_z[:, 3] = 0
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate properly the confocal scanner dummy.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         self.reset_hardware()
 

--- a/hardware/edwards_vacuum_controller.py
+++ b/hardware/edwards_vacuum_controller.py
@@ -188,15 +188,13 @@ class EdwardsVacuumController(Base):
 
 
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate modeule
-
-            @param object e: fysom state transition information
         """
         config = self.getConfiguration()
         self.connect_tic(config['interface'])
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate modeule
 
             @param object e: fysom state transition information

--- a/hardware/fast_counter_dummy.py
+++ b/hardware/fast_counter_dummy.py
@@ -66,27 +66,16 @@ class FastCounterDummy(Base, FastCounterInterface):
                 'tools',
                 'FastComTec_demo_timetrace.asc')
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self.statusvar = 0
         self._binwidth = 1
         self._gate_length_bins = 8192
         return
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method activation.
         """
         self.statusvar = -1
         return

--- a/hardware/fastcomtec/fastcomtecmcs6.py
+++ b/hardware/fastcomtec/fastcomtecmcs6.py
@@ -155,27 +155,16 @@ class FastComtec(Base, FastCounterInterface):
         #in the fastcomtec it can be on "stopped" or "halt"
         self.stopped_or_halt = "stopped"
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         self.dll = ctypes.windll.LoadLibrary('C:\Windows\System32\DMCS6.dll')
 
         return
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method activation.
         """
         return
 

--- a/hardware/fastcomtec/fastcomtecp7887.py
+++ b/hardware/fastcomtec/fastcomtecp7887.py
@@ -166,26 +166,15 @@ class FastComtec(Base, FastCounterInterface):
         #in the fastcomtec it can be on "stopped" or "halt"
         self.stopped_or_halt = "stopped"
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self.dll = ctypes.windll.LoadLibrary('dp7887.dll')
 
         return
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method activation.
         """
         return
 

--- a/hardware/fpga_fastcounter/fast_counter_fpga_pi3.py
+++ b/hardware/fpga_fastcounter/fast_counter_fpga_pi3.py
@@ -30,17 +30,9 @@ class FastCounterFGAPiP3(Base, FastCounterInterface):
     _modclass = 'FastCounterFGAPiP3'
     _modtype = 'hardware'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Connect and configure the access to the FPGA.
-
-                @param object e: Event class object from Fysom.
-                                 An object created by the state machine module Fysom,
-                                 which is connected to a specific event (have a look in
-                                 the Base Class). This object contains the passed event
-                                 the state before the event happens and the destination
-                                 of the state which should be reached after the event
-                                 has happen.
-                """
+        """
 
         config = self.getConfiguration()
         if 'fpgacounter_serial' in config.keys():
@@ -128,11 +120,8 @@ class FastCounterFGAPiP3(Base, FastCounterInterface):
 
         return constraints
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate the FPGA.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         if self.getState() == 'locked':
             self.pulsed.stop()

--- a/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
+++ b/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
@@ -63,16 +63,8 @@ class FastCounterFPGAQO(Base, FastCounterInterface):
         self._internal_clock_hz = 950e6     # that is a fixed number, 950MHz
         self.statusvar = -1                 # fast counter state
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Connect and configure the access to the FPGA.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event
-                         the state before the event happens and the destination
-                         of the state which should be reached after the event
-                         has happen.
         """
 
         config = self.getConfiguration()
@@ -124,11 +116,8 @@ class FastCounterFPGAQO(Base, FastCounterInterface):
         self._set_dac_voltages()
         return
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate the FPGA.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         self.stop_measure()
         self.statusvar = 0

--- a/hardware/fpga_pulser/ok_fpga_pulser.py
+++ b/hardware/fpga_pulser/ok_fpga_pulser.py
@@ -88,13 +88,13 @@ class OkFpgaPulser(Base, PulserInterface):
         self.sample_rate = 950e6
         self.current_loaded_asset = ''
 
-    def on_activate(self, e):
+    def on_activate(self):
         self.current_loaded_asset = ''
         self.fpga = ok.FrontPanel()
         self._connect_fpga()
         self.sample_rate = self.get_sample_rate()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         self._disconnect_fpga()
 
     def get_constraints(self):

--- a/hardware/high_finesse_wavemeter.py
+++ b/hardware/high_finesse_wavemeter.py
@@ -113,7 +113,7 @@ class HighFinesseWavemeter(Base,WavemeterInterface):
                         'using {} instead.'.format(self._measurement_timing))
 
 
-    def on_activate(self, e):
+    def on_activate(self):
         #############################################
         # Initialisation to access external DLL
         #############################################
@@ -169,7 +169,7 @@ class HighFinesseWavemeter(Base,WavemeterInterface):
         self.hardware_thread.start()
 
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         if self.getState() != 'idle' and self.getState() != 'deactivated':
             self.stop_acqusition()
         self.hardware_thread.quit()

--- a/hardware/influx_data_client.py
+++ b/hardware/influx_data_client.py
@@ -32,10 +32,8 @@ class InfluxDataClient(Base, ProcessInterface):
     _modclass = 'InfluxDataClient'
     _modtype = 'hardware'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate module.
-
-            @param e object: Fysom state transition information
         """
         config = self.getConfiguration()
 
@@ -67,10 +65,8 @@ class InfluxDataClient(Base, ProcessInterface):
 
         self.connect_db()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module.
-
-            @param e object: Fysom state transition information
         """
         del self.conn
 
@@ -87,7 +83,7 @@ class InfluxDataClient(Base, ProcessInterface):
 
     def getProcessUnit(self):
         """ Return the unit that the value is measured in
-        
+
             @return (str, str): a tuple of ('abreviation', 'full unit name')
         """
         return '°C', ' degrees Celsius'

--- a/hardware/influx_data_logger.py
+++ b/hardware/influx_data_logger.py
@@ -34,10 +34,8 @@ class InfluxLogger(Base, DataLoggerInterface):
         super().__init__(**kwargs)
         self.log_channels = {}
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate module.
-        
-            @param e object: Fysom state transition information
         """
         config = self.getConfiguration()
 
@@ -69,10 +67,8 @@ class InfluxLogger(Base, DataLoggerInterface):
 
         self.connect_db()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module.
-        
-            @param e object: Fysom state transition information
         """
         del self.conn
 
@@ -82,14 +78,14 @@ class InfluxLogger(Base, DataLoggerInterface):
 
     def get_log_channels(self):
         """ Get number of logging channels
-        
+
             @return int: number of channels
         """
         return self.log_channels
 
     def set_log_channels(self, channelspec):
         """ Set number of logging channels.
-        
+
             @param channelspec dict: name, spec
         """
         for name, spec in channelspec.items():

--- a/hardware/laser/laserquantum_laser.py
+++ b/hardware/laser/laserquantum_laser.py
@@ -46,10 +46,8 @@ class LaserQuantumLaser(Base, SimpleLaserInterface):
     _modclass = 'lqlaser'
     _modtype = 'hardware'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate module.
-
-        @param e: fysom state transition information
         """
         config = self.getConfiguration()
         if 'psu' in config:
@@ -67,10 +65,8 @@ class LaserQuantumLaser(Base, SimpleLaserInterface):
         else:
             self.maxpower = 0.250
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module.
-
-        @param e: fysom state transition information
         """
         self.disconnect_laser()
 
@@ -363,7 +359,7 @@ class LaserQuantumLaser(Base, SimpleLaserInterface):
 
     def off(self):
         """ Turn laser off.
-            
+
             @return LaserState: actual laser state
         """
         return self.set_laser_state(LaserState.OFF)

--- a/hardware/laser/millennia_ev_laser.py
+++ b/hardware/laser/millennia_ev_laser.py
@@ -41,10 +41,8 @@ class MillenniaeVLaser(Base, SimpleLaserInterface):
     _modclass = 'millenniaevlaser'
     _modtype = 'hardware'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate Module.
-
-        @param e: fysom state transition information
         """
         config = self.getConfiguration()
         self.connect_laser(config['interface'])
@@ -53,10 +51,8 @@ class MillenniaeVLaser(Base, SimpleLaserInterface):
         else:
             self.maxpower = 25.0
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module
-
-        @param e: fysom state transition information
         """
         self.disconnect_laser()
 
@@ -93,7 +89,7 @@ class MillenniaeVLaser(Base, SimpleLaserInterface):
 
     def allowed_control_modes(self):
         """ Control modes for this laser
-        
+
             @return ControlMode: available control modes
         """
         return [ControlMode.MIXED]
@@ -228,7 +224,7 @@ class MillenniaeVLaser(Base, SimpleLaserInterface):
     def get_tower_temperature(self):
         """ Get SHG tower temperature
 
-            @return float: SHG tower temperature in degrees Celsius 
+            @return float: SHG tower temperature in degrees Celsius
         """
         return float(self.inst.query('?TT'))
 
@@ -301,14 +297,14 @@ class MillenniaeVLaser(Base, SimpleLaserInterface):
 
     def on(self):
         """ Turn laser on.
-            
+
             @return LaserState: actual laser state
         """
         return self.set_laser_state(LaserState.ON)
 
     def off(self):
         """ Turn laser off.
-            
+
             @return LaserState: actual laser state
         """
         return self.set_laser_state(LaserState.OFF)

--- a/hardware/laser/simple_laser_dummy.py
+++ b/hardware/laser/simple_laser_dummy.py
@@ -44,17 +44,13 @@ class SimpleLaserDummy(Base, SimpleLaserInterface):
         self.current_setpoint = 0
         self.power_setpoint = 0
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate module.
-
-        @param e: fysom state transition information
         """
         pass
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module.
-
-        @param e: fysom state transition information
         """
         pass
 
@@ -74,7 +70,7 @@ class SimpleLaserDummy(Base, SimpleLaserInterface):
 
     def get_power_setpoint(self):
         """ Return optical power setpoint.
-            
+
             @return float: power setpoint in watts
         """
         return self.power_setpoint
@@ -83,7 +79,7 @@ class SimpleLaserDummy(Base, SimpleLaserInterface):
         """ Set power setpoint.
 
             @param float power: power setpoint
-        
+
             @return float: actual new power setpoint
         """
         self.power_setpoint = power
@@ -113,16 +109,16 @@ class SimpleLaserDummy(Base, SimpleLaserInterface):
 
     def get_current_setpoint(self):
         """ Get laser curent setpoint
-        
+
             @return float: laser current setpoint
         """
         return self.current_setpoint
 
     def set_current(self, current):
         """ Set laser current setpoint
-        
+
             @prarm float current: desired laser current setpoint
-            
+
             @return float: actual laser current setpoint
         """
         self.current_setpoint = current
@@ -131,21 +127,21 @@ class SimpleLaserDummy(Base, SimpleLaserInterface):
 
     def allowed_control_modes(self):
         """ Get supported control modes
-        
+
             @return list(): list of supported ControlMode
         """
         return [ControlMode.POWER, ControlMode.CURRENT]
 
     def get_control_mode(self):
-        """ Get the currently active control mode 
-        
+        """ Get the currently active control mode
+
             @return ControlMode: active control mode
         """
         return self.mode
 
     def set_control_mode(self, control_mode):
         """ Set the active control mode
-        
+
             @param ControlMode control_mode: desired control mode
 
             @return ControlMode: actual active ControlMode
@@ -155,7 +151,7 @@ class SimpleLaserDummy(Base, SimpleLaserInterface):
 
     def on(self):
         """ Turn on laser.
-        
+
             @return LaserState: actual laser state
         """
         time.sleep(1)
@@ -164,7 +160,7 @@ class SimpleLaserDummy(Base, SimpleLaserInterface):
 
     def off(self):
         """ Turn off laser.
-        
+
             @return LaserState: actual laser state
         """
         time.sleep(1)
@@ -173,14 +169,14 @@ class SimpleLaserDummy(Base, SimpleLaserInterface):
 
     def get_laser_state(self):
         """ Get laser state
-        
+
             @return LaserState: actual laser state
         """
         return self.lstate
 
     def set_laser_state(self, state):
         """ Set laser state.
-        
+
             @param LaserState state: desired laser state
 
             @return LaserState: actual laser state
@@ -191,14 +187,14 @@ class SimpleLaserDummy(Base, SimpleLaserInterface):
 
     def get_shutter_state(self):
         """ Get laser shutter state
-        
+
             @return ShutterState: actual laser shutter state
         """
         return self.shutter
 
     def set_shutter_state(self, state):
         """ Set laser shutter state.
-        
+
             @param ShutterState state: desired laser shutter state
 
             @return ShutterState: actual laser shutter state
@@ -209,7 +205,7 @@ class SimpleLaserDummy(Base, SimpleLaserInterface):
 
     def get_temperatures(self):
         """ Get all available temperatures.
-        
+
             @return dict: dict of temperature namce and value in degrees Celsius
         """
         return {
@@ -233,7 +229,7 @@ class SimpleLaserDummy(Base, SimpleLaserInterface):
 
     def get_extra_info(self):
         """ Multiple lines of dignostic information
-        
+
             @return str: much laser, very useful
         """
         return "Dummy laser v0.9.9\nnot used very much\nvery cheap price very good quality"

--- a/hardware/magnet/magnet_dummy.py
+++ b/hardware/magnet/magnet_dummy.py
@@ -61,25 +61,14 @@ class MagnetDummy(Base, MagnetInterface):
 
 
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Definition and initialisation of the GUI.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         pass
 
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate the module properly.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method activation.
         """
         pass
 

--- a/hardware/microwave/mw_source_agilent.py
+++ b/hardware/microwave/mw_source_agilent.py
@@ -41,16 +41,8 @@ class MicrowaveAgilent(Base, MicrowaveInterface):
     _modclass = 'MicrowaveAgilent'
     _modtype = 'hardware'
 
-    def on_activate(self,e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         # checking for the right configuration
         config = self.getConfiguration()
@@ -80,11 +72,8 @@ class MicrowaveAgilent(Base, MicrowaveInterface):
         self.log.info('MWAGILENT initialised and connected to hardware.')
         self.model = self._usb_connection.query('*IDN?').split(',')[1]
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
 
         self._usb_connection.close()

--- a/hardware/microwave/mw_source_anritsu.py
+++ b/hardware/microwave/mw_source_anritsu.py
@@ -38,16 +38,8 @@ class MicrowaveAnritsu(Base, MicrowaveInterface):
     _modclass = 'MicrowaveAnritsu'
     _modtype = 'hardware'
 
-    def on_activate(self,e=None):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         # checking for the right configuration
@@ -78,11 +70,8 @@ class MicrowaveAnritsu(Base, MicrowaveInterface):
         self.log.info('MicrowaveAnritsu initialised and connected to '
                 'hardware.')
 
-    def on_deactivate(self,e=None):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         self._gpib_connection.close()
         self.rm.close()

--- a/hardware/microwave/mw_source_anritsu70GHz.py
+++ b/hardware/microwave/mw_source_anritsu70GHz.py
@@ -39,16 +39,8 @@ class MicrowaveAnritsu70GHz(Base, MicrowaveInterface):
     _modclass = 'MicrowaveAanritsu70GHz'
     _modtype = 'hardware'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param e object: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         # checking for the right configuration
         config = self.getConfiguration()
@@ -82,11 +74,8 @@ class MicrowaveAnritsu70GHz(Base, MicrowaveInterface):
         self.log.info('Anritsu {} initialised and connected to hardware.'
                 ''.format(self.model))
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param e object: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         self._gpib_connection.close()
         self.rm.close()

--- a/hardware/microwave/mw_source_dummy.py
+++ b/hardware/microwave/mw_source_dummy.py
@@ -45,25 +45,13 @@ class MicrowaveDummy(Base, MicrowaveInterface):
         for key in config.keys():
             self.log.info("{0}: {1}".format(key,config[key]))
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self.mw_power = -120
-        pass
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         pass
 

--- a/hardware/microwave/mw_source_gigatronics.py
+++ b/hardware/microwave/mw_source_gigatronics.py
@@ -40,16 +40,8 @@ class MicrowaveGigatronics(Base, MicrowaveInterface):
     _modclass = 'MicrowaveInterface'
     _modtype = 'hardware'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         # checking for the right configuration
         config = self.getConfiguration()
@@ -88,11 +80,8 @@ class MicrowaveGigatronics(Base, MicrowaveInterface):
         self.model = idnlist[1]
         self.log.info('MWgigatronics initialised and connected to hardware.')
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         self._gpib_connection.close()
         self.rm.close()

--- a/hardware/microwave/mw_source_smiq.py
+++ b/hardware/microwave/mw_source_smiq.py
@@ -41,16 +41,8 @@ class MicrowaveSmiq(Base, MicrowaveInterface):
     _modclass = 'MicrowaveSmiq'
     _modtype = 'hardware'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         # checking for the right configuration
         config = self.getConfiguration()
@@ -83,11 +75,8 @@ class MicrowaveSmiq(Base, MicrowaveInterface):
         self.log.info('MWSMIQ initialised and connected to hardware.')
         self.model = self._gpib_connection.query('*IDN?').split(',')[1]
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
 
         self._gpib_connection.close()
@@ -95,7 +84,7 @@ class MicrowaveSmiq(Base, MicrowaveInterface):
 
     def get_limits(self):
         """ Create an object containing parameter limits for this microwave source.
-            
+
             @return MicrowaveLimits: device-specific parameter limits
         """
         limits = MicrowaveLimits()

--- a/hardware/microwave/mw_source_smr20.py
+++ b/hardware/microwave/mw_source_smr20.py
@@ -42,16 +42,8 @@ class MicrowaveSMR20(Base, MicrowaveInterface):
     _modclass = 'MicrowaveSMR20'
     _modtype = 'hardware'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         # checking for the right configuration
@@ -94,11 +86,8 @@ class MicrowaveSMR20(Base, MicrowaveInterface):
         self._POWER_MAX = float(self._gpib_connection.ask('POWER? MAX'))
         self._POWER_MIN = float(self._gpib_connection.ask('POWER? MIN'))
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
 
         self.off()  # turn the device off in case it is running

--- a/hardware/microwave/mw_source_srssg.py
+++ b/hardware/microwave/mw_source_srssg.py
@@ -35,16 +35,8 @@ class MicrowaveSRSSG(Base, MicrowaveInterface):
     _modclass = 'MicrowaveSRSSG'
     _modtype = 'interface'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         # checking for the right configuration
@@ -78,11 +70,8 @@ class MicrowaveSRSSG(Base, MicrowaveInterface):
         self.log.info('MW SRS SG initialised and connected to hardware.')
         self.model = self._gpib_connection.query('*IDN?').split(',')[1]
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
 
         self._gpib_connection.close()

--- a/hardware/motor/aptmotor.py
+++ b/hardware/motor/aptmotor.py
@@ -790,16 +790,8 @@ class APTStage(Base, MotorInterface):
         module, then overwrite it in the class, which inherited that class.
      """
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialize instance variables and connect to hardware as configured.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event
-                         the state before the event happens and the destination
-                         of the state which should be reached after the event
-                         has happen.
         """
 
         # create the magnet dump folder
@@ -869,31 +861,25 @@ class APTStage(Base, MotorInterface):
                         'coincide with the label given in the config!\n'
                         'Restart the program!')
 
-        self.custom_activation(e)
+        self.custom_activation()
 
 
-    def custom_activation(self, e):
+    def custom_activation(self):
         """ That activation method can be overwritten in the sub-classed file.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         pass
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Disconnect from hardware and clean up.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
 
         for label_axis in self._axis_dict:
             self._axis_dict[label_axis].cleanUpAPT()
 
-        self.custom_deactivation(e)
+        self.custom_deactivation()
 
 
-    def custom_deactivation(self, e):
+    def custom_deactivation(self):
         """ That deactivation method can be overwritten in the sub-classed file.
 
         @param object e: Event class object from Fysom. A more detailed
@@ -1146,13 +1132,8 @@ class APTOneAxisStage(APTStage):
     _modclass = 'APTOneAxis'
     _modtype = 'hardware'
 
-    def custom_activation(self, e):
+    def custom_activation(self):
         """ That activation method can be overwritten in the sub-classed file.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation of the
-                         parent class APTStage.
-
         """
         # my specific settings for the stage can be set here.
         # remember to set the units to degree if you want to use it as a
@@ -1193,12 +1174,8 @@ class APTOneAxisStage(APTStage):
             # preciser than the backward:
             self._axis_dict[label_axis].set_backlash(backlash_correction)
 
-    def custom_deactivation(self, e):
+    def custom_deactivation(self):
         """ That deactivation method can be overwritten in the sub-classed file.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation of the
-                         parent class APTStage.
         """
         pass
 
@@ -1263,12 +1240,8 @@ class APTThreeAxisStage(APTStage):
     _modclass = 'APTThreeAxis'
     _modtype = 'hardware'
 
-    def custom_activation(self, e):
+    def custom_activation(self):
         """ That activation method can be overwritten in the sub-classed file.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation of the
-                         parent class APTStage.
 
         """
 
@@ -1305,12 +1278,8 @@ class APTThreeAxisStage(APTStage):
             # preciser than the backward:
             self._axis_dict[label_axis].set_backlash(backlash_correction)
 
-    def custom_deactivation(self, e):
+    def custom_deactivation(self):
         """ That deactivation method can be overwritten in the sub-classed file.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation of the
-                         parent class APTStage.
         """
         pass
 
@@ -1408,13 +1377,8 @@ class APTFourAxisStage(APTStage):
     _modclass = 'APTThreeAxis'
     _modtype = 'hardware'
 
-    def custom_activation(self, e):
+    def custom_activation(self):
         """ That activation method can be overwritten in the sub-classed file.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation of the
-                         parent class APTStage.
-
         """
 
         # my specific settings for the stage:
@@ -1455,12 +1419,8 @@ class APTFourAxisStage(APTStage):
                                                 limits_dict[label_axis]['vel_max'])
                 self._axis_dict[label_axis].set_velocity(limits_dict[label_axis]['vel_max']/2)
 
-    def custom_deactivation(self, e):
+    def custom_deactivation(self):
         """ That deactivation method can be overwritten in the sub-classed file.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation of the
-                         parent class APTStage.
         """
         pass
 

--- a/hardware/motor/motor_dummy.py
+++ b/hardware/motor/motor_dummy.py
@@ -57,7 +57,7 @@ class MotorDummy(Base, MotorInterface):
 
     #TODO: Checks if configuration is set and is reasonable
 
-    def on_activate(self, e):
+    def on_activate(self):
 
         # PLEASE REMEMBER: DO NOT CALL THE POSITION SIMPLY self.x SINCE IT IS
         # EXTREMLY DIFFICULT TO SEARCH FOR x GLOBALLY IN A FILE!
@@ -78,7 +78,7 @@ class MotorDummy(Base, MotorInterface):
         self._z_axis.status = 0
         self._phi_axis.status = 0
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         pass
 
 

--- a/hardware/motor/motor_stage_micos.py
+++ b/hardware/motor/motor_stage_micos.py
@@ -67,7 +67,7 @@ class MotorStageMicos(Base, MotorInterface):
         for key in config.keys():
             self.log.info('{0}: {1}'.format(key,config[key]))
 
-    def on_activate(self, e):
+    def on_activate(self):
 
 
         # ALEX COMMENT: Why are the values stored? In general that is not a
@@ -149,7 +149,7 @@ class MotorStageMicos(Base, MotorInterface):
         self._micos_b.baud_rate = self._baud_rate_zphi
 
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Disconnect from hardware and clean up """
         self._micos_a.close()
         self._micos_b.close()

--- a/hardware/motor/motor_stage_pi.py
+++ b/hardware/motor/motor_stage_pi.py
@@ -40,16 +40,8 @@ class MotorStagePI(Base, MotorInterface):
         super().__init__(**kwargs)
 
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         @return: error code
         """
         # Read configs from config-file
@@ -264,11 +256,8 @@ class MotorStagePI(Base, MotorInterface):
         return 0
 
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         @return: error code
         """
         self._serial_connection_xyz.close()

--- a/hardware/motor/zaber_motor_rotation_stage.py
+++ b/hardware/motor/zaber_motor_rotation_stage.py
@@ -40,16 +40,8 @@ class MotorRotationZaber(Base, MotorInterface):
 
 
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         # Read configs from config-file
         config = self.getConfiguration()
@@ -162,11 +154,8 @@ class MotorRotationZaber(Base, MotorInterface):
 
 
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         self._serial_connection_rot.close()
         return 0

--- a/hardware/ni_card.py
+++ b/hardware/ni_card.py
@@ -431,11 +431,8 @@ class NICard(Base, SlowCounterInterface, ConfocalScannerInterface, ODMRCounterIn
             self.log.error('Failed to start analog output.')
             raise Exception('Failed to start NI Card module due to analog output failure.')
 
-    def on_deactivate(self, e=None):
+    def on_deactivate(self):
         """ Shut down the NI card.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         self.reset_hardware()
 
@@ -2064,16 +2061,8 @@ class SlowGatedNICard(NICard):
     _modtype = 'SlowGatedNICard'
     _modclass = 'hardware'
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Starts up the NI Card at activation.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event
-                         the state before the event happens and the destination
-                         of the state which should be reached after the event
-                         has happen.
         """
         self._gated_counter_daq_task = None
         # used as a default for expected maximum counts

--- a/hardware/ni_pulser.py
+++ b/hardware/ni_pulser.py
@@ -41,10 +41,8 @@ class NIPulser(Base, PulserInterface):
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate module
-
-            @param e object: Fysom state transition information
         """
         config = self.getConfiguration()
         if 'pulsed_file_dir' in config.keys():
@@ -91,10 +89,8 @@ class NIPulser(Base, PulserInterface):
             k: True for k in self.constraints['activation_config']['analog_only']})
         #self.sample_rate = self.get_sample_rate()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module
-
-            @param e object: Fysom state transition information
         """
         self.close_pulser_task()
 

--- a/hardware/odmr_counter_dummy.py
+++ b/hardware/odmr_counter_dummy.py
@@ -53,24 +53,13 @@ class ODMRCounterDummy(Base, ODMRCounterInterface):
         self._scanner_counter_daq_task = None
         self._odmr_length = None
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self._fit_logic = self.get_connector('fitlogic')
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         self.log.debug('ODMR counter is shutting down.')
 

--- a/hardware/pi_pwm.py
+++ b/hardware/pi_pwm.py
@@ -40,10 +40,8 @@ class PiPWM(Base, ProcessControlInterface):
         #locking for thread safety
         self.threadlock = Mutex()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate module.
-
-            @param object e: fysom state transition information
         """
         config = self.getConfiguration()
 
@@ -81,10 +79,8 @@ class PiPWM(Base, ProcessControlInterface):
         self.setupPins()
         self.startPWM()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module.
-
-            @param object e: fysom state transition information
         """
         self.stopPWM()
 
@@ -142,7 +138,7 @@ class PiPWM(Base, ProcessControlInterface):
 
     def setControlValue(self, value):
         """ Set control value for this controller.
-        
+
             @param float value: control value, in this case duty cycle in percent
         """
         with self.threadlock:
@@ -150,7 +146,7 @@ class PiPWM(Base, ProcessControlInterface):
 
     def getControlValue(self):
         """ Get control value for this controller.
-        
+
             @return float: control value, in this case duty cycle in percent
         """
         return self.dutycycle
@@ -173,7 +169,7 @@ class PiPWM(Base, ProcessControlInterface):
 class PiPWMHalf(PiPWM):
     """ PWM controller restricted to positive values.
     """
-    
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         #locking for thread safety

--- a/hardware/picoquant/picoharp300.py
+++ b/hardware/picoquant/picoharp300.py
@@ -144,16 +144,8 @@ class PicoHarp300(Base, SlowCounterInterface, FastCounterInterface):
         self.threadlock = Mutex()
 
 
-    def on_activate(self, fysom_e=None):
+    def on_activate(self):
         """ Activate and establish the connection to Picohard and initialize.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event
-                         the state before the event happens and the destination
-                         of the state which should be reached after the event
-                         has happen.
         """
         self.open_connection()
         self.initialize(self._mode)
@@ -172,11 +164,8 @@ class PicoHarp300(Base, SlowCounterInterface, FastCounterInterface):
         self.result = []
 
 
-    def on_deactivate(self, fysom_e=None):
+    def on_deactivate(self):
         """ Deactivates and disconnects the device.
-
-        @param object e: Event class object from Fysom. Detailed explanation
-                         see in method 'activation'.
         """
 
         self.close_connection()

--- a/hardware/process_dummy.py
+++ b/hardware/process_dummy.py
@@ -31,10 +31,8 @@ class ProcessDummy(Base, ProcessInterface, ProcessControlInterface):
     _modclass = 'Process'
     _modtype = 'hardware'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate module.
-
-            @param object e: fysom state transition information
         """
         self.temperature = 300.0
         self.pwmpower = 0
@@ -43,10 +41,8 @@ class ProcessDummy(Base, ProcessInterface, ProcessControlInterface):
         self.recalctimer.timeout.connect(self._recalcTemp)
         self.recalctimer.start(100)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module.
-
-            @param object e: fysom state transition information
         """
         pass
 
@@ -87,7 +83,7 @@ class ProcessDummy(Base, ProcessInterface, ProcessControlInterface):
 
     def getControlLimits(self):
         """ Get minimum and maximum of control value.
-            
+
             @return tuple(float, float): minimum and maximum of control value
         """
         return (-100, 100)

--- a/hardware/pulser_dummy.py
+++ b/hardware/pulser_dummy.py
@@ -108,24 +108,13 @@ class PulserDummy(Base, PulserInterface):
 
         self.current_status = 0    # that means off, not running.
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self.connected = True
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
 
         self.connected = False

--- a/hardware/sc_magnet/magnet.py
+++ b/hardware/sc_magnet/magnet.py
@@ -85,7 +85,7 @@ class Magnet(Base, MagnetInterface):
         self.z_constr = 3.0
         self.rho_constr = 1.2
 
-    def on_activate(self, e):
+    def on_activate(self):
         """
         loads the config file and extracts the necessary configurations for the
         superconducting magnet
@@ -146,7 +146,7 @@ class Magnet(Base, MagnetInterface):
         tell_dict = {'x': 'CONF:FIELD:UNITS 1', 'y': 'CONF:FIELD:UNITS 1', 'z': 'CONF:FIELD:UNITS 1'}
         self.tell(tell_dict)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         self.soc_x.close()
         self.soc_y.close()
         self.soc_z.close()

--- a/hardware/simple_data_acq.py
+++ b/hardware/simple_data_acq.py
@@ -31,10 +31,8 @@ class SimpleAcq(Base, SimpleDataInterface):
     _modclass = 'simple'
     _modtype = 'hardware'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate module.
-
-            @param object e: fysom state transition information
         """
         config = self.getConfiguration()
         if 'interface' in config:
@@ -51,10 +49,8 @@ class SimpleAcq(Base, SimpleDataInterface):
         self.log.debug('Resources: {0}'.format(self.rm.list_resources()))
         self.my_instrument = self.rm.open_resource(self.resource, baud_rate=self.baudrate)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module.
-
-            @param object e: fysom state transition information
         """
         self.my_instrument.close()
         self.rm.close()

--- a/hardware/simple_data_dummy.py
+++ b/hardware/simple_data_dummy.py
@@ -32,10 +32,10 @@ class SimpleDummy(Base, SimpleDataInterface):
     _modclass = 'simple'
     _modtype = 'hardware'
 
-    def on_activate(self, e):
+    def on_activate(self):
         pass
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         pass
 
     def getData(self):

--- a/hardware/slow_counter_dummy.py
+++ b/hardware/slow_counter_dummy.py
@@ -47,16 +47,8 @@ class SlowCounterDummy(Base, SlowCounterInterface):
         for key in config.keys():
             self.log.info('{0}: {1}'.format(key, config[key]))
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         config = self.getConfiguration()
@@ -112,11 +104,8 @@ class SlowCounterDummy(Base, SlowCounterInterface):
         self.curr_state_b = True
         self.total_time = 0.0
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method activation.
         """
         self.log.warning('slowcounterdummy>deactivation')
 

--- a/hardware/spectrometer/lightfield_spectrometer.py
+++ b/hardware/spectrometer/lightfield_spectrometer.py
@@ -52,10 +52,8 @@ class Lightfield(Base, SpectrometerInterface):
         as it can only do one thing right now: crash Lightfield.
     """
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate module.
-
-            @param e object: fysom state transition information
 
             This method needs to set ip the CLR to Python binding and start Lightfield.
         """
@@ -111,7 +109,7 @@ class Lightfield(Base, SpectrometerInterface):
         #self.openExperiment(name)
         self.lastframe = list()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module.
 
             @param e object: fysom state transition information

--- a/hardware/spectrometer/spectrometer_dummy.py
+++ b/hardware/spectrometer/spectrometer_dummy.py
@@ -36,18 +36,14 @@ class SpectrometerInterfaceDummy(Base,SpectrometerInterface):
 
     _connectors = {'fitlogic': 'FitLogic'}
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate module.
-
-            @param object e: fysom state transition information
         """
         self._fitLogic = self.get_connector('fitlogic')
         self.exposure = 0.1
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module.
-
-            @param object e: fysom state transition information
         """
         pass
 
@@ -85,7 +81,7 @@ class SpectrometerInterfaceDummy(Base,SpectrometerInterface):
 
     def saveSpectrum(self, path, postfix = ''):
         """ Dummy save function.
-        
+
             @param str path: path of saved spectrum
             @param str postfix: postfix of saved spectrum file
         """

--- a/hardware/spectrometer/winspec_spectrometer.py
+++ b/hardware/spectrometer/winspec_spectrometer.py
@@ -42,20 +42,16 @@ class WinSpec32(Base, SpectrometerInterface):
     """ Hardware module for reading spectra from the WinSpec32 spectrometer software.
     """
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate module.
-
-            @param object e: fysom state transition information
         """
         w32c.pythoncom.CoInitialize()
         self.expt_is_running = WinSpecLib.EXP_RUNNING
         self.path = 'asdf'
         self.prefix = 'test'
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module.
-
-            @param object e: fysom state transition information
         """
         pass
 

--- a/hardware/spincore/pulse_blaster_esrpro.py
+++ b/hardware/spincore/pulse_blaster_esrpro.py
@@ -69,16 +69,8 @@ class PulseBlasterESRPRO(Base, PulserInterface):
         self.GRAN_MIN = 2   # minimal possible granuality in time, in ns.
         self.FREQ_MAX = int(1/self.GRAN_MIN *1000) # Maximal output frequency.
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         # Check the platform architecture:
@@ -103,11 +95,8 @@ class PulseBlasterESRPRO(Base, PulserInterface):
 
         self.open_connection()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method activation.
         """
         self.close_connection()
 

--- a/hardware/swabian_instruments/pulse_streamer.py
+++ b/hardware/swabian_instruments/pulse_streamer.py
@@ -2,7 +2,7 @@
 """
 Use Swabian Instruments PulseStreamer8/2 as a pulse generator.
 
-Protobuf (pb2) and grpc files generated from pulse_streamer.proto 
+Protobuf (pb2) and grpc files generated from pulse_streamer.proto
 file available at https://www.swabianinstruments.com/static/documentation/PulseStreamer/sections/interface.html#grpc-interface.
 
 Regenerate files for an update proto file using the following:
@@ -64,14 +64,14 @@ class PulseStreamer(Base, PulserInterface):
         if 'pulsestreamer_ip' in config.keys():
             self._pulsestreamer_ip = config['pulsestreamer_ip']
         else:
-            self._pulsestreamer_ip = '192.168.1.100' 
+            self._pulsestreamer_ip = '192.168.1.100'
             self.log.warning('No value set for "pulsestreamer_ip" in configuration. The default value '
                              '"192.168.1.100" will be used.')
 
         if 'laser_channel' in config.keys():
             self._laser_channel = config['laser_channel']
         else:
-            self._laser_channel = 0 
+            self._laser_channel = 0
             self.log.warning('No value set for "laser_channel" in configuration. The default value '
                              'channel 0 will be used.')
 
@@ -90,13 +90,13 @@ class PulseStreamer(Base, PulserInterface):
 
         self._channel = grpc.insecure_channel(self._pulsestreamer_ip + ':50051')
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Establish connection to pulse streamer and tell it to cancel all operations """
         self.pulse_streamer = pulse_streamer_pb2.PulseStreamerStub(self._channel)
         self.pulser_off()
         self.current_status = 0
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         del self.pulse_streamer
 
     def get_constraints(self):

--- a/hardware/swabian_instruments/timetagger_fast_counter.py
+++ b/hardware/swabian_instruments/timetagger_fast_counter.py
@@ -30,18 +30,9 @@ class TimeTaggerFastCounter(Base, FastCounterInterface):
     _modclass = 'FastCounterFGAPiP3'
     _modtype = 'hardware'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Connect and configure the access to the FPGA.
-
-                @param object e: Event class object from Fysom.
-                                 An object created by the state machine module Fysom,
-                                 which is connected to a specific event (have a look in
-                                 the Base Class). This object contains the passed event
-                                 the state before the event happens and the destination
-                                 of the state which should be reached after the event
-                                 has happen.
-                """
-
+        """
         self._tagger = tt.createTimeTagger()
         self._tagger.reset()
         config = self.getConfiguration()
@@ -133,11 +124,8 @@ class TimeTaggerFastCounter(Base, FastCounterInterface):
 
         return constraints
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate the FPGA.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         if self.getState() == 'locked':
             self.pulsed.stop()

--- a/hardware/switches/flipmirror.py
+++ b/hardware/switches/flipmirror.py
@@ -46,10 +46,8 @@ class FlipMirror(Base, SwitchInterface):
         print(config)
         print(self._configuration)
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Prepare module, connect to hardware.
-
-          @param e: Fysom stae change notification.
         """
         config = self.getConfiguration()
         if not 'interface' in config:
@@ -64,10 +62,8 @@ class FlipMirror(Base, SwitchInterface):
                 send_end=True
         )
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Disconnect from hardware on deactivation.
-
-          @param e: Fysom stae change notification.
         """
         self.inst.close()
         self.rm.close()

--- a/hardware/switches/hbridge.py
+++ b/hardware/switches/hbridge.py
@@ -36,10 +36,8 @@ class HBridge(Base, SwitchInterface):
         super().__init__(**kwargs)
         self.lock = Mutex()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate module.
-
-            @param object e: fysom state transition information
         """
         config = self.getConfiguration()
         if not 'interface' in config:
@@ -54,10 +52,8 @@ class HBridge(Base, SwitchInterface):
                 send_end=True
         )
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module.
-
-            @param object e: fysom state transition information
         """
         self.inst.close()
 

--- a/hardware/switches/ok_fpga/ok_fpga_switch.py
+++ b/hardware/switches/ok_fpga/ok_fpga_switch.py
@@ -38,7 +38,7 @@ class OkFpgaTtlSwitch(Base, SwitchInterface):
         super().__init__(**kwargs)
         self.lock = Mutex()
 
-    def on_activate(self, e):
+    def on_activate(self):
         self.fp = ok.FrontPanel()
         self.fp.GetDeviceCount()
         self.fp.OpenBySerial(self.fp.GetDeviceListSerial(0))
@@ -50,7 +50,7 @@ class OkFpgaTtlSwitch(Base, SwitchInterface):
             self.reset()
             self.log.info('FPGA connected')
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         pass
         # self.fp.
 

--- a/hardware/switches/ok_fpga/ok_s6_switch.py
+++ b/hardware/switches/ok_fpga/ok_s6_switch.py
@@ -41,16 +41,8 @@ class HardwareSwitchFpga(Base, SwitchInterface):
     _modclass = 'HardwareSwitchFpga'
     _modtype = 'hardware'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Connect and configure the access to the FPGA.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event
-                         the state before the event happens and the destination
-                         of the state which should be reached after the event
-                         has happen.
         """
 
         config = self.getConfiguration()
@@ -82,11 +74,8 @@ class HardwareSwitchFpga(Base, SwitchInterface):
         self._connect()
         return
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate the FPGA.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         self.reset()
         del self._fpga

--- a/hardware/switches/switch_dummy.py
+++ b/hardware/switches/switch_dummy.py
@@ -38,10 +38,10 @@ class SwitchDummy(Base, SwitchInterface):
         self.switchCalibration['On'] = [0.9, 0.8, 0.88]
         self.switchCalibration['Off'] = [0.15, 0.3, 0.2]
 
-    def on_activate(self, e):
+    def on_activate(self):
         pass
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         pass
 
     def getNumberOfSwitches(self):

--- a/hardware/timetagger_counter.py
+++ b/hardware/timetagger_counter.py
@@ -37,16 +37,8 @@ class TimeTaggerCounter(Base, SlowCounterInterface):
     _modclass = 'hardware'
 
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Start up TimeTagger interface
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         self._tagger = tt.createTimeTagger()
@@ -85,11 +77,8 @@ class TimeTaggerCounter(Base, SlowCounterInterface):
         else:
             self._mode = 2
 
-    def on_deactivate(self, e=None):
+    def on_deactivate(self):
         """ Shut down the TimeTagger.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         #self.reset_hardware()
         pass

--- a/hardware/tsys01_spi.py
+++ b/hardware/tsys01_spi.py
@@ -47,10 +47,8 @@ class TSYS01SPI(Base, ProcessInterface):
         #locking for thread safety
         self.threadlock = Mutex()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate module.
-
-            @param object e: fysom state transition information
         """
         config = self.getConfiguration()
         print(config)
@@ -62,10 +60,8 @@ class TSYS01SPI(Base, ProcessInterface):
         self.reset()
         self.readROM()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module.
-
-            @param object e: fysom state transition information
         """
         self.spi.close()
 

--- a/hardware/wavemeter_dummy.py
+++ b/hardware/wavemeter_dummy.py
@@ -94,10 +94,8 @@ class WavemeterDummy(Base, WavemeterInterface):
             self.log.warning('No measurement_timing configured, '
                     'using {} instead.'.format(self._measurement_timing))
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activate module.
-
-            @param object e: fysom state transition information
         """
         # create an indepentent thread for the hardware communication
         self.hardware_thread = QtCore.QThread()
@@ -112,10 +110,8 @@ class WavemeterDummy(Base, WavemeterInterface):
         # start the event loop for the hardware
         self.hardware_thread.start()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module.
-
-            @param object e: fysom state transition information
         """
 
         self.stop_acqusition()

--- a/logic/automation.py
+++ b/logic/automation.py
@@ -42,14 +42,14 @@ class TreeItem:
 
     def appendChild(self, item):
         """ Append child node to tree item.
-        
+
             @param item :
         """
         self.childItems.append(item)
 
     def child(self, row):
         """ Get child item for specific index
-        
+
             @param row int: row index for child item
 
             @return : child item in given row
@@ -84,7 +84,7 @@ class TreeItem:
 
     def parent(self):
         """ Get parent item.
-        
+
             @return TreeItem: parent item
         """
         return self.parentItem
@@ -113,7 +113,7 @@ class TreeModel(QtCore.QAbstractItemModel):
 
     def columnCount(self, parent):
         """ Return number of columns.
-            
+
             @param parent TreeModel: prent model
         """
         if parent.isValid():
@@ -123,7 +123,7 @@ class TreeModel(QtCore.QAbstractItemModel):
 
     def data(self, index, role):
         """ Retrieve data from model.
-            
+
             @param index QModelIndex: index of data
             @param role QtRole: role for data
         """
@@ -219,7 +219,7 @@ class TreeModel(QtCore.QAbstractItemModel):
 
     def loadExecTree(self, tree, parent=None):
         """ Load a tree from a nested dictionary into the model.
-        
+
             @param tree dict: dictionary tree to be loaded
             @param parent TreeItem: root item for loaded tree
         """
@@ -231,7 +231,7 @@ class TreeModel(QtCore.QAbstractItemModel):
 
     def recursiveLoad(self, tree, parent):
         """ Recursively load a tree from a nested dictionary into the model.
-        
+
             @param tree dict: dictionary for (sub)tree to be loaded
             @param parent TreeItem: root item for loaded (sub)tree
         """
@@ -269,10 +269,8 @@ class AutomationLogic(GenericLogic):
 
     sigRepeat = QtCore.Signal()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Prepare logic module for work.
-
-          @param object e: Fysom state change information
         """
         self._taskrunner = self.get_connector('taskrunner')
         #stuff = "a\txyz\n    b\tx\n    c\ty\n        d\tw\ne\tm\n"
@@ -292,10 +290,8 @@ class AutomationLogic(GenericLogic):
         #self.model.loadExecTree(tr)
         self.loadAutomation('auto.cfg')
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate modeule.
-
-          @param object e: Fysom state change information
         """
         print(self.model.recursiveSave(self.model.rootItem))
 

--- a/logic/confocal_logic.py
+++ b/logic/confocal_logic.py
@@ -282,10 +282,8 @@ class ConfocalLogic(GenericLogic):
         self.depth_scan_dir_is_xz = True
         self.permanent_scan = False
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param e: error code
         """
         self._scanning_device = self.get_connector('confocalscanner1')
         self._save_logic = self.get_connector('savelogic')
@@ -345,10 +343,8 @@ class ConfocalLogic(GenericLogic):
 
         self._change_position('activation')
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Reverse steps of activation
-
-        @param e: error code
 
         @return int: error code (0:OK, -1:error)
         """

--- a/logic/counter_logic.py
+++ b/logic/counter_logic.py
@@ -92,16 +92,8 @@ class CounterLogic(GenericLogic):
         self._saving = False
         return
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event
-                         the state before the event happens and the destination
-                         of the state which should be reached after the event
-                         has happen.
         """
         # Connect to hardware and save logic
         self._counting_device = self.get_connector('counter1')
@@ -140,11 +132,8 @@ class CounterLogic(GenericLogic):
         self.sigCountDataNext.connect(self.count_loop_body, QtCore.Qt.QueuedConnection)
         return
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         # Save parameters to disk
         self._statusVariables['count_length'] = self._count_length

--- a/logic/fit_logic.py
+++ b/logic/fit_logic.py
@@ -146,23 +146,15 @@ class FitLogic(GenericLogic):
         self.log.info('Methods were included to FitLogic, but only if naming is right: check the'
                          ' doxygen documentation if you added a new method and it does not show.')
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         # FIXME: load all the fits here, otherwise reloading this module is really questionable
         fitversion = LooseVersion(lmfit.__version__)
         if fitversion < LooseVersion('0.9.2'):
             raise Exception('lmfit needs to be at least version 0.9.2!')
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ """
         pass
 
@@ -252,7 +244,7 @@ class FitLogic(GenericLogic):
         return self.validate_load_fits(fits)
 
     def save_fits(self, filename, fits):
-        """ Save a collection of configured fits to YAML file. 
+        """ Save a collection of configured fits to YAML file.
             @param fits dict: dictionay with fits, function references and parameter objects
 
             @return dict: storable dictionary with fit description
@@ -332,7 +324,7 @@ class FitContainer(QtCore.QObject):
 
     def save_to_dict(self):
         """ Convert self.fit_list to a storable dictionary.
-            
+
             @return dict: storable configured fits dictionary
         """
         prep = self.fit_logic.prepare_save_fits({self.dimension: self.fit_list})

--- a/logic/interfuse/confocal_scanner_spectrometer_interfuse.py
+++ b/logic/interfuse/confocal_scanner_spectrometer_interfuse.py
@@ -67,7 +67,7 @@ class SpectrometerScannerInterfuse(Base, ConfocalScannerInterface):
 
         self._num_points = 500
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
         """
 
@@ -76,7 +76,7 @@ class SpectrometerScannerInterfuse(Base, ConfocalScannerInterface):
         self._spectrometer_hw = self.get_connector('spectrometer1')
 
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         self.reset_hardware()
 
     def reset_hardware(self):

--- a/logic/interfuse/magnet_motor_interfuse.py
+++ b/logic/interfuse/magnet_motor_interfuse.py
@@ -43,26 +43,14 @@ class MagnetMotorInterfuse(GenericLogic, MagnetInterface):
         # whether movement commands are passed to the hardware.
         self._magnet_idle = False
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         self._motor_device = self.get_connector('motorstage')
 
-
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         pass
 

--- a/logic/interfuse/magnet_motor_xyz_rot_interfuse.py
+++ b/logic/interfuse/magnet_motor_xyz_rot_interfuse.py
@@ -61,27 +61,14 @@ class MagnetMotorXYZROTInterfuse(GenericLogic, MagnetInterface):
         # whether movement commands are passed to the hardware.
         self._magnet_idle = False
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self._motor_device_rot = self.get_connector('motorstage_rot')
         self._motor_device_xyz = self.get_connector('motorstage_xyz')
 
-
-
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         pass
 

--- a/logic/interfuse/mw_differential_scanner.py
+++ b/logic/interfuse/mw_differential_scanner.py
@@ -62,7 +62,7 @@ class ConfocalScannerInterfaceDummy(Base, ConfocalScannerInterface):
 
         self._num_points = 500
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
         """
 
@@ -119,7 +119,7 @@ class ConfocalScannerInterfaceDummy(Base, ConfocalScannerInterface):
 #        print('Position of NV 1',self._points[0,:],self._points_z[0,:],len(self._points))
 #        print(self._points_z[:,0],self._points[:,0])
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         self.reset_hardware()
 
     def reset_hardware(self):

--- a/logic/interfuse/scanner_tilt_interfuse.py
+++ b/logic/interfuse/scanner_tilt_interfuse.py
@@ -35,16 +35,8 @@ class ScannerTiltInterfuse(GenericLogic, ConfocalScannerInterface):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self._scanning_device = self.get_connector('confocalscanner1')
 
@@ -54,11 +46,8 @@ class ScannerTiltInterfuse(GenericLogic, ConfocalScannerInterface):
         self.tilt_reference_x = 0
         self.tilt_reference_y = 0
 
-    def on_deactivate(self,e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         pass
 

--- a/logic/jupyterkernel/kernellogic.py
+++ b/logic/jupyterkernel/kernellogic.py
@@ -45,20 +45,16 @@ class QudiKernelLogic(GenericLogic):
         self.kernellist = dict()
         self.modules = set()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Prepare logic module for work.
-
-          @param object e: Fysom state change notification
         """
         self.kernellist = dict()
         self.modules = set()
         self._manager.sigModulesChanged.connect(self.updateModuleList)
         self.sigStartKernel.connect(self.updateModuleList, QtCore.Qt.QueuedConnection)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate module.
-
-          @param object e: Fysom state change notification
         """
         kernels = tuple(self.kernellist.keys())
         for k in kernels:

--- a/logic/laser_logic.py
+++ b/logic/laser_logic.py
@@ -36,10 +36,8 @@ class LaserLogic(GenericLogic):
 
     sigUpdate = QtCore.Signal()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Prepare logic module for work.
-
-          @param object e: Fysom state change notification
         """
         self._laser = self.get_connector('laser')
         self.stopRequest = False
@@ -74,10 +72,8 @@ class LaserLogic(GenericLogic):
         self.init_data_logging()
         self.start_query_loop()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate modeule.
-
-          @param object e: Fysom state change notification
         """
         self.stop_query_loop()
         for i in range(5):

--- a/logic/laser_scanner_logic.py
+++ b/logic/laser_scanner_logic.py
@@ -65,10 +65,8 @@ class LaserScannerLogic(GenericLogic):
 
         self.stopRequested = False
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-          @param object e: Fysom state change event
         """
         self._scanning_device = self.get_connector('confocalscanner1')
         self._save_logic = self.get_connector('savelogic')
@@ -122,10 +120,8 @@ class LaserScannerLogic(GenericLogic):
         # Initialie data matrix
         self._initialise_data_matrix(100)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-          @param object e: Fysom state change event
         """
         pass
 

--- a/logic/magnet_logic.py
+++ b/logic/magnet_logic.py
@@ -141,16 +141,8 @@ class MagnetLogic(GenericLogic):
 
         self._stop_measure = False
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Definition and initialisation of the GUI.
-
-        @param object e: Fysom.event object from Fysom class.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self._magnet_device = self.get_connector('magnetstage')
         self._save_logic = self.get_connector('savelogic')
@@ -468,11 +460,8 @@ class MagnetLogic(GenericLogic):
             self.nuclear_2d_num_ssr = 3000
 
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate the module properly.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method activation.
         """
 
         constraints=self.get_hardware_constraints()

--- a/logic/measurement_simulator/polarisation_dependence_sim.py
+++ b/logic/measurement_simulator/polarisation_dependence_sim.py
@@ -42,7 +42,7 @@ class PolarizationDependenceSim(Base, SlowCounterInterface, MotorInterface):
 
     _move_signal = QtCore.Signal()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Activation of the class
         """
         # name connected modules
@@ -64,7 +64,7 @@ class PolarizationDependenceSim(Base, SlowCounterInterface, MotorInterface):
         # Signals
         self._move_signal.connect(self._move_step, QtCore.Qt.QueuedConnection)
 
-    def on_deactivate(self,e):
+    def on_deactivate(self):
         self._counter_hw.close_counter()
         self._counter_hw.close_clock()
 

--- a/logic/nuclear_operations_logic.py
+++ b/logic/nuclear_operations_logic.py
@@ -88,16 +88,8 @@ class NuclearOperationsLogic(GenericLogic):
 
         self.threadlock = Mutex()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         # Retrieve the status variables or use default values:
@@ -322,11 +314,8 @@ class NuclearOperationsLogic(GenericLogic):
         # connect signals:
         self.sigNextMeasPoint.connect(self._meas_point_loop, QtCore.Qt.QueuedConnection)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate the module properly.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method activation.
         """
 
 

--- a/logic/odmr_logic.py
+++ b/logic/odmr_logic.py
@@ -77,16 +77,8 @@ class ODMRLogic(GenericLogic):
         self.stopRequested = False
         self._clear_odmr_plots = False
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         self._mw_device = self.get_connector('microwave1')
@@ -197,11 +189,8 @@ class ODMRLogic(GenericLogic):
         self.MW_off()
         self._mw_device.set_ext_trigger(self.MW_trigger_pol)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         # save parameters stored in app state store
         self._statusVariables['clock_frequency'] = self._clock_frequency

--- a/logic/optimizer_logic.py
+++ b/logic/optimizer_logic.py
@@ -75,10 +75,8 @@ class OptimizerLogic(GenericLogic):
         # Keep track of who called the refocus
         self._caller_tag = ''
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param e: error code
 
         @return int: error code (0:OK, -1:error)
         """
@@ -187,10 +185,8 @@ class OptimizerLogic(GenericLogic):
         self._initialize_z_refocus_image()
         return 0
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Reverse steps of activation
-
-        @param e: error code
 
         @return int: error code (0:OK, -1:error)
         """
@@ -259,7 +255,7 @@ class OptimizerLogic(GenericLogic):
         """Starts the optimization scan around initial_pos
 
             @param [float, float, float] initial_pos:
-            @param str caller_tag: 
+            @param str caller_tag:
             @param str tag:
         """
         # checking if refocus corresponding to crosshair or corresponding to initial_pos

--- a/logic/pid_logic.py
+++ b/logic/pid_logic.py
@@ -53,7 +53,7 @@ class PIDLogic(GenericLogic):
         self.NumberOfSecondsLog = 100
         self.threadlock = Mutex()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
         """
         self._controller = self.get_connector('controller')
@@ -80,7 +80,7 @@ class PIDLogic(GenericLogic):
         self.timer.setInterval(self.timestep)
         self.timer.timeout.connect(self.loop)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Perform required deactivation. """
 
         # save parameters stored in ap state store

--- a/logic/poi_manager_logic.py
+++ b/logic/poi_manager_logic.py
@@ -217,7 +217,7 @@ class PoiManagerLogic(GenericLogic):
         # locking for thread safety
         self.threadlock = Mutex()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
         """
 
@@ -249,7 +249,7 @@ class PoiManagerLogic(GenericLogic):
         # A POI is active if the scanner is at that POI
         self.active_poi = None
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         return
 
     def user_move_deactivates_poi(self, tag):

--- a/logic/polarisation_dep_logic.py
+++ b/logic/polarisation_dep_logic.py
@@ -41,10 +41,8 @@ class PolarisationDepLogic(GenericLogic):
     signal_rotation_finished = QtCore.Signal()
     signal_start_rotation = QtCore.Signal()
 
-    def on_activate(self,e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-          @param object e: Fysom state change event
         """
 
         self._counter_logic = self.get_connector('counterlogic')
@@ -63,10 +61,8 @@ class PolarisationDepLogic(GenericLogic):
         self.signal_start_rotation.connect(self.rotate_polarisation, QtCore.Qt.QueuedConnection)
 
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-          @param object e: Fysom state change event
         """
         return
 

--- a/logic/pulse_analysis_logic.py
+++ b/logic/pulse_analysis_logic.py
@@ -49,16 +49,8 @@ class PulseAnalysisLogic(GenericLogic):
         self.norm_end_bin = 400
         self.current_method = 'mean_norm'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         # recall saved variables from file
         if 'current_method' in self._statusVariables:
@@ -98,11 +90,8 @@ class PulseAnalysisLogic(GenericLogic):
                                    'PulseAnalysisLogic.'.format(method, filename))
         return
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e:    Event class object from Fysom. A more detailed explanation can be found
-                            in method activation.
         """
         # Save variables to file
         self._statusVariables['current_method'] = self.current_method

--- a/logic/pulse_extraction_logic.py
+++ b/logic/pulse_extraction_logic.py
@@ -49,16 +49,8 @@ class PulseExtractionLogic(GenericLogic):
         self.min_laser_length = 200
         self.current_method = 'conv_deriv'
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         # recall saved variables from file
         if 'conv_std_dev' in self._statusVariables:
@@ -106,11 +98,8 @@ class PulseExtractionLogic(GenericLogic):
                                    'PulseExtractionLogic.'.format(method, filename))
         return
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         # Save variables to file
         self._statusVariables['conv_std_dev'] = self.conv_std_dev

--- a/logic/pulsed_extraction_external_logic.py
+++ b/logic/pulsed_extraction_external_logic.py
@@ -59,28 +59,15 @@ class PulsedExtractionExternalLogic(GenericLogic):
         # locking for thread safety
         self.threadlock = Mutex()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event
-                         the state before the event happens and the destination
-                         of the state which should be reached after the event
-                         has happen.
         """
-
-
         self._save_logic = self.get_connector('savelogic')
         self._pe_logic = self.get_connector('pulseextractionlogic')
         self._pa_logic = self.get_connector('pulseanalysislogic')
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         return
 

--- a/logic/pulsed_master_logic.py
+++ b/logic/pulsed_master_logic.py
@@ -143,10 +143,8 @@ class PulsedMasterLogic(GenericLogic):
             self.direct_write = False
 
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-          @param object e: Fysom state change event
         """
         self._measurement_logic = self.get_connector('pulsedmeasurementlogic')
         self._generator_logic = self.get_connector('sequencegeneratorlogic')
@@ -313,10 +311,9 @@ class PulsedMasterLogic(GenericLogic):
         self.status_dict['measurement_running'] = False
         self.status_dict['microwave_running'] = False
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """
 
-        @param e:
         @return:
         """
         # Save status variables

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -143,16 +143,8 @@ class PulsedMeasurementLogic(GenericLogic):
         self.signal_plot_x_fit = np.arange(10, dtype=float)
         self.signal_plot_y_fit = np.zeros(len(self.signal_plot_x_fit), dtype=float)
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         # get all the connectors:
         self._pulse_analysis_logic = self.get_connector('pulseanalysislogic')
@@ -241,11 +233,8 @@ class PulsedMeasurementLogic(GenericLogic):
         self.recalled_raw_data = None
         return
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate the module properly.
-
-        @param object e: Fysom.event object from Fysom class. A more detailed
-                         explanation can be found in the method activation.
         """
 
         if self.getState() != 'idle' and self.getState() != 'deactivated':

--- a/logic/qdplot_logic.py
+++ b/logic/qdplot_logic.py
@@ -59,16 +59,8 @@ class QdplotLogic(GenericLogic):
         # locking for thread safety
         self.threadlock = Mutex()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event
-                         the state before the event happens and the destination
-                         of the state which should be reached after the event
-                         has happen.
         """
         self.indep_vals = np.zeros((10,))
         self.depen_vals = np.zeros((10,))
@@ -81,11 +73,8 @@ class QdplotLogic(GenericLogic):
 
         self._save_logic = self.get_connector('savelogic')
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         return
 

--- a/logic/save_logic.py
+++ b/logic/save_logic.py
@@ -202,16 +202,8 @@ class SaveLogic(GenericLogic):
         for key in config.keys():
             self.log.info('{0}: {1}'.format(key, config[key]))
 
-    def on_activate(self, e=None):
+    def on_activate(self):
         """ Definition, configuration and initialisation of the SaveLogic.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look
-                         in the Base Class). This object contains the passed
-                         event the state before the event happens and the
-                         destination of the state which should be reached
-                         after the event has happen.
         """
         if self.log_into_daily_directory:
             # adds a log handler for logging into daily directory
@@ -225,7 +217,7 @@ class SaveLogic(GenericLogic):
         else:
             self._daily_loghandler = None
 
-    def on_deactivate(self, e=None):
+    def on_deactivate(self):
         if self._daily_loghandler is not None:
             # removes the log handler logging into the daily directory
             logging.getLogger().removeHandler(self._daily_loghandler)

--- a/logic/sequence_generator_logic.py
+++ b/logic/sequence_generator_logic.py
@@ -147,16 +147,8 @@ class SequenceGeneratorLogic(GenericLogic, SamplingFunctions, SamplesWriteMethod
         # a dictionary with all predefined generator methods and measurement sequence names
         self.generate_methods = None
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
         self._get_blocks_from_file()
         self._get_ensembles_from_file()
@@ -179,11 +171,8 @@ class SequenceGeneratorLogic(GenericLogic, SamplingFunctions, SamplesWriteMethod
         self.sigSettingsUpdated.emit(self.activation_config, self.laser_channel, self.sample_rate,
                                      self.amplitude_dict, self.waveform_format)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         self._statusVariables['activation_config'] = self.activation_config
         self._statusVariables['laser_channel'] = self.laser_channel

--- a/logic/simple_data_logic.py
+++ b/logic/simple_data_logic.py
@@ -34,20 +34,16 @@ class SimpleDataLogic(GenericLogic):
 
     sigRepeat = QtCore.Signal()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Prepare logic module for work.
-
-          @param object e: Fysom state change notification
         """
         self._data_logic = self.get_connector('simpledata')
         self.stopRequest = False
         self.bufferLength = 10000
         self.sigRepeat.connect(self.measureLoop, QtCore.Qt.QueuedConnection)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate modeule.
-
-          @param object e: Fysom state change notification
         """
         self.stopMeasure()
 

--- a/logic/singleshot_logic.py
+++ b/logic/singleshot_logic.py
@@ -79,16 +79,8 @@ class SingleShotLogic(GenericLogic):
 
         self.data_dict = None
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         self._fast_counter_device = self.get_connector('fastcounter')
@@ -108,7 +100,7 @@ class SingleShotLogic(GenericLogic):
         self.sigMeasurementFinished.connect(self.ssr_measurement_analysis)
 
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
 
         @param object e: Event class object from Fysom. A more detailed

--- a/logic/software_pid_controller.py
+++ b/logic/software_pid_controller.py
@@ -55,10 +55,8 @@ class SoftPIDController(GenericLogic, PIDControllerInterface):
         self.NumberOfSecondsLog = 100
         self.threadlock = Mutex()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-            @param object e: fysom state transition object
         """
         self._process = self.get_connector('process')
         self._control = self.get_connector('control')
@@ -114,10 +112,8 @@ class SoftPIDController(GenericLogic, PIDControllerInterface):
 
         self.timer.start(self.timestep)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Perform required deactivation.
-        
-            @param object e: fysom state transition object
         """
 
         # save parameters stored in app state store
@@ -190,7 +186,7 @@ class SoftPIDController(GenericLogic, PIDControllerInterface):
 
     def getSavingState(self):
         """ Find out if we are keeping data for saving later.
-        
+
             @return bool: whether module is saving process and control data
         """
         return self.savingState
@@ -218,7 +214,7 @@ class SoftPIDController(GenericLogic, PIDControllerInterface):
 
     def set_kp(self, kp):
         """ Set the proportional constant of the PID controller.
-            
+
             @prarm float kp: proportional constant of PID controller
         """
         self.kP = kp

--- a/logic/spectrum.py
+++ b/logic/spectrum.py
@@ -57,10 +57,8 @@ class SpectrumLogic(GenericLogic):
         # locking for thread safety
         self.threadlock = Mutex()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-          @param object e: Fysom state change event
         """
         self.spectrum_data = np.array([])
         self.diff_spec_data_mod_on = np.array([])
@@ -73,10 +71,8 @@ class SpectrumLogic(GenericLogic):
 
         self.sig_next_diff_loop.connect(self._loop_differential_spectrum)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-          @param object e: Fysom state change event
         """
         if self.getState() != 'idle' and self.getState() != 'deactivated':
             pass

--- a/logic/switch_logic.py
+++ b/logic/switch_logic.py
@@ -44,10 +44,8 @@ class SwitchLogic(GenericLogic):
                 self.connectors[connector]['class'] = 'SwitchInterface'
                 self.connectors[connector]['object'] = None
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Prepare logic module for work.
-
-          @param object e: Fysom state change notification
         """
         self.switches = dict()
         for connector in self.connectors:
@@ -56,10 +54,8 @@ class SwitchLogic(GenericLogic):
             for i in range(self.get_connector(connector).getNumberOfSwitches()):
                 self.switches[hwname][i] = self.get_connector(connector)
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deactivate modeule.
-
-          @param object e: Fysom state change notification
         """
         self.switches = dict()
 

--- a/logic/taskrunner.py
+++ b/logic/taskrunner.py
@@ -94,10 +94,8 @@ class TaskRunner(GenericLogic):
     sigLoadTasks = QtCore.Signal()
     sigCheckTasks = QtCore.Signal()
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialise task runner.
-
-        @param object e: Fysom state change notification
         """
         self.model = TaskListTableModel()
         self.model.rowsInserted.connect(self.modelChanged)
@@ -107,10 +105,8 @@ class TaskRunner(GenericLogic):
         self._manager.registerTaskRunner(self)
         self.sigLoadTasks.emit()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Shut down task runner.
-
-        @param object e: Fysom state change notification
         """
         self._manager.registerTaskRunner(None)
 

--- a/logic/trace_analysis_logic.py
+++ b/logic/trace_analysis_logic.py
@@ -64,16 +64,8 @@ class TraceAnalysisLogic(GenericLogic):
         self.hist_data = None
         self._hist_num_bins = None
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-        @param object e: Event class object from Fysom.
-                         An object created by the state machine module Fysom,
-                         which is connected to a specific event (have a look in
-                         the Base Class). This object contains the passed event,
-                         the state before the event happened and the destination
-                         of the state which should be reached after the event
-                         had happened.
         """
 
         self._counter_logic = self.get_connector('counterlogic1')
@@ -85,11 +77,8 @@ class TraceAnalysisLogic(GenericLogic):
 
         self.current_fit_function = 'No Fit'
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-        @param object e: Event class object from Fysom. A more detailed
-                         explanation can be found in method activation.
         """
         return
 

--- a/logic/wavemeter_logger_logic.py
+++ b/logic/wavemeter_logger_logic.py
@@ -149,10 +149,8 @@ class WavemeterLoggerLogic(GenericLogic):
         self.intern_xmin = 1.0e10
         self.current_wavelength = 0
 
-    def on_activate(self, e):
+    def on_activate(self):
         """ Initialisation performed during activation of the module.
-
-          @param object e: Fysom state change event
         """
         self._wavelength_data = []
 
@@ -190,10 +188,8 @@ class WavemeterLoggerLogic(GenericLogic):
         self.hardware_thread.start()
         self.last_point_time = time.time()
 
-    def on_deactivate(self, e):
+    def on_deactivate(self):
         """ Deinitialisation performed during deactivation of the module.
-
-          @param object e: Fysom state change event
         """
         if self.getState() != 'idle' and self.getState() != 'deactivated':
             self.stop_scanning()


### PR DESCRIPTION
This patch removes the fysom event parameters (usually called "e") from on_activate and on_deactivate methods.

Reason
I couldn't find a single qudi module which makes actually use of this parameter. This patch thus simplifies this matter.

What if?
If the fysom event is needed at some point in some specific module, it is possible to override the default callback for onactivate and ondeactivate events