### PR TITLE
allows any module to be started in a thread

### DIFF
--- a/core/manager.py
+++ b/core/manager.py
@@ -914,7 +914,7 @@ class Manager(QtCore.QObject):
         try:
             module.setStatusVariables(self.loadStatusVariables(base, name))
             # start main loop for qt objects
-            if base == 'logic':
+            if module.is_module_threaded:
                 modthread = self.tm.newThread('mod-{0}-{1}'.format(base, name))
                 module.moveToThread(modthread)
                 modthread.start()

--- a/core/module.py
+++ b/core/module.py
@@ -257,6 +257,7 @@ class BaseMixin(Fysom, metaclass=ModuleMeta):
 
     _modclass = 'base'
     _modtype = 'base'
+    _threaded = False
     _connectors = dict()
 
     # do not copy declaration of trigger(self, event, *args, **kwargs), just apply Slot decorator
@@ -417,6 +418,13 @@ class BaseMixin(Fysom, metaclass=ModuleMeta):
         """
         return logging.getLogger("{0}.{1}".format(
             self.__module__, self.__class__.__name__))
+
+    @property
+    def is_module_threaded(self):
+        """
+        Returns whether the module shall be started in a thread.
+        """
+        return self._threaded
 
     def on_activate(self):
         """ Method called when module is activated. If not overridden

--- a/logic/generic_logic.py
+++ b/logic/generic_logic.py
@@ -28,6 +28,7 @@ class GenericLogic(Base):
     """
     _modclass = 'GenericLogic'
     _modtype = 'logic'
+    _threaded = True
 
     def __init__(self, **kwargs):
         """ Initialzize a logic module.


### PR DESCRIPTION
threading is controlled by a parameter in the module and (in principle) allowed for hardware and gui as well.

## Description
```
class Module(QObject, BaseMixin):
    _threaded = True # start thread
    ...
```

default is `False`, `generic_logic` sets it to `True`, so the pull request does not change anything in the default behavior.

## Motivation and Context
Sometimes hardware modules shall be threaded as well and this patch makes it easy to use the same framework as for logic.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
