### PR TITLE
Improve Appveyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ platform:
 install:
     - "powershell %APPVEYOR_BUILD_FOLDER%\\tools\\setup_conda_windows.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-    - "conda env remove --yes --name qudi"
+    - "conda env remove --yes --name qudi && exit 0"
     - "conda env create -f %APPVEYOR_BUILD_FOLDER%\\tools\\conda-env-win8-qt5.yml"
     - "activate qudi"
     - "python %APPVEYOR_BUILD_FOLDER%\\tools\\qudikernel.py install"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,7 +14,7 @@ platform:
     -x64
 
 install:
-    - "powershell %APPVEYOR_BUILD_FOLDER%\\tools\\setup_conda_windows.ps"
+    - "powershell %APPVEYOR_BUILD_FOLDER%\\tools\\setup_conda_windows.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "conda env remove --yes --name qudi"
     - "conda env create -f %APPVEYOR_BUILD_FOLDER%\\tools\\conda-env-win8-qt5.yml"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,3 +27,10 @@ build: false
 test_script:
     - sh "%APPVEYOR_BUILD_FOLDER%\\tools\\test.sh"
 
+artifacts:
+  - path: qudi.log
+    name: Qudi log file
+
+  - path: notebooks
+    name: test notebooks
+    type: zip

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ platform:
 install:
     - "powershell %APPVEYOR_BUILD_FOLDER%\\tools\\setup_conda_windows.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-    - "conda env remove --yes --name qudi" && exit 0
+    - 'conda env remove --yes --name qudi && exit 0'
     - "conda env create -f %APPVEYOR_BUILD_FOLDER%\\tools\\conda-env-win8-qt5.yml"
     - "activate qudi"
     - "python %APPVEYOR_BUILD_FOLDER%\\tools\\qudikernel.py install"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ platform:
 install:
     - "powershell %APPVEYOR_BUILD_FOLDER%\\tools\\setup_conda_windows.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-    - 'conda env remove --yes --name qudi && exit 0'
+    - '"conda env remove --yes --name qudi" && exit 0'
     - "conda env create -f %APPVEYOR_BUILD_FOLDER%\\tools\\conda-env-win8-qt5.yml"
     - "activate qudi"
     - "python %APPVEYOR_BUILD_FOLDER%\\tools\\qudikernel.py install"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ platform:
 install:
     - "powershell %APPVEYOR_BUILD_FOLDER%\\tools\\setup_conda_windows.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-    - '"conda env remove --yes --name qudi" && exit 0'
+    - 'conda env remove --yes --name qudi || exit 0'
     - "conda env create -f %APPVEYOR_BUILD_FOLDER%\\tools\\conda-env-win8-qt5.yml"
     - "activate qudi"
     - "python %APPVEYOR_BUILD_FOLDER%\\tools\\qudikernel.py install"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ platform:
 install:
     - "powershell %APPVEYOR_BUILD_FOLDER%\\tools\\setup_conda_windows.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-    - "conda env remove --yes --name qudi && exit 0"
+    - "conda env remove --yes --name qudi" && exit 0
     - "conda env create -f %APPVEYOR_BUILD_FOLDER%\\tools\\conda-env-win8-qt5.yml"
     - "activate qudi"
     - "python %APPVEYOR_BUILD_FOLDER%\\tools\\qudikernel.py install"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,16 +14,16 @@ platform:
     -x64
 
 install:
-    - "powershell %~dp0\\tools\\setup_conda_windows.ps"
+    - "powershell %APPVEYOR_BUILD_FOLDER%\\tools\\setup_conda_windows.ps"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "conda env remove --yes --name qudi"
-    - "conda env create -f %~dp0\\conda-env-win8-qt5.yml"
+    - "conda env create -f %APPVEYOR_BUILD_FOLDER%\\tools\\conda-env-win8-qt5.yml"
     - "activate qudi"
-    - "python %~dp0\\qudikernel.py install"
+    - "python %APPVEYOR_BUILD_FOLDER%\\tools\\qudikernel.py install"
 
 # Not a .NET project, we build in the install step instead
 build: false
 
 test_script:
-    - sh "tools\\test.sh"
+    - sh "%APPVEYOR_BUILD_FOLDER%\\tools\\test.sh"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,12 +14,12 @@ platform:
     -x64
 
 install:
-    - "powershell tools/setup_conda_windows.ps"
+    - "powershell %~dp0\\setup_conda_windows.ps"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "conda env remove --yes --name qudi"
     - "conda env create -f %~dp0\\conda-env-win8-qt5.yml"
     - "activate qudi"
-    - "python tools\\qudikernel.py install"
+    - "python %~dp0\\qudikernel.py install"
 
 # Not a .NET project, we build in the install step instead
 build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,51 +5,21 @@
 
 environment:
   global:
