### PR TITLE
Rpyc / Remote server optional

### DIFF
--- a/config/example/default.cfg
+++ b/config/example/default.cfg
@@ -9,8 +9,9 @@ global:
     # list of modules to load when starting
     startup: ['man', 'tray', 'tasklogic']
 
-    serveraddress: localhost
-    serverport: 12345
+    module_server:
+        address: 'localhost'
+        port: 12345
 
     ## For controlling the appearance of the GUI:
     stylesheet: 'qdark.qss'

--- a/core/manager.py
+++ b/core/manager.py
@@ -133,70 +133,59 @@ class Manager(QtCore.QObject):
             self.configDir = os.path.dirname(config_file)
             self.readConfig(config_file)
 
-            # Create remote module server if specified in config file
-            if ('module_server' in self.tree['global'] or
-                'serveraddress' in self.tree['global']):
-                # check first if remote support is actually enabled
-                if (RemoteObjectManager is None):
-                    logger.error('Remote modules disabled. Rpyc not installed.')
-                else:
-                    if ('module_server' in self.tree['global']):
-                        if (not isinstance(self.tree['global']['module_server'], dict)):
-                            logger.error('"module_server" entry in "global" section of configuration'
-                                         ' file is not a dictionary.')
-                        else:
-                            # new style
-                            try:
-                                server_address = self.tree['global']['module_server'].get(
-                                    'address',
-                                    'localhost')
-                                server_port = self.tree['global']['module_server'].get(
-                                    'port', 12345)
-                                certfile = self.tree['global']['module_server'].get(
-                                    'certfile', None)
-                                keyfile = self.tree['global']['module_server'].get('keyfile', None)
-                                self.rm = RemoteObjectManager(self,
-                                                              server_address,
-                                                              server_port,
-                                                              certfile=certfile,
-                                                              keyfile=keyfile)
-                                self.rm.createServer()
-                                # successfully started remote server
-                                logger.info('Started server rpyc://{0}:{1}'.format(server_address,
-                                                                                   server_port))
-                                self.remote_server = True
-                            except:
-                                logger.exception('Rpyc server could not be started.')
+            # check first if remote support is enabled and if so create RemoteObjectManager
+            if (RemoteObjectManager is None):
+                logger.error('Remote modules disabled. Rpyc not installed.')
+                self.rm = None
+            else:
+                self.rm = RemoteObjectManager(self)
+                # Create remote module server if specified in config file
+                if ('module_server' in self.tree['global']):
+                    if (not isinstance(self.tree['global']['module_server'], dict)):
+                        logger.error('"module_server" entry in "global" section of configuration'
+                                     ' file is not a dictionary.')
                     else:
-                        logger.warning('Deprecated remote server settings. Please update to new '
-                                       'style. See documentation.')
-                        server_address = self.tree['global']['serveraddress']
+                        # new style
                         try:
-                            if 'serverport' in self.tree['global']:
-                                remote_port = self.tree['global']['serverport']
-                                logger.info('Remote port is configured to {0}'.format(remote_port))
-                            else:
-                                remote_port = 12345
-                                logger.info('Remote port is the standard {0}'.format(remote_port))
-                            if 'certfile' in self.tree['global']:
-                                certfile = self.tree['global']['certfile']
-                            else:
-                                certfile = None
-                            if 'keyfile' in self.tree['global']:
-                                keyfile = self.tree['global']['keyfile']
-                            else:
-                                keyfile = None
-                            self.rm = RemoteObjectManager(
-                                self,
-                                server_address,
-                                remote_port,
-                                certfile=certfile,
-                                keyfile=keyfile)
-                            self.rm.createServer()
+                            server_address = self.tree['global']['module_server'].get(
+                                'address',
+                                'localhost')
+                            server_port = self.tree['global']['module_server'].get(
+                                'port', 12345)
+                            certfile = self.tree['global']['module_server'].get(
+                                'certfile', None)
+                            keyfile = self.tree['global']['module_server'].get('keyfile', None)
+                            self.rm.createServer(server_address, server_port, certfile, keyfile)
                             # successfully started remote server
