### PR TITLE
Pulsed spinbox ranges and fixed issues #245 #246 #247

### DIFF
--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -886,6 +886,8 @@ class PulsedMeasurementGui(GUIBase):
 
     def load_block_in_editor(self, block_obj):
         self.block_editor.load_pulse_block(block_obj)
+        if block_obj is not None:
+            self._pg.curr_block_name_LineEdit.setText(block_obj.name)
         return
 
     def load_ensemble_in_editor(self, ensemble_obj, ensemble_params):
@@ -902,6 +904,8 @@ class PulsedMeasurementGui(GUIBase):
             self._pg.curr_ensemble_bins_SpinBox.setValue(0)
             self._pg.curr_ensemble_size_DSpinBox.setValue(0.0)
             self._pg.curr_ensemble_laserpulses_SpinBox.setValue(0)
+        if ensemble_obj is not None:
+            self._pg.curr_ensemble_name_LineEdit.setText(ensemble_obj.name)
         return
 
     def load_sequence_in_editor(self, sequence_obj, sequence_params):
@@ -916,6 +920,8 @@ class PulsedMeasurementGui(GUIBase):
             self._sg.curr_sequence_length_DSpinBox.setValue(0.0)
             self._sg.curr_sequence_bins_SpinBox.setValue(0)
             self._sg.curr_sequence_size_DSpinBox.setValue(0.0)
+        if sequence_obj is not None:
+            self._sg.curr_sequence_name_LineEdit.setText(sequence_obj.name)
         return
 
     def update_block_dict(self, block_dict):

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -1297,6 +1297,14 @@ class PulsedMeasurementGui(GUIBase):
         # set boundaries
         self._pe.extract_param_conv_std_dev_slider.setRange(1, 200)
         self._pe.extract_param_conv_std_dev_DSpinBox.setRange(1, 200)
+        self._pa.ana_param_x_axis_start_ScienDSpinBox.setRange(0, 1.0e99)
+        self._pa.ana_param_x_axis_inc_ScienDSpinBox.setRange(0, 1.0e99)
+        self._pa.ana_param_num_laser_pulse_SpinBox.setRange(1, 1e6)
+        self._pa.ana_param_record_length_SpinBox.setRange(0, 1.0e99)
+        self._pa.time_param_ana_periode_DoubleSpinBox.setRange(0, 1.0e99)
+        self._pa.ext_control_mw_freq_DoubleSpinBox.setRange(0, 1.0e99)
+        self._pa.ext_control_mw_power_DoubleSpinBox.setRange(0, 1.0e99)
+        self._pe.extract_param_threshold_SpinBox.setRange(1, 2**31)
 
         # ---------------------------------------------------------------------
         #                         Connect signals

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -1304,7 +1304,7 @@ class PulsedMeasurementGui(GUIBase):
         self._pa.time_param_ana_periode_DoubleSpinBox.setRange(0, 1.0e99)
         self._pa.ext_control_mw_freq_DoubleSpinBox.setRange(0, 1.0e99)
         self._pa.ext_control_mw_power_DoubleSpinBox.setRange(0, 1.0e99)
-        self._pe.extract_param_threshold_SpinBox.setRange(1, 2**31)
+        self._pe.extract_param_threshold_SpinBox.setRange(1, 2**31-1)
 
         # ---------------------------------------------------------------------
         #                         Connect signals

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -943,6 +943,16 @@ class PulsedMeasurementGui(GUIBase):
         @param ensemble_dict:
         @return:
         """
+        # Check if an ensemble has been added. In that case set the current index to the new one.
+        # In all other cases try to maintain the current item and if it was removed, set the first.
+        text_to_set = None
+        if len(ensemble_dict) == self._pg.gen_ensemble_ComboBox.count() + 1:
+            for key in ensemble_dict:
+                if self._pg.gen_ensemble_ComboBox.findText(key) == -1:
+                    text_to_set = key
+        else:
+            text_to_set = self._pg.gen_ensemble_ComboBox.currentText()
+
         self.sequence_editor.set_ensemble_dict(ensemble_dict)
         # block signals
         self._pg.gen_ensemble_ComboBox.blockSignals(True)
@@ -952,6 +962,10 @@ class PulsedMeasurementGui(GUIBase):
         self._pg.gen_ensemble_ComboBox.addItems(list(ensemble_dict))
         self._pg.saved_ensembles_ComboBox.clear()
         self._pg.saved_ensembles_ComboBox.addItems(list(ensemble_dict))
+        if text_to_set is not None:
+            index = self._pg.gen_ensemble_ComboBox.findText(text_to_set)
+            if index != -1:
+                self._pg.gen_ensemble_ComboBox.setCurrentIndex(index)
         # unblock signals
         self._pg.gen_ensemble_ComboBox.blockSignals(False)
         self._pg.saved_ensembles_ComboBox.blockSignals(False)
@@ -963,6 +977,16 @@ class PulsedMeasurementGui(GUIBase):
         @param sequence_dict:
         @return:
         """
