### PR TITLE
Saving pulse blocks/ensembles/sequences will no longer update the editor in GUI

### DIFF
--- a/logic/sequence_generator_logic.py
+++ b/logic/sequence_generator_logic.py
@@ -346,7 +346,6 @@ class SequenceGeneratorLogic(GenericLogic, SamplingFunctions, SamplesWriteMethod
         self.saved_pulse_blocks[name] = block
         self._save_blocks_to_file()
         self.sigBlockDictUpdated.emit(self.saved_pulse_blocks)
-        self.sigCurrentBlockUpdated.emit(self.current_block)
         return
 
     def load_block(self, name):
@@ -436,7 +435,6 @@ class SequenceGeneratorLogic(GenericLogic, SamplingFunctions, SamplesWriteMethod
         self.saved_pulse_block_ensembles[name] = ensemble
         self._save_ensembles_to_file()
         self.sigEnsembleDictUpdated.emit(self.saved_pulse_block_ensembles)
-        self.sigCurrentEnsembleUpdated.emit(self.current_ensemble)
         return
 
     def load_ensemble(self, name):
@@ -538,7 +536,7 @@ class SequenceGeneratorLogic(GenericLogic, SamplingFunctions, SamplesWriteMethod
         self.saved_pulse_sequences[name] = sequence
         self._save_sequences_to_file()
         self.sigSequenceDictUpdated.emit(self.saved_pulse_sequences)
-        self.sigCurrentSequenceUpdated.emit(self.current_sequence)
+        return
 
     def load_sequence(self, name):
         """


### PR DESCRIPTION
## Description
see above

## Motivation and Context
When generating a large pulse_sequence via script or predefined_sequences each call to save a block and block_ensemble caused the GUI to update the editor content to these blocks/ensembles. This behaviour is nice for single blocks/ensembles but slows down the generation of more complex sequences by a huge amount. Removed that. If you want to view the generated assets, one can still just load them manually into the editor with the dedicated dialogue. 

## How Has This Been Tested?
since it's just GUI related I tested it in dummy only.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