+                            logger.info('Started server rpyc://{0}:{1}'.format(server_address,
+                                                                               server_port))
                             self.remote_server = True
                         except:
-                            logger.exception('Remote server could not be started.')
+                            logger.exception('Rpyc server could not be started.')
+                elif ('serveraddress' in self.tree['global']):
+                    logger.warning('Deprecated remote server settings. Please update to new '
+                                   'style. See documentation.')
+                    server_address = self.tree['global']['serveraddress']
+                    try:
+                        if 'serverport' in self.tree['global']:
+                            remote_port = self.tree['global']['serverport']
+                            logger.info('Remote port is configured to {0}'.format(remote_port))
+                        else:
+                            remote_port = 12345
+                            logger.info('Remote port is the standard {0}'.format(remote_port))
+                        if 'certfile' in self.tree['global']:
+                            certfile = self.tree['global']['certfile']
+                        else:
+                            certfile = None
+                        if 'keyfile' in self.tree['global']:
+                            keyfile = self.tree['global']['keyfile']
+                        else:
+                            keyfile = None
+                        self.rm.createServer(server_address, remote_port, certfile, keyfile)
+                        # successfully started remote server
+                        self.remote_server = True
+                    except:
+                        logger.exception('Remote server could not be started.')
 
             logger.info('Qudi started.')
 
@@ -766,7 +755,7 @@ class Manager(QtCore.QObject):
         defined_module = self.tree['defined'][base][key]
         if 'module.Class' in defined_module:
             if 'remote' in defined_module:
-                if not self.remote_server:
+                if self.rm is None:
                     logger.error('Remote functionality not working, check your log.')
                     return -1
                 if not isinstance(defined_module['remote'], str):
@@ -774,8 +763,8 @@ class Manager(QtCore.QObject):
                     return -1
                 try:
                     instance = self.rm.getRemoteModuleUrl(defined_module['remote'])
-                    logger.info('Remote module {0} loaded as .{1}.{2}.'
-                        ''.format(defined_module['remote'], base, key))
+                    logger.info('Remote module {0} loaded as {1}.{2}.'
+                                ''.format(defined_module['remote'], base, key))
                     with self.lock:
                         if isBase(base):
                             self.tree['loaded'][base][key] = instance
@@ -827,7 +816,7 @@ class Manager(QtCore.QObject):
         """
         defined_module = self.tree['defined'][base][key]
         if 'remote' in defined_module:
-            if not self.remote_server:
+            if self.rm is None:
                 logger.error('Remote functionality not working, check your log.')
                 return -1
             if not isinstance(defined_module['remote'], str):

--- a/core/manager.py
+++ b/core/manager.py
@@ -762,7 +762,12 @@ class Manager(QtCore.QObject):
                     logger.error('Remote URI of {0} module {1} not a string.'.format(base, key))
                     return -1
                 try:
-                    instance = self.rm.getRemoteModuleUrl(defined_module['remote'])
+                    certfile = defined_module.get('certfile', None)
+                    keyfile = defined_module.get('keyfile', None)
+                    instance = self.rm.getRemoteModuleUrl(
+                        defined_module['remote'],
+                        certfile=certfile,
+                        keyfile=keyfile)
                     logger.info('Remote module {0} loaded as {1}.{2}.'
                                 ''.format(defined_module['remote'], base, key))
                     with self.lock:

--- a/core/manager.py
+++ b/core/manager.py
@@ -756,7 +756,7 @@ class Manager(QtCore.QObject):
         if 'module.Class' in defined_module:
             if 'remote' in defined_module:
                 if self.rm is None:
-                    logger.error('Remote functionality not working, check your log.')
+                    logger.error('Remote module functionality disabled. Rpyc not installed.')
                     return -1
                 if not isinstance(defined_module['remote'], str):
                     logger.error('Remote URI of {0} module {1} not a string.'.format(base, key))
@@ -790,10 +790,14 @@ class Manager(QtCore.QObject):
                     modObj = self.importModule(base, module_name)
                     self.configureModule(modObj, base, class_name, key, defined_module)
                     if 'remoteaccess' in defined_module and defined_module['remoteaccess']:
+                        if self.rm is None:
+                            logger.error('Remote module sharing functionality disabled. Rpyc not'
+                                         ' installed.')
+                            return 1
                         if not self.remote_server:
                             logger.error('Remote module sharing does not work '
-                                         'as server startup failed earlier, check '
-                                         'your log.')
+                                         'as no server configured or server startup failed earlier.'
+                                         ' Check your configuration and log.')
                             return 1
                         self.rm.shareModule(key, self.tree['loaded'][base][key])
                 except:

--- a/core/remote.py
+++ b/core/remote.py
@@ -25,11 +25,11 @@ logger = logging.getLogger(__name__)
 
 from qtpy.QtCore import QObject
 from urllib.parse import urlparse
-from rpyc.utils.server import ThreadedServer
-from rpyc.utils.authenticators import SSLAuthenticator
 import ssl
 from .util.models import DictTableModel, ListTableModel
 import rpyc
+from rpyc.utils.server import ThreadedServer
+from rpyc.utils.authenticators import SSLAuthenticator
 rpyc.core.protocol.DEFAULT_CONFIG['allow_pickle'] = True
 
 

--- a/core/remote.py
+++ b/core/remote.py
@@ -146,10 +146,12 @@ class RemoteObjectManager(QObject):
             logger.error('Module {0} was not shared.'.format(name))
         self.sharedModules.pop(name)
 
-    def getRemoteModuleUrl(self, url):
+    def getRemoteModuleUrl(self, url, certfile=None, keyfile=None):
         """ Get a remote module via its URL.
 
           @param str url: URL pointing to a module hosted b a remote server
