### PR TITLE
mapper: allow getter callable to be given as text

### DIFF
--- a/core/mapper.py
+++ b/core/mapper.py
@@ -251,11 +251,18 @@ class Mapper():
                     if model_getter is None:
                         raise Exception('Attribute {0} of model is readonly.'
                                         ''.format(model_property_name))
+            else:
+                # getter is not a property. Check if it is a callable.
+                model_getter_name = model_getter
+                model_getter = getattr(model, model_getter)
+                if not callable(model_getter):
+                    raise Exception('Attribute {0} of model is not callable.'.format(
+                        model_getter_name))
         if isinstance(model_setter, str):
             model_setter_name = model_setter
             model_setter = getattr(model, model_setter)
             if not callable(model_setter):
-                raise Exception('{0} is not callable'.format(
+                raise Exception('Attribute {0} of model is not callable'.format(
                     model_setter_name))
         if isinstance(model_property_notifier, str):
             model_property_notifier = getattr(model, model_property_notifier)


### PR DESCRIPTION
this patch allows to pass a getter callable as text in the add method in mapper.

## Description
This patch is an improvement for convenience as sometimes it might be useful to pass method names as text. Previously this was only possible with properties.

## How Has This Been Tested?
In a private module.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
