### PR TITLE
Fixed missing connection of the odmrgui signal "sigClockFreqChanged"

### DIFF
--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -259,6 +259,8 @@ class ODMRGui(GUIBase):
         self.sigRuntimeChanged.connect(self._odmr_logic.set_runtime, QtCore.Qt.QueuedConnection)
         self.sigNumberOfLinesChanged.connect(self._odmr_logic.set_matrix_line_number,
                                              QtCore.Qt.QueuedConnection)
+        self.sigClockFreqChanged.connect(self._odmr_logic.set_clock_frequency,
+                                         QtCore.Qt.QueuedConnection)
         self.sigSaveMeasurement.connect(self._odmr_logic.save_odmr_data, QtCore.Qt.QueuedConnection)
 
         # Update signals coming from logic:
@@ -308,6 +310,7 @@ class ODMRGui(GUIBase):
         self.sigMwSweepParamsChanged.disconnect()
         self.sigRuntimeChanged.disconnect()
         self.sigNumberOfLinesChanged.disconnect()
+        self.sigClockFreqChanged.disconnect()
         self.sigSaveMeasurement.disconnect()
         self._mw.odmr_cb_manual_RadioButton.clicked.disconnect()
         self._mw.odmr_cb_centiles_RadioButton.clicked.disconnect()


### PR DESCRIPTION
## Description
It was all functional... just the connection to the logic was missing.
Connected the GUI signal to the logic method set_clock_frequency and voilà... working as intended.

## Motivation and Context
I forgot the signal connection during the ODMR overhaul and nobody noticed the clock frequency could not be changed from GUI until now.
Fixed issue #241

## How Has This Been Tested?
Run qudi with default config.
Load ODMR GUI.
Run ODMR measurement, note elapsed time and elapsed sweeps
Double clock frequency in GUI dialogue
Run ODMR again and see if the number of sweeps has doubled for the same runtime.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