+          @param str certfile: filename of certificate or None if SSL is not used
+          @param str keyfile: filename of key or None if SSL is not used
 
           @return object: remote module
         """
@@ -157,16 +159,18 @@ class RemoteObjectManager(QObject):
         name = parsed.path.replace('/', '')
         return self.getRemoteModule(parsed.hostname, parsed.port, name)
 
-    def getRemoteModule(self, host, port, name):
+    def getRemoteModule(self, host, port, name, certfile=None, keyfile=None):
         """ Get a remote module via its host, port and name.
 
           @param str host: host that the remote module server is running on
           @param int port: port that the remote module server is listening on
           @param str name: unique name of the remote module
+          @param str certfile: filename of certificate or None if SSL is not used
+          @param str keyfile: filename of key or None if SSL is not used
 
           @return object: remote module
         """
-        module = RemoteModule(host, port, name)
+        module = RemoteModule(host, port, name, certfile=certfile, keyfile=keyfile)
         self.remoteModules.append(module)
         return module.module
 

--- a/core/util/helpers.py
+++ b/core/util/helpers.py
@@ -103,9 +103,10 @@ def import_check():
     """
     # encode like: (python-package-name, repository-name, version)
     vital_pkg = [('ruamel.yaml','ruamel.yaml', None),
-                 ('rpyc','rpyc', None),
                  ('fysom','fysom', '2.1.4')]
-    opt_pkg = [('pyqtgraph','pyqtgraph', None), ('git','gitpython', None)]
+    opt_pkg = [('rpyc','rpyc', None),
+               ('pyqtgraph','pyqtgraph', None),
+               ('git','gitpython', None)]
 
 
     def check_package(pkg_name, repo_name, version, optional=False):

--- a/documentation/main.md
+++ b/documentation/main.md
@@ -21,6 +21,7 @@
 
 * Configuration
     * [Using a Config file](@ref config-explanation)
+    * [Remote access to modules)(@red remote_modules)
 
 * GUI documentation
     * [Keyboard shortcuts](@ref shortcuts)