+        # Check if a sequence has been added. In that case set the current index to the new one.
+        # In all other cases try to maintain the current item and if it was removed, set the first.
+        text_to_set = None
+        if len(sequence_dict) == self._sg.gen_sequence_ComboBox.count() + 1:
+            for key in sequence_dict:
+                if self._sg.gen_sequence_ComboBox.findText(key) == -1:
+                    text_to_set = key
+        else:
+            text_to_set = self._sg.gen_sequence_ComboBox.currentText()
+
         # block signals
         self._sg.gen_sequence_ComboBox.blockSignals(True)
         self._sg.saved_sequences_ComboBox.blockSignals(True)
@@ -971,6 +995,10 @@ class PulsedMeasurementGui(GUIBase):
         self._sg.gen_sequence_ComboBox.addItems(list(sequence_dict))
         self._sg.saved_sequences_ComboBox.clear()
         self._sg.saved_sequences_ComboBox.addItems(list(sequence_dict))
+        if text_to_set is not None:
+            index = self._sg.gen_sequence_ComboBox.findText(text_to_set)
+            if index != -1:
+                self._sg.gen_sequence_ComboBox.setCurrentIndex(index)
         # unblock signals
         self._sg.gen_sequence_ComboBox.blockSignals(False)
         self._sg.saved_sequences_ComboBox.blockSignals(False)

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -661,7 +661,8 @@ class PulsedMeasurementLogic(GenericLogic):
         #       and how the used thread principle was used in this method (or
         #       will be use in another method).
         self.sigMeasurementRunningUpdated.emit(True, False)
-        self.set_laser_to_show(0, self.show_raw_data)
+        if self.show_laser_index > self.number_of_lasers:
+            self.set_laser_to_show(0, self.show_raw_data)
         if stashed_raw_data_tag == '':
             stashed_raw_data_tag = None
         with self.threadlock:

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -661,6 +661,7 @@ class PulsedMeasurementLogic(GenericLogic):
         #       and how the used thread principle was used in this method (or
         #       will be use in another method).
         self.sigMeasurementRunningUpdated.emit(True, False)
+        self.set_laser_to_show(0, self.show_raw_data)
         if stashed_raw_data_tag == '':
             stashed_raw_data_tag = None
         with self.threadlock:


### PR DESCRIPTION
## Description
The range for the spinboxes in the pulsed_maingui analysis and extraction tabs was very limited. They are getting set properly in the GUI activation now.
Also fixed issues #245, #246 and #247. Those were mainly about convenience. When generating ensembles/sequences, the new asset will be the current item in the spinbox for sample/upload/load.
When loading a block/ensemble/sequence the name of the loaded asset will show in the LineEdit next to it.
Fixed a bug where the laser-to-show index was out of range when starting a new measurement with less laser pulses than the previous but the index was still set to a higher number. Now it will be reset to 0 upon starting a new measurement if it is out of range.

## Motivation and Context
Problems existed when trying to set the controlled variable axis for pulsed measurements, e.g. in the 1e9 regime.
Fixed issues #245, #246 and #247.

## How Has This Been Tested?
All changes tested with dummy configuration since all is more or less GUI related.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