-      PYTHON: "C:\\conda"
-      CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
+      PYTHON: "C:\\miniconda"
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      # Used by atropy ci-helpers
-      CONDA_CHANNELS: "qttesting"
-
-  matrix:
-    # Qt4
-    - PYTHON_VERSION: "3.4"
-      CONDA_DEPENDENCIES: "jedi jupyter lxml matplotlib numpy openssl pip pygments pyzmq scipy sip six traitlets qt=4.8.7 pyqt=4.10.4"
-      PIP_DEPENDENCIES: "pyqtgraph fysom gitpython hdf5storage lmfit pydaqmx pyvisa pyvisa-py qtpy rpyc ruamel.yaml smmap"
-      QT_API: "pyqt4"
-    - PYTHON_VERSION: "3.5"
-      CONDA_DEPENDENCIES: "jedi jupyter lxml matplotlib numpy openssl pip pygments pyzmq scipy sip six traitlets qt=4.* pyqt=4.*"
-      PIP_DEPENDENCIES: "pyqtgraph fysom gitpython hdf5storage lmfit pydaqmx pyvisa pyvisa-py qtpy rpyc ruamel.yaml smmap"
-      QT_API: "pyqt4"
-    # Qt5
-    - PYTHON_VERSION: "3.4"
-      CONDA_DEPENDENCIES: "jedi jupyter lxml matplotlib numpy openssl pip pygments pyopengl pyzmq scipy sip six traitlets qt=5.* pyqt=5.*"
-      PIP_DEPENDENCIES: "pyqtgraph fysom gitpython hdf5storage lmfit pydaqmx pyvisa pyvisa-py qtpy rpyc ruamel.yaml smmap"
-      QT_API: "pyqt5"
-    - PYTHON_VERSION: "3.5"
-      CONDA_DEPENDENCIES: "jedi jupyter lxml matplotlib numpy openssl pip pygments pyopengl pyzmq scipy sip six traitlets qt=5.* pyqt=5.*"
-      PIP_DEPENDENCIES: "pyqtgraph fysom gitpython hdf5storage lmfit pydaqmx pyvisa pyvisa-py qtpy rpyc ruamel.yaml smmap"
-      QT_API: "pyqt5"
 
 platform:
     -x64
 
 install:
-    - "git clone git://github.com/astropy/ci-helpers.git"
-    - "powershell ci-helpers/appveyor/install-miniconda.ps1"
+    - "powershell tools/setup_conda_windows.ps"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-    - "activate test"
+    - "conda env remove --yes --name qudi"
+    - "conda env create -f %~dp0\\conda-env-win8-qt5.yml"
+    - "activate qudi"
     - "python tools\\qudikernel.py install"
-#    - ps: |
-#        if ($env:QT_API -eq "pyqt5") {
-#            push-location
-#            cmd /c 'git clone https://github.com/pyqtgraph/pyqtgraph.git pyqtgraph-github 2>&1'
-#            cd pyqtgraph-github
-#            cmd /c 'python setup.py install 2>&1'
-#            pop-location
-#        }
 
 # Not a .NET project, we build in the install step instead
 build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ platform:
     -x64
 
 install:
-    - "powershell %~dp0\\setup_conda_windows.ps"
+    - "powershell %~dp0\\tools\\setup_conda_windows.ps"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "conda env remove --yes --name qudi"
     - "conda env create -f %~dp0\\conda-env-win8-qt5.yml"

--- a/tools/setup_conda_windows.ps1
+++ b/tools/setup_conda_windows.ps1
@@ -1,0 +1,77 @@
+# Sample script to install anaconda under windows
+#
+# Authors: Stuart Mumford
+# Borrowed from: Olivier Grisel and Kyle Kastner
+# License: BSD 3 clause
+
+$MINICONDA_URL = "https://repo.continuum.io/miniconda/"
+
+function DownloadMiniconda ($version, $platform_suffix) {
+    $webclient = New-Object System.Net.WebClient
+    $filename = "Miniconda3-" + $version + "-Windows-" + $platform_suffix + ".exe"
+
+    $url = $MINICONDA_URL + $filename
+
+    $basedir = $pwd.Path + "\"
+    $filepath = $basedir + $filename
+    if (Test-Path $filename) {
+        Write-Host "Reusing" $filepath
+        return $filepath
+    }
+
+    # Download and retry up to 3 times in case of network transient errors.
+    Write-Host "Downloading" $filename "from" $url
+    $retry_attempts = 2
+    for($i=0; $i -lt $retry_attempts; $i++){
+        try {
+            $webclient.DownloadFile($url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+   }
+   if (Test-Path $filepath) {
+       Write-Host "File saved at" $filepath
+   } else {
+       # Retry once to get the error message if any at the last try
+       $webclient.DownloadFile($url, $filepath)
+   }
+   return $filepath
+}
+
+function InstallMiniconda ($miniconda_version, $architecture, $python_home) {
+    Write-Host "Installing miniconda" $miniconda_version "for" $architecture "bit architecture to" $python_home
+    if (Test-Path $python_home) {
+        Write-Host $python_home "already exists, skipping."
+        return $false
+    }
+    if ($architecture -eq "x86") {
+        $platform_suffix = "x86"
+    } else {
+        $platform_suffix = "x86_64"
+    }
+    $filepath = DownloadMiniconda $miniconda_version $platform_suffix
+    Write-Host "Installing" $filepath "to" $python_home
+    $args = "/InstallationType=AllUsers /S /AddToPath=1 /RegisterPython=1 /D=" + $python_home
+    Write-Host $filepath $args
+    Start-Process -FilePath $filepath -ArgumentList $args -Wait -Passthru
+    #Start-Sleep -s 15
+    if (Test-Path $python_home) {
+        Write-Host "Miniconda $miniconda_version ($architecture) installation complete"
+    } else {
+        Write-Host "Failed to install Python in $python_home"
+        Exit 1
+    }
+}
+
+# Install miniconda, if no version is given use the latest
+if (! $env:MINICONDA_VERSION) {
+   $env:MINICONDA_VERSION="latest"
+}
+
+InstallMiniconda $env:MINICONDA_VERSION $env:PLATFORM $env:PYTHON
+
+# Set environment variables
+$env:PATH = "${env:PYTHON};${env:PYTHON}\Scripts;" + $env:PATH
+


### PR DESCRIPTION
* use tools/conda-env-win8-qt5.yml to install known-good python environment
* no more python 3.4/3.5 Qt4/Qt5 tests. 3.6 is official now.
* produces log and zipped test notebooks as artifacts
* get rid of astropy ci-helpers
* simplify .appveyor.yml