--- a/documentation/remote_modules.md
+++ b/documentation/remote_modules.md
@@ -1,0 +1,46 @@
+# Remote Modules
+
+Using rpyc Qudi modules can be accessed from a remote computer like they were locally used.
+
+## Requirements
+
+* rpyc in at least version 3.3 has to be installed.
+
+## Server Configuration
+
+The Qudi instance where the actual module is running can provide access from a remote Qudi instance by setting up a server:
+
+In the configuration file:
+
+```
+[global]
+  remote_server:
+    - address: ''
+    - port: 12345
+    - certfile: 'path/to/ssl/certificate'
+    - keyfile: 'path/to/ssl/key'
+```
+
+To activate access to individual modules, add
+
+```
+remoteaccess: true
+```
+
+as an option to their configuration.
+
+Using the `address` option the rpyc server can be bound to a specific interface. Specifing an empty string as in the example above will make the qudi server listening on all interfaces.
+
+## Client Configuration
+
+Specify a module in the configuration file as usual, but add the following options:
+
+```
+remote: 'rpyc://servername:port/module_name'
+certfile: 'path/to/ssl/certificate'
+keyfile: 'path/to/ssl/key'
+```
+
+## Important Notes
+
+* If `certfile` and `keyfile` are not specified, the connection is unencrypted and not authenticated.

--- a/documentation/required_python_packages.md
+++ b/documentation/required_python_packages.md
@@ -3,19 +3,20 @@
 # Do not use this list to install Qudi for normal use. Check the Installation page to see how to do that.
 [Installation page with full install instructions](@ref installation)
 
-These package have to be installed in order to run Qudi (easily installed with Anaconda console: pip install "packagename"):
+These package have to be or can be installed to run Qudi (easily installed with Anaconda console: pip install "packagename"):
 
 | Package  | Minimum Version | URL  | Needed by |
 | ------------- | ---------- | ------------------------------------------- | ----------- |
-| Fysom         | 2.1        | https://pypi.python.org/pypi/fysom          | all         |
-| qtpy          | 1.1.2      | https://pypi.python.org/pypi/qtpy           | all         |
-| RPyC          | 3.3.0      | https://pypi.python.org/pypi/rpyc           | all         |
-| ruamel.yaml   | 0.11       | https://pypi.python.org/pypi/ruamel.yaml    | all         |
+| Fysom         | 2.1.4      | https://pypi.python.org/pypi/fysom          | core         |
+| Qt5           | 5.6        | https://www.riverbankcomputing.com/software/pyqt/download5 | core |
+| qtpy          | 1.1.2      | https://pypi.python.org/pypi/qtpy           | core         |
+| ruamel.yaml   | 0.11       | https://pypi.python.org/pypi/ruamel.yaml    | core         |
+| RPyC          | 3.3.0      | https://pypi.python.org/pypi/rpyc           | core (optional) |
 | pyqtgraph     | 0.10.0     | http://www.pyqtgraph.org/                   | Lots        |
 | pyvisa        | 1.8        | https://pypi.python.org/pypi/PyVISA         | Lots        |
 | lmfit         | 0.9.2      | https://pypi.python.org/pypi/lmfit/         | fitlogic    |
 | jupyter       | 1.0.0      | https://pypi.python.org/pypi/jupyter        | Manager gui, Notebook features|
-| git           | 2.0.0      | https://pypi.python.org/pypi/GitPython      | Manager GUI |
+| git           | 2.0.0      | https://pypi.python.org/pypi/GitPython      | Manager GUI (optional) |
 | PyDAQmx       | 1.3.2      | https://pypi.python.org/pypi/PyDAQmx        | NI card     |
 | hdf5storage   | ???        | https://pypi.python.org/pypi/hdf5storage    | awg70k      |
 | comtypes      | 1.1        | https://pypi.python.org/pypi/comtypes       | winspec_spectrometer (hardware) |

--- a/gui/manager/managergui.py
+++ b/gui/manager/managergui.py
@@ -163,14 +163,18 @@ class ManagerGui(GUIBase):
         # thread widget
         self._mw.threadWidget.threadListView.setModel(self._manager.tm)
         # remote widget
