### PR TITLE
small fix for odmrgui

### DIFF
--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -280,7 +280,7 @@ class ODMRGui(GUIBase):
         self.reject_settings()
 
         # Show the Main ODMR GUI:
-        self._show()
+        self.show()
 
     def on_deactivate(self):
         """ Reverse steps of activation
@@ -334,12 +334,11 @@ class ODMRGui(GUIBase):
         self._mw.close()
         return 0
 
-    def _show(self):
+    def show(self):
         """Make window visible and put it above all other windows. """
         self._mw.show()
         self._mw.activateWindow()
         self._mw.raise_()
-        return
 
     def _menu_settings(self):
         """ Open the settings menu """


### PR DESCRIPTION
was broken by reverting attempt to move qmainwindow into the module class #214.

## Description
<!--- Describe your changes in detail -->
rename `_show()` to `show()` so the manager gui does not complain about the missing show method

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
issue not in bugtracker

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
load odmr gui, then show odmr gui. without this fix, the show odmr gui produces an error

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentaion, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
