### PR TITLE
Display of fit parameters in pulsedmeasurement gui

### DIFF
--- a/logic/fitmethods/decaylikemethods.py
+++ b/logic/fitmethods/decaylikemethods.py
@@ -216,13 +216,7 @@ def make_decayexponential_fit(self, x_axis, data, estimator, units=None, add_par
                                     'error': result.params['offset'].stderr,
                                     'unit': units[1]}                               #offset
 
-    #result_str_dict['Beta'] = {'value': result.params['beta'].value,
-    #                                'error': result.params['beta'].stderr,
-    #                                'unit': units[0]}                               #Beta (exponent of exponential exponent)
-
-
     result.result_str_dict = result_str_dict
-
 
     return result
 
@@ -343,13 +337,11 @@ def make_decayexponentialstretched_fit(self, x_axis, data, estimator, units=None
                                     'error': result.params['offset'].stderr,
                                     'unit': units[1]}                               #offset
 
-    #result_str_dict['Beta'] = {'value': result.params['beta'].value,
-    #                                'error': result.params['beta'].stderr,
-    #                                'unit': units[0]}                               #Beta (exponent of exponential exponent)
-
+    result_str_dict['Beta'] = {'value': result.params['beta'].value,
+                                    'error': result.params['beta'].stderr,
+                                    'unit': ''}                               #Beta (exponent of exponential exponent)
 
     result.result_str_dict = result_str_dict
-
 
     return result
 

--- a/logic/fitmethods/decaylikemethods.py
+++ b/logic/fitmethods/decaylikemethods.py
@@ -119,7 +119,16 @@ def make_decayexponential_model(self, prefix=None):
     """
 
     bare_exp_model, params = self.make_bareexponentialdecay_model(prefix=prefix)
+
+
+
+
     amplitude_model, params = self.make_amplitude_model(prefix=prefix)
+
+
+
+
+
     constant_model, params = self.make_constant_model(prefix=prefix)
 
     exponentialdecay_model = amplitude_model * bare_exp_model + constant_model
@@ -188,7 +197,35 @@ def make_decayexponential_fit(self, x_axis, data, estimator, units=None, add_par
         result = exponentialdecay.fit(data, x=x_axis, params=params)
         self.log.warning('The exponentialdecay with offset fit did not work. '
                        'Message: {}'.format(str(result.message)))
+
+
+    if units is None:
+        units = ['arb. unit', 'arb. unit']
+
+    result_str_dict = dict()  #create result string for gui
+
+    result_str_dict['Amplitude'] = {'value': result.params['amplitude'].value,
+                                    'error': result.params['amplitude'].stderr,
+                                    'unit': units[1]}                               #amplitude
+
+    result_str_dict['Lifetime'] = {'value': result.params['lifetime'].value,
+                                    'error': result.params['lifetime'].stderr,
+                                    'unit': units[0]}                               #lifetime
+
+    result_str_dict['Offset'] = {'value': result.params['offset'].value,
+                                    'error': result.params['offset'].stderr,
+                                    'unit': units[1]}                               #offset
+
+    #result_str_dict['Beta'] = {'value': result.params['beta'].value,
+    #                                'error': result.params['beta'].stderr,
+    #                                'unit': units[0]}                               #Beta (exponent of exponential exponent)
+
+
+    result.result_str_dict = result_str_dict
+
+
     return result
+
 
 def estimate_decayexponential(self, x_axis, data, params):
     """ Estimation of the initial values for an exponential decay function.
@@ -288,6 +325,32 @@ def make_decayexponentialstretched_fit(self, x_axis, data, estimator, units=None
         result = stret_exp_decay_offset.fit(data, x=x_axis, params=params)
         self.log.warning('The double exponentialdecay with offset fit did not work. '
                        'Message: {}'.format(str(result.message)))
+
+    if units is None:
+        units = ['arb. unit', 'arb. unit']
+
+    result_str_dict = dict()  #create result string for gui
+
+    result_str_dict['Amplitude'] = {'value': result.params['amplitude'].value,
+                                    'error': result.params['amplitude'].stderr,
+                                    'unit': units[1]}                               #amplitude
+
+    result_str_dict['Lifetime'] = {'value': result.params['lifetime'].value,
+                                    'error': result.params['lifetime'].stderr,
+                                    'unit': units[0]}                               #lifetime
+
+    result_str_dict['Offset'] = {'value': result.params['offset'].value,
+                                    'error': result.params['offset'].stderr,
+                                    'unit': units[1]}                               #offset
+
+    #result_str_dict['Beta'] = {'value': result.params['beta'].value,
+    #                                'error': result.params['beta'].stderr,
+    #                                'unit': units[0]}                               #Beta (exponent of exponential exponent)
+
+
+    result.result_str_dict = result_str_dict
+
+
     return result
 
 def estimate_decayexponentialstretched(self, x_axis, data, params):

--- a/logic/fitmethods/gaussianlikemethods.py
+++ b/logic/fitmethods/gaussianlikemethods.py
@@ -330,7 +330,35 @@ def make_gaussian_fit(self, x_axis, data, estimator, units=None, add_params=None
         self.log.warning('The 1D gaussian peak fit did not work. Error '
                        'message: {0}\n'.format(result.message))
 
+        if units is None:
+            units = ['arb. unit', 'arb. unit']
+
+    result_str_dict = OrderedDict()  # create result string for gui
+
+    #result_str_dict['Amplitude'] = {'value': result.params['amplitude'].value,
+    #                                    'error': result.params['amplitude'].stderr,
+    #                                    'unit': units[1]}                               #amplitude
+
+    result_str_dict['Center'] = {'value': result.params['center'].value,
+                                        'error': result.params['center'].stderr,
+                                        'unit': units[0]}                               #center
+
+    #result_str_dict['Standard deviation'] = {'value': result.params['sigma'].value,
+    #                                'error': result.params['sigma'].stderr,
+    #                                'unit': units[0]}                               #standart deviation
+
+    result_str_dict['Linewidth'] = {'value': result.params['fwhm'].value,
+                                        'error': result.params['fwhm'].stderr,
+                                        'unit': units[0]}                               #FWHM
+
+    result_str_dict['Contrast'] = {'value': result.params['contrast'].value,
+                                        'error': result.params['contrast'].stderr,
+                                        'unit': '%'}                                    #Contrast
+    result.result_str_dict = result_str_dict
+
     return result
+
+
 
 def estimate_gaussian_peak(self, x_axis, data, params):
     """ Provides a gaussian offset peak estimator.
@@ -555,7 +583,7 @@ def make_gaussiandouble_fit(self, x_axis, data, estimator,
                           with best fit with given axis,...
     """
     if units is None:
-        units = ['fucking units', 'other fucking units']
+        units = ['arb. unit', 'arb. unit']
 
     model, params = self.make_multiplegaussianoffset_model(no_of_functions=2)
 

--- a/logic/fitmethods/gaussianlikemethods.py
+++ b/logic/fitmethods/gaussianlikemethods.py
@@ -330,7 +330,7 @@ def make_gaussian_fit(self, x_axis, data, estimator, units=None, add_params=None
         self.log.warning('The 1D gaussian peak fit did not work. Error '
                        'message: {0}\n'.format(result.message))
 
-        if units is None:
+    if units is None:
             units = ['arb. unit', 'arb. unit']
 
     result_str_dict = OrderedDict()  # create result string for gui
@@ -339,9 +339,9 @@ def make_gaussian_fit(self, x_axis, data, estimator, units=None, add_params=None
     #                                    'error': result.params['amplitude'].stderr,
     #                                    'unit': units[1]}                               #amplitude
 
-    result_str_dict['Center'] = {'value': result.params['center'].value,
+    result_str_dict['Position'] = {'value': result.params['center'].value,
                                         'error': result.params['center'].stderr,
-                                        'unit': units[0]}                               #center
+                                        'unit': units[0]}                               #position
 
     #result_str_dict['Standard deviation'] = {'value': result.params['sigma'].value,
     #                                'error': result.params['sigma'].stderr,
@@ -476,7 +476,6 @@ def estimate_gaussian_dip(self, x_axis, data, params):
 
 def make_gaussianlinearoffset_fit(self, x_axis, data, estimator, units=None, add_params=None):
     """ Perform a 1D gaussian peak fit with linear offset on the provided data.
-
     @param numpy.array x_axis: 1D axis values
     @param numpy.array data: 1D data, should have the same dimension as x_axis.
     @param method estimator: Pointer to the estimator method
@@ -484,7 +483,6 @@ def make_gaussianlinearoffset_fit(self, x_axis, data, estimator, units=None, add
     @param Parameters or dict add_params: optional, additional parameters of
                 type lmfit.parameter.Parameters, OrderedDict or dict for the fit
                 which will be used instead of the values from the estimator.
-
     @return object model: lmfit.model.ModelFit object, all parameters
                           provided about the fitting, like: success,
                           initial fitting values, best fitting values, data
@@ -502,6 +500,36 @@ def make_gaussianlinearoffset_fit(self, x_axis, data, estimator, units=None, add
     except:
         self.log.warning('The 1D gaussian peak fit did not work. Error '
                        'message: {0}\n'.format(result.message))
+    if units is None:
+            units = ['arb. unit', 'arb. unit']
+
+    result_str_dict = OrderedDict()  # create result string for gui
+
+    #result_str_dict['Amplitude'] = {'value': result.params['amplitude'].value,
+    #                                    'error': result.params['amplitude'].stderr,
+    #                                    'unit': units[1]}                               #amplitude
+
+    result_str_dict['Position'] = {'value': result.params['center'].value,
+                                        'error': result.params['center'].stderr,
+                                        'unit': units[0]}                               #position
+
+    #result_str_dict['Standard deviation'] = {'value': result.params['sigma'].value,
+    #                                'error': result.params['sigma'].stderr,
+    #                                'unit': units[0]}                               #standart deviation
+
+    result_str_dict['Linewidth'] = {'value': result.params['fwhm'].value,
+                                        'error': result.params['fwhm'].stderr,
+                                        'unit': units[0]}                               #FWHM
+
+    result_str_dict['Contrast'] = {'value': result.params['contrast'].value,
+                                        'error': result.params['contrast'].stderr,
+                                        'unit': '%'}                                    #Contrast
+
+    #result_str_dict['Slope'] = {'value': result.params['slope'].value,
+    #                                    'error': result.params['slope'].stderr,
+    #                                    'unit': ''}                                    #Slope
+
+    result.result_str_dict = result_str_dict
 
     return result
 

--- a/logic/fitmethods/poissonianlikemethods.py
+++ b/logic/fitmethods/poissonianlikemethods.py
@@ -188,6 +188,21 @@ def make_poissonian_fit(self, x_axis, data, estimator, units=None, add_params=No
         result = poissonian_model.fit(data, x=x_axis, params=params)
         print(result.message)
 
+    if units is None:
+        units = ['arb. unit', 'arb. unit']
+
+    result_str_dict = dict()  # create result string for gui   oder OrderedDict()
+
+    result_str_dict['Amplitude'] = {'value': result.params['amplitude'].value,
+                                    'error': result.params['amplitude'].stderr,
+                                    'unit': units[1]}     # Amplitude
+
+    result_str_dict['Event rate'] = {'value': result.params['mu'].value,
+                                    'error': result.params['mu'].stderr,
+                                    'unit': units[0]}      # event rate
+
+    result.result_str_dict = result_str_dict
+
     return result
 
 

--- a/logic/fitmethods/sinemethods.py
+++ b/logic/fitmethods/sinemethods.py
@@ -276,7 +276,6 @@ def make_sinedoublewithtwoexpdecay_model(self, prefix=None):
     @return tuple: (object model, object params), for more description see in
                    the method make_baresine_model.
     """
-
     if prefix is None:
         add_text = ''
     else:
@@ -287,10 +286,10 @@ def make_sinedoublewithtwoexpdecay_model(self, prefix=None):
 
     constant_model, params = self.make_constant_model(prefix=prefix)
 
-    two_sine_exp_decay_offset = sine_exp_decay_model1 + sine_exp_decay_model2 + constant_model
-    params = two_sine_exp_decay_offset.make_params()
+    sinedoublewithtwoexpdecay = sine_exp_decay_model1 + sine_exp_decay_model2 + constant_model
+    params = sinedoublewithtwoexpdecay.make_params()
 
-    return two_sine_exp_decay_offset, params
+    return sinedoublewithtwoexpdecay, params
 
 #############################################
 # Sum of three individual Sinus with offset #
@@ -662,6 +661,33 @@ def make_sineexponentialdecay_fit(self, x_axis, data, estimator, units=None, add
         self.log.error('The sineexponentialdecayoffset fit did not work.\n'
                      'Error message: {0}'.format(result.message))
 
+    if units is None:
+        units = ['arb. unit', 'arb. unit']
+
+    result_str_dict = dict()
+
+    result_str_dict['Period'] = {'value': 1./result.params['frequency'].value,
+                                 'error': 1./result.params['frequency'].stderr,
+                                 'unit': units[0]}
+    result_str_dict['Amplitude'] = {'value': result.params['amplitude'].value,
+                                    'error': result.params['amplitude'].stderr,
+                                    'unit': units[1]}
+    result_str_dict['Phase'] = {'value': result.params['phase'].value,
+                                'error': result.params['phase'].stderr,
+                                'unit': 'deg'}
+    result_str_dict['Offset'] = {'value': result.params['offset'].value,
+                                 'error': result.params['offset'].stderr,
+                                 'unit': units[1]}
+
+    result_str_dict['Lifetime'] = {'value': result.params['lifetime'].value,
+                                 'error': result.params['lifetime'].stderr,
+                                 'unit': units[0]}
+
+    result_str_dict['Beta'] = {'value': result.params['beta'].value,
+                                   'error': result.params['beta'].stderr,
+                                   'unit': ''}
+
+    result.result_str_dict = result_str_dict
 
     return result
 
@@ -786,6 +812,34 @@ def make_sinestretchedexponentialdecay_fit(self, x_axis, data, estimator, units=
         self.log.error('The sineexponentialdecay fit did not work.\n'
                      'Error message: {0}'.format(result.message))
 
+    if units is None:
+        units = ['arb. unit', 'arb. unit']
+
+    result_str_dict = dict()
+
+    result_str_dict['Period'] = {'value': 1./result.params['frequency'].value,
+                                 'error': 1./result.params['frequency'].stderr,
+                                 'unit': units[0]}
+    result_str_dict['Amplitude'] = {'value': result.params['amplitude'].value,
+                                    'error': result.params['amplitude'].stderr,
+                                    'unit': units[1]}
+    result_str_dict['Phase'] = {'value': result.params['phase'].value,
+                                'error': result.params['phase'].stderr,
+                                'unit': 'deg'}
+    result_str_dict['Offset'] = {'value': result.params['offset'].value,
+                                 'error': result.params['offset'].stderr,
+                                 'unit': units[1]}
+
+    result_str_dict['Lifetime'] = {'value': result.params['lifetime'].value,
+                                 'error': result.params['lifetime'].stderr,
+                                 'unit': units[0]}
+
+    result_str_dict['Beta'] = {'value': result.params['beta'].value,
+                                   'error': result.params['beta'].stderr,
+                                   'unit': ''}
+
+    result.result_str_dict = result_str_dict
+
     return result
 
 def estimate_sinestretchedexponentialdecay(self, x_axis, data, params):
@@ -842,7 +896,43 @@ def make_sinedouble_fit(self, x_axis, data, estimator, units=None, add_params=No
                        'Error message: {}'.format(str(result.message)))
         result = two_sine_offset.fit(data, x=x_axis, params=params)
 
+    if units is None:
+        units = ['arb. unit', 'arb. unit']
+
+    result_str_dict = dict()  # create result string for gui or OrderedDict()
+
+    result_str_dict['Period 1'] = {'value': 1. / result.params['s1_frequency'].value,
+                                   'error': 1. / result.params['s1_frequency'].stderr,
+                                   'unit': units[0]}
+
+    result_str_dict['Period 2'] = {'value': 1. / result.params['s2_frequency'].value,
+                                   'error': 1. / result.params['s2_frequency'].stderr,
+                                   'unit': units[0]}
+
+    result_str_dict['Amplitude 1'] = {'value': result.params['s1_amplitude'].value,
+                                      'error': result.params['s1_amplitude'].stderr,
+                                      'unit': units[1]}
+
+    result_str_dict['Amplitude 2'] = {'value': result.params['s2_amplitude'].value,
+                                      'error': result.params['s2_amplitude'].stderr,
+                                      'unit': units[1]}
+
+    result_str_dict['Phase 1'] = {'value': result.params['s1_phase'].value,
+                                  'error': result.params['s1_phase'].stderr,
+                                  'unit': 'deg'}
+
+    result_str_dict['Phase 2'] = {'value': result.params['s2_phase'].value,
+                                  'error': result.params['s2_phase'].stderr,
+                                  'unit': 'deg'}
+
+    result_str_dict['Offset'] = {'value': result.params['offset'].value,
+                                 'error': result.params['offset'].stderr,
+                                 'unit': units[1]}
+
+    result.result_str_dict = result_str_dict
+
     return result
+
 
 def estimate_sinedouble(self, x_axis, data, params):
     """ Provides an estimator for initial values of two sines with offset fitting.
@@ -917,6 +1007,45 @@ def make_sinedoublewithexpdecay_fit(self, x_axis, data, estimator, units=None, a
                 'Error message: {}'.format(str(result.message)))
         result = two_sine_exp_decay_offset.fit(data, x=x_axis, params=params)
 
+    if units is None:
+        units = ['arb. unit', 'arb. unit']
+
+    result_str_dict = dict()  # create result string for gui or OrderedDict()
+
+    result_str_dict['Period 1'] = {'value': 1. / result.params['s1_frequency'].value,
+                                   'error': 1. / result.params['s1_frequency'].stderr,
+                                   'unit': units[0]}
+
+    result_str_dict['Period 2'] = {'value': 1. / result.params['s2_frequency'].value,
+                                   'error': 1. / result.params['s2_frequency'].stderr,
+                                   'unit': units[0]}
+
+    result_str_dict['Amplitude 1'] = {'value': result.params['s1_amplitude'].value,
+                                      'error': result.params['s1_amplitude'].stderr,
+                                      'unit': units[1]}
+
+    result_str_dict['Amplitude 2'] = {'value': result.params['s2_amplitude'].value,
+                                      'error': result.params['s2_amplitude'].stderr,
+                                      'unit': units[1]}
+
+    result_str_dict['Phase 1'] = {'value': result.params['s1_phase'].value,
+                                  'error': result.params['s1_phase'].stderr,
+                                  'unit': 'deg'}
+
+    result_str_dict['Phase 2'] = {'value': result.params['s2_phase'].value,
+                                  'error': result.params['s2_phase'].stderr,
+                                  'unit': 'deg'}
+
+    result_str_dict['Offset'] = {'value': result.params['offset'].value,
+                                 'error': result.params['offset'].stderr,
+                                 'unit': units[1]}
+
+    result_str_dict['Lifetime'] = {'value': result.params['lifetime'].value,
+                                 'error': result.params['lifetime'].stderr,
+                                 'unit': units[0]}
+
+    result.result_str_dict = result_str_dict
+
     return result
 
 def estimate_sinedoublewithexpdecay(self, x_axis, data, params):
@@ -972,7 +1101,7 @@ def estimate_sinedoublewithexpdecay(self, x_axis, data, params):
 # Sum of two individual Sinus exponential decays (and offset) #
 ###############################################################
 
-def make_sinedoublewithtwoexpdecay_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_sinedoublewithtwoexpdecay_fit(self, x_axis, data, estimator, units=None, add_params=None): #Problem with stderr: x.stderr will always be 0 for this model
     """ Perform a two sine with two exponential decay and offset fit on the
         provided data.
 
@@ -1001,6 +1130,41 @@ def make_sinedoublewithtwoexpdecay_fit(self, x_axis, data, estimator, units=None
         self.log.warning('The sinedoublewithtwoexpdecay fit did not work. '
                 'Error message: {}'.format(str(result.message)))
         result = two_sine_two_exp_decay_offset.fit(data, x=x_axis, params=params)
+
+    if units is None:
+        units = ['arb. unit', 'arb. unit']
+
+    result_str_dict = dict()  # create result string for gui or OrderedDict()
+
+    result_str_dict['Period 1'] = {'value': 1. / result.params['e1_frequency'].value,
+                                                                      'unit': units[0]}
+
+    result_str_dict['Period 2'] = {'value': 1. / result.params['e2_frequency'].value,
+                                                                     'unit': units[0]}
+
+    result_str_dict['Amplitude 1'] = {'value': result.params['e1_amplitude'].value,
+                                                                            'unit': units[1]}
+
+    result_str_dict['Amplitude 2'] = {'value': result.params['e2_amplitude'].value,
+                                                                           'unit': units[1]}
+
+    result_str_dict['Phase 1'] = {'value': result.params['e1_phase'].value,
+                                                                    'unit': 'deg'}
+
+    result_str_dict['Phase 2'] = {'value': result.params['e2_phase'].value,
+                                                                    'unit': 'deg'}
+
+    result_str_dict['Lifetime 1'] = {'value': result.params['e1_lifetime'].value,
+                                                                  'unit': units[0]}
+
+    result_str_dict['Lifetime 2'] = {'value': result.params['e1_lifetime'].value,
+                                                                  'unit': units[0]}
+
+
+    result_str_dict['Offset'] = {'value': result.params['offset'].value,
+                                                                  'unit': units[1]}
+
+    result.result_str_dict = result_str_dict
 
     return result
 
@@ -1087,6 +1251,53 @@ def make_sinetriple_fit(self, x_axis, data, estimator, units=None, add_params=No
                        'Error message: {}'.format(str(result.message)))
         result = two_sine_offset.fit(data, x=x_axis, params=params)
 
+    if units is None:
+        units = ['arb. unit', 'arb. unit']
+
+    result_str_dict = dict()  # create result string for gui or OrderedDict()
+
+    result_str_dict['Period 1'] = {'value': 1. / result.params['s1_frequency'].value,
+                                   'error': 1. / result.params['s1_frequency'].stderr,
+                                   'unit': units[0]}
+
+    result_str_dict['Period 2'] = {'value': 1. / result.params['s2_frequency'].value,
+                                   'error': 1. / result.params['s2_frequency'].stderr,
+                                   'unit': units[0]}
+
+    result_str_dict['Period 3'] = {'value': 1. / result.params['s3_frequency'].value,
+                                   'error': 1. / result.params['s3_frequency'].stderr,
+                                   'unit': units[0]}
+
+    result_str_dict['Amplitude 1'] = {'value': result.params['s1_amplitude'].value,
+                                      'error': result.params['s1_amplitude'].stderr,
+                                      'unit': units[1]}
+
+    result_str_dict['Amplitude 2'] = {'value': result.params['s2_amplitude'].value,
+                                      'error': result.params['s2_amplitude'].stderr,
+                                      'unit': units[1]}
+
+    result_str_dict['Amplitude 3'] = {'value': result.params['s3_amplitude'].value,
+                                      'error': result.params['s3_amplitude'].stderr,
+                                      'unit': units[1]}
+
+    result_str_dict['Phase 1'] = {'value': result.params['s1_phase'].value,
+                                  'error': result.params['s1_phase'].stderr,
+                                  'unit': 'deg'}
+
+    result_str_dict['Phase 2'] = {'value': result.params['s2_phase'].value,
+                                  'error': result.params['s2_phase'].stderr,
+                                  'unit': 'deg'}
+
+    result_str_dict['Phase 3'] = {'value': result.params['s3_phase'].value,
+                                  'error': result.params['s3_phase'].stderr,
+                                  'unit': 'deg'}
+
+    result_str_dict['Offset'] = {'value': result.params['offset'].value,
+                                 'error': result.params['offset'].stderr,
+                                 'unit': units[1]}
+
+    result.result_str_dict = result_str_dict
+
     return result
 
 def estimate_sinetriple(self, x_axis, data, params):
@@ -1167,6 +1378,57 @@ def make_sinetriplewithexpdecay_fit(self, x_axis, data, estimator, units=None, a
         self.log.warning('The sinetriplewithexpdecay fit did not work. '
                        'Error message: {}'.format(str(result.message)))
         result = three_sine_exp_decay_offset.fit(data, x=x_axis, params=params)
+
+    if units is None:
+        units = ['arb. unit', 'arb. unit']
+
+    result_str_dict = dict()  # create result string for gui or OrderedDict()
+
+    result_str_dict['Period 1'] = {'value': 1. / result.params['s1_frequency'].value,
+                                  'error': 1. / result.params['s1_frequency'].stderr,
+                                   'unit': units[0]}
+
+    result_str_dict['Period 2'] = {'value': 1. / result.params['s2_frequency'].value,
+                                   'error': 1. / result.params['s2_frequency'].stderr,
+                                   'unit': units[0]}
+
+    result_str_dict['Period 3'] = {'value': 1. / result.params['s3_frequency'].value,
+                                   'error': 1. / result.params['s3_frequency'].stderr,
+                                   'unit': units[0]}
+
+    result_str_dict['Amplitude 1'] = {'value': result.params['s1_amplitude'].value,
+                                      'error': result.params['s1_amplitude'].stderr,
+                                      'unit': units[1]}
+
+    result_str_dict['Amplitude 2'] = {'value': result.params['s2_amplitude'].value,
+                                      'error': result.params['s2_amplitude'].stderr,
+                                      'unit': units[1]}
+
+    result_str_dict['Amplitude 3'] = {'value': result.params['s3_amplitude'].value,
+                                      'error': result.params['s3_amplitude'].stderr,
+                                      'unit': units[1]}
+
+    result_str_dict['Phase 1'] = {'value': result.params['s1_phase'].value,
+                                  'error': result.params['s1_phase'].stderr,
+                                  'unit': 'deg'}
+
+    result_str_dict['Phase 2'] = {'value': result.params['s2_phase'].value,
+                                  'error': result.params['s2_phase'].stderr,
+                                  'unit': 'deg'}
+
+    result_str_dict['Phase 3'] = {'value': result.params['s3_phase'].value,
+                                  'error': result.params['s3_phase'].stderr,
+                                  'unit': 'deg'}
+
+    result_str_dict['Lifetime'] = {'value': result.params['lifetime'].value,
+                                 'error': result.params['lifetime'].stderr,
+                                 'unit': units[0]}
+
+    result_str_dict['Offset'] = {'value': result.params['offset'].value,
+                                 'error': result.params['offset'].stderr,
+                                 'unit': units[1]}
+
+    result.result_str_dict = result_str_dict
 
     return result
 
@@ -1265,6 +1527,65 @@ def make_sinetriplewiththreeexpdecay_fit(self, x_axis, data, estimator, units=No
         self.log.warning('The twosinetwoexpdecayoffset fit did not work. '
                 'Error message: {}'.format(str(result.message)))
         result = three_sine_three_exp_decay_offset.fit(data, x=x_axis, params=params)
+
+    if units is None:
+        units = ['arb. unit', 'arb. unit']
+
+    result_str_dict = dict()  # create result string for gui or OrderedDict()
+
+    result_str_dict['Period 1'] = {'value': 1. / result.params['e1_frequency'].value,
+                                   'error': 1. / result.params['e1_frequency'].stderr,
+                                   'unit': units[0]}
+
+    result_str_dict['Period 2'] = {'value': 1. / result.params['e2_frequency'].value,
+                                   'error': 1. / result.params['e2_frequency'].stderr,
+                                   'unit': units[0]}
+
+    result_str_dict['Period 3'] = {'value': 1. / result.params['e3_frequency'].value,
+                                   'error': 1. / result.params['e3_frequency'].stderr,
+                                   'unit': units[0]}
+
+    result_str_dict['Amplitude 1'] = {'value': result.params['e1_amplitude'].value,
+                                      'error': result.params['e1_amplitude'].stderr,
+                                      'unit': units[1]}
+
+    result_str_dict['Amplitude 2'] = {'value': result.params['e2_amplitude'].value,
+                                      'error': result.params['e2_amplitude'].stderr,
+                                      'unit': units[1]}
+
+    result_str_dict['Amplitude 3'] = {'value': result.params['e3_amplitude'].value,
+                                      'error': result.params['e3_amplitude'].stderr,
+                                      'unit': units[1]}
+
+    result_str_dict['Phase 1'] = {'value': result.params['e1_phase'].value,
+                                  'error': result.params['e1_phase'].stderr,
+                                  'unit': 'deg'}
+
+    result_str_dict['Phase 2'] = {'value': result.params['e2_phase'].value,
+                                  'error': result.params['e2_phase'].stderr,
+                                  'unit': 'deg'}
+
+    result_str_dict['Phase 3'] = {'value': result.params['e3_phase'].value,
+                                  'error': result.params['e3_phase'].stderr,
+                                  'unit': 'deg'}
+
+    result_str_dict['Lifetime 1'] = {'value': result.params['e1_lifetime'].value,
+                                   'error': result.params['e1_lifetime'].stderr,
+                                   'unit': units[0]}
+
+    result_str_dict['Lifetime 2'] = {'value': result.params['e2_lifetime'].value,
+                                     'error': result.params['e2_lifetime'].stderr,
+                                     'unit': units[0]}
+
+    result_str_dict['Lifetime 3'] = {'value': result.params['e3_lifetime'].value,
+                                     'error': result.params['e3_lifetime'].stderr,
+                                     'unit': units[0]}
+
+    result_str_dict['Offset'] = {'value': result.params['offset'].value,
+                                 'error': result.params['offset'].stderr,
+                                 'unit': units[1]}
+
+    result.result_str_dict = result_str_dict
 
     return result
 


### PR DESCRIPTION
## Description
The fit parameters and their standard deviation will now be shown correctly in the pulsedmeasurement gui. I added a string to the result object in the make_fit methods, which contains these parameters.
Some parameters are commented out, because I did not consider them as an important result. 
However, these parameters can also be displayed by deleting the # in front of the following object (example):

#result_str_dict['Contrast'] = {'value': result.params['contrast'].value,
#                                        'error': result.params['contrast'].stderr,
#                                        'unit': '%'}. (in make_fit methods) 

Note that the doublesinewithtwoexpdecay method gives a standard deviation of 0, therefore this method has no error displayed in the gui.

## Motivation and Context
Did not show the results before.

## How Has This Been Tested?
Test runs for each single fit.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentaion, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