-        self._mw.remoteWidget.hostLabel.setText('URL:')
-        self._mw.remoteWidget.portLabel.setText(
-            'rpyc://{0}:{1}/'.format(self._manager.rm.host,
-                                     self._manager.rm.server.port))
-        self._mw.remoteWidget.remoteModuleListView.setModel(
-            self._manager.rm.remoteModules)
-        self._mw.remoteWidget.sharedModuleListView.setModel(
-            self._manager.rm.sharedModules)
+        if (self._manager.remote_server):
+            self._mw.remoteWidget.hostLabel.setText('URL:')
+            self._mw.remoteWidget.portLabel.setText(
+                'rpyc://{0}:{1}/'.format(self._manager.rm.host,
+                                         self._manager.rm.server.port))
+            self._mw.remoteWidget.remoteModuleListView.setModel(
+                self._manager.rm.remoteModules)
+            self._mw.remoteWidget.sharedModuleListView.setModel(
+                self._manager.rm.sharedModules)
+        else:
+            # hide remote menu item when no remote server was started
+            self._mw.actionRemoteView.setVisible(False)
 
         self._mw.configDisplayDockWidget.hide()
         self._mw.remoteDockWidget.hide()

--- a/gui/manager/managergui.py
+++ b/gui/manager/managergui.py
@@ -163,18 +163,21 @@ class ManagerGui(GUIBase):
         # thread widget
         self._mw.threadWidget.threadListView.setModel(self._manager.tm)
         # remote widget
-        if (self._manager.remote_server):
-            self._mw.remoteWidget.hostLabel.setText('URL:')
-            self._mw.remoteWidget.portLabel.setText(
-                'rpyc://{0}:{1}/'.format(self._manager.rm.host,
-                                         self._manager.rm.server.port))
-            self._mw.remoteWidget.remoteModuleListView.setModel(
-                self._manager.rm.remoteModules)
-            self._mw.remoteWidget.sharedModuleListView.setModel(
-                self._manager.rm.sharedModules)
-        else:
-            # hide remote menu item when no remote server was started
-            self._mw.actionRemoteView.setVisible(False)
+        # hide remote menu item if rpyc is not available
+        self._mw.actionRemoteView.setVisible(self._manager.rm is not None)
+        if (self._manager.rm is not None):
+            self._mw.remoteWidget.remoteModuleListView.setModel(self._manager.rm.remoteModules)
+            if (self._manager.remote_server):
+                self._mw.remoteWidget.hostLabel.setText('Server URL:')
+                self._mw.remoteWidget.portLabel.setText(
+                    'rpyc://{0}:{1}/'.format(self._manager.rm.server.host,
+                                             self._manager.rm.server.port))
+                self._mw.remoteWidget.sharedModuleListView.setModel(
+                    self._manager.rm.sharedModules)
+            else:
+                self._mw.remoteWidget.hostLabel.setVisible(False)
+                self._mw.remoteWidget.portLabel.setVisible(False)
+                self._mw.remoteWidget.sharedModuleListView.setVisible(False)
 
         self._mw.configDisplayDockWidget.hide()
         self._mw.remoteDockWidget.hide()


### PR DESCRIPTION
So far rpyc was a core dependency and an rpyc server was always started even if the functionality wasn't used at all. This patch makes both optional. 

## Description
Using a remote module is a nice feature in qudi, however, not quite everybody is using it. Up to now rpyc had to be installed and a server was started even if the functionality wasn't used at all. This patch disables all remote module functionality if rpyc is not installed. If it is installed qudi can be used as client or as server or both, depending on configuration.

The server is now disabled if no corresponding configuration is available. This can in principle break existing configurations (though I hope that people using the functionality use certificates!).
New configuration options:
```
[global]
module_server:
  address: ''
  port: 12345
  certfile: 'filename.cert'
  keyfile: 'filename.key'
```
The old configuration options still work and are labelled as deprecated. The reason for the change is that I prefer to have them grouped together.

Note: This patch does not intend to fix any issues within the remote module implementation.

## How Has This Been Tested?
I tried the different configurations (server, client, both) including an uninstalled rpyc.

Would be great if someone actually using the functionality could check that it is still working as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
No documentation describing the remote module functionality exists yet.