### PR TITLE
[WIP] saving of status variables

### DIFF
--- a/core/manager.py
+++ b/core/manager.py
@@ -568,7 +568,7 @@ class Manager(QtCore.QObject):
                 instanceName, baseName, className))
 
         # Create object from class
-        instance = modclass(manager=self, name=instanceName, config=configuration)
+        instance = modclass(manager=self, base=baseName, name=instanceName, config=configuration)
 
         with self.lock:
             self.tree['loaded'][baseName][instanceName] = instance
@@ -912,7 +912,6 @@ class Manager(QtCore.QObject):
             logger.error('{0} module {1} not deactivated'.format(base, name))
             return
         try:
-            module.setStatusVariables(self.loadStatusVariables(base, name))
             # start main loop for qt objects
             if base == 'logic':
                 modthread = self.tm.newThread('mod-{0}-{1}'.format(base, name))
@@ -975,7 +974,6 @@ class Manager(QtCore.QObject):
             else:
                 success = module.deactivate() # runs on_deactivate in main thread
 
-            self.saveStatusVariables(base, name, module.getStatusVariables())
             logger.debug('Deactivation success: {}'.format(success))
         except:
             logger.exception('{0} module {1}: error during deactivation:'.format(base, name))
@@ -1232,60 +1230,12 @@ class Manager(QtCore.QObject):
             os.makedirs(appStatusDir)
         return appStatusDir
 
-    @QtCore.Slot(str, str, dict)
-    def saveStatusVariables(self, base, module, variables):
-        """ If a module has status variables, save them to a file in the application status directory.
-
-          @param str base: the module category
-          @param str module: the unique module name
-          @param dict variables: a dictionary of status variable names and values
-        """
-        if len(variables) > 0:
-            try:
-                statusdir = self.getStatusDir()
-                classname = self.tree['loaded'][base][module].__class__.__name__
-                filename = os.path.join(statusdir,
-                    'status-{0}_{1}_{2}.cfg'.format(classname, base, module))
-                config.save(filename, variables)
-            except:
-                print(variables)
-                logger.exception('Failed to save status variables of module '
-                        '{0}.{1}:\n{2}'.format(base, module, repr(variables)))
-
-    def loadStatusVariables(self, base, module):
-        """ If a status variable file exists for a module, load it into a dictionary.
-
-          @param str base: the module category
-          @param str module: the unique mduel name
-
-          @return dict: dictionary of satus variable names and values
-        """
-        try:
-            statusdir = self.getStatusDir()
-            classname = self.tree['loaded'][base][module].__class__.__name__
-            filename = os.path.join(
-                statusdir, 'status-{0}_{1}_{2}.cfg'.format(classname, base, module))
-            if os.path.isfile(filename):
-                variables = config.load(filename)
-            else:
-                variables = OrderedDict()
-        except:
-            logger.exception('Failed to load status variables.')
-            variables = OrderedDict()
-        return variables
-
     @QtCore.Slot(str, str)
     def removeStatusFile(self, base, module):
         try:
-            statusdir = self.getStatusDir()
-            classname = self.tree['defined'][base][
-                module]['module.Class'].split('.')[-1]
-            filename = os.path.join(
-                statusdir, 'status-{0}_{1}_{2}.cfg'.format(classname, base, module))
-            if os.path.isfile(filename):
-                os.remove(filename)
-        except:
-            logger.exception('Failed to remove module status file.')
+            self.tree['loaded'][base][module].remove_status_file()
+        except KeyError:
+            self.log.error('Could not find {0} module {1}'.format(base, module))
 
     @QtCore.Slot()
     def quit(self):

--- a/gui/manager/managergui.py
+++ b/gui/manager/managergui.py
@@ -65,7 +65,7 @@ class ManagerGui(GUIBase):
     """
 
     # status vars
-    consoleFontSize = StatusVar('console_font_size', 10)
+    consoleFontSize = StatusVar('console_font_size', 10, save='delayed')
 
     # signals
     sigStartAll = QtCore.Signal()


### PR DESCRIPTION
I open this pull request with a work-in-progress tag to enable design discussions.

## Description

Status variables are so far only saved when a module is deactivated. If qudi or the operating system crashes before, all status variable changes are lost.

To prevent this situation this pull requests extends the `StatusVar` class by a new parameter `save` which controls when a status variable is saved to file. The default value is `deactivation` which is the previous behavior, so no behavioral changes on existing code.

The two new options are:
- `immediately`: saving of status variables is issued directly after the status variable is changed
- `delayed`: status variables are saved after a certain amount of time (currently 500ms) after the status variable is changed. If it is changed in the mean-time, the timer is restarted.

If one of the two new options are used, all status variables of a certain module are saved to file. This is important to note as this behavior has to be considered if huge numpy arrays are stored in status variables. Currently I don't see a way around this unless status variables are split over several files.

Other changes:
- status variables are implemented as properties, values are stored in the value attribute of the status variable
- I moved saving and loading of status variables from the manager to the module level. In principle a module could override the implementation if something else is needed.

## How Has This Been Tested?
- changed managergui to support saving the only status variable `delayed`.
- it definitely needs more testing.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.