### PR TITLE
Pulsed save and display enhancement

### DIFF
--- a/core/util/units.py
+++ b/core/util/units.py
@@ -88,8 +88,20 @@ class ScaledFloat(float):
             exponent = -8
         if exponent > 8:
             exponent = 8
-        prefix = 'yzafpnum kMGTPEZY'
+        prefix = 'yzafpnµm kMGTPEZY'
         return prefix[8 + exponent].strip()
+
+    @property
+    def scale_val(self):
+        """ Returns the scale value which can be used to devide the actual value
+
+        Examples
+        --------
+        m: 1e-3
+        M: 1e6
+        """
+        scale_str = self.scale
+        return get_unit_prefix_dict()[scale_str]
 
     def __format__(self, fmt):
         """

--- a/gui/pulsed/pulse_editors.py
+++ b/gui/pulsed/pulse_editors.py
@@ -3,7 +3,6 @@ from qtpy import QtWidgets
 import numpy as np
 from collections import OrderedDict
 import re
-import copy
 
 from logic.pulse_objects import PulseBlockElement
 from logic.pulse_objects import PulseBlock
@@ -12,10 +11,12 @@ from logic.pulse_objects import PulseSequence
 from logic.sampling_functions import SamplingFunctions
 
 from .spinbox_delegate import SpinBoxDelegate
-# from .doublespinbox_delegate import DoubleSpinBoxDelegate
 from .scientificspinbox_delegate import ScienDSpinBoxDelegate
 from .combobox_delegate import ComboBoxDelegate
 from .checkbox_delegate import CheckBoxDelegate
+
+import logging
+logger = logging.getLogger(__name__)
 
 
 class BlockEditor:
@@ -223,8 +224,8 @@ class BlockEditor:
 
     def _get_headernames(self):
         """ Get the names of the current header.
-        
-        @return: dict with keys being the header names and items being the column number 
+
+        @return: dict with keys being the header names and items being the column number
         """
         headers = OrderedDict()
         for column in range(self.be_widget.columnCount()):
@@ -235,7 +236,7 @@ class BlockEditor:
     def set_displayed_analog_amplitude(self, ampl_dict):
         """ Update the maximal amplitudes of the current pulse block editor.
 
-        @param dict ampl_dict: 
+        @param dict ampl_dict:
         @return: list, with integers representing the column indices which have
                  changed
         """
@@ -365,10 +366,10 @@ class BlockEditor:
 
     def get_column_delegate(self, column):
         """ Get the delegate object, which is responsible for the specific column
-        
-        @param int column: column index 
-        
-        @return: QDelegate 
+
+        @param int column: column index
+
+        @return: QDelegate
         """
         return self.be_widget.itemDelegate(column)
 

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -1311,35 +1311,52 @@ class PulsedMeasurementGui(GUIBase):
         self._pa.pulse_analysis_PlotWidget.addItem(self.fit_image)
 
         # Configure the errorbars of the data in the main pulse analysis display:
-        self.signal_image_error_bars = pg.ErrorBarItem(x=np.array(range(10)), y=np.zeros(10),
-                                                       top=0., bottom=0., pen=palette.c2)
-        self.signal_image_error_bars2 = pg.ErrorBarItem(x=np.array(range(10)), y=np.zeros(10),
-                                                        top=0., bottom=0., pen=palette.c5)
+        self.signal_image_error_bars = pg.ErrorBarItem(x=np.array(range(10)),
+                                                       y=np.zeros(10),
+                                                       top=0., bottom=0.,
+                                                       pen=palette.c2)
+        self.signal_image_error_bars2 = pg.ErrorBarItem(x=np.array(range(10)),
+                                                        y=np.zeros(10),
+                                                        top=0., bottom=0.,
+                                                        pen=palette.c5)
 
         # Configure the second pulse analysis display:
-        self.second_plot_image = pg.PlotDataItem(np.array(range(10)), np.zeros(10), pen=palette.c1)
+        self.second_plot_image = pg.PlotDataItem(np.array(range(10)),
+                                                 np.zeros(10), pen=palette.c1)
         self._pa.pulse_analysis_second_PlotWidget.addItem(self.second_plot_image)
         self.second_plot_image2 = pg.PlotDataItem(pen=palette.c4)
         self._pa.pulse_analysis_second_PlotWidget.addItem(self.second_plot_image2)
-        self._pa.pulse_analysis_second_PlotWidget.showGrid(x=True, y=True, alpha=0.8)
+        self._pa.pulse_analysis_second_PlotWidget.showGrid(x=True, y=True,
+                                                           alpha=0.8)
 
         # Configure the lasertrace plot display:
-        self.sig_start_line = pg.InfiniteLine(pos=0, pen=QtGui.QPen(palette.c3, 2), movable=True)
+        self.sig_start_line = pg.InfiniteLine(pos=0,
+                                              pen=QtGui.QPen(palette.c3, 2),
+                                              movable=True)
         self.sig_start_line.setHoverPen(QtGui.QPen(palette.c3), width=10)
-        self.sig_end_line = pg.InfiniteLine(pos=0, pen=QtGui.QPen(palette.c3, 2), movable=True)
+        self.sig_end_line = pg.InfiniteLine(pos=0,
+                                            pen=QtGui.QPen(palette.c3, 2),
+                                            movable=True)
         self.sig_end_line.setHoverPen(QtGui.QPen(palette.c3), width=10)
-        self.ref_start_line = pg.InfiniteLine(pos=0, pen=QtGui.QPen(palettedark.c4, 2), movable=True)
+        self.ref_start_line = pg.InfiniteLine(pos=0,
+                                              pen=QtGui.QPen(palettedark.c4, 2),
+                                              movable=True)
         self.ref_start_line.setHoverPen(QtGui.QPen(palette.c4), width=10)
-        self.ref_end_line = pg.InfiniteLine(pos=0, pen=QtGui.QPen(palettedark.c4, 2), movable=True)
+        self.ref_end_line = pg.InfiniteLine(pos=0,
+                                            pen=QtGui.QPen(palettedark.c4, 2),
+                                            movable=True)
         self.ref_end_line.setHoverPen(QtGui.QPen(palette.c4), width=10)
         # Configure the measuring error display:
-        self.measuring_error_image = pg.PlotDataItem(np.array(range(10)), np.zeros(10),
+        self.measuring_error_image = pg.PlotDataItem(np.array(range(10)),
+                                                     np.zeros(10),
                                                      pen=palette.c1)
-        self.measuring_error_image2 = pg.PlotDataItem(np.array(range(10)), np.zeros(10),
+        self.measuring_error_image2 = pg.PlotDataItem(np.array(range(10)),
+                                                      np.zeros(10),
                                                       pen=palette.c3)
         self._pe.measuring_error_PlotWidget.addItem(self.measuring_error_image)
         self._pe.measuring_error_PlotWidget.addItem(self.measuring_error_image2)
-        self._pe.measuring_error_PlotWidget.setLabel('left', 'measuring error', units='a.u.')
+        self._pe.measuring_error_PlotWidget.setLabel('left', 'measuring error',
+                                                     units='a.u.')
         #self._pe.measuring_error_PlotWidget.setLabel('bottom', 'tau', units='s')
 
 

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -1287,32 +1287,32 @@ class PulsedMeasurementGui(GUIBase):
         # Configure the main pulse analysis display:
         self.signal_image = pg.PlotDataItem(np.array(range(10)), np.zeros(10), pen=palette.c1)
         self._pa.pulse_analysis_PlotWidget.addItem(self.signal_image)
-        self.signal_image2 = pg.PlotDataItem(pen=palette.c3)
+        self.signal_image2 = pg.PlotDataItem(pen=palette.c4)
         self._pa.pulse_analysis_PlotWidget.addItem(self.signal_image2)
         self._pa.pulse_analysis_PlotWidget.showGrid(x=True, y=True, alpha=0.8)
 
         # Configure the fit of the data in the main pulse analysis display:
-        self.fit_image = pg.PlotDataItem(pen=palette.c2)
+        self.fit_image = pg.PlotDataItem(pen=palette.c3)
         self._pa.pulse_analysis_PlotWidget.addItem(self.fit_image)
 
         # Configure the errorbars of the data in the main pulse analysis display:
         self.signal_image_error_bars = pg.ErrorBarItem(x=np.array(range(10)), y=np.zeros(10),
-                                                       top=0., bottom=0., pen=palette.c1)
+                                                       top=0., bottom=0., pen=palette.c2)
         self.signal_image_error_bars2 = pg.ErrorBarItem(x=np.array(range(10)), y=np.zeros(10),
-                                                        top=0., bottom=0., pen=palette.c3)
+                                                        top=0., bottom=0., pen=palette.c5)
 
         # Configure the second pulse analysis display:
         self.second_plot_image = pg.PlotDataItem(np.array(range(10)), np.zeros(10), pen=palette.c1)
         self._pa.pulse_analysis_second_PlotWidget.addItem(self.second_plot_image)
-        self.second_plot_image2 = pg.PlotDataItem(pen=palette.c3)
+        self.second_plot_image2 = pg.PlotDataItem(pen=palette.c4)
         self._pa.pulse_analysis_second_PlotWidget.addItem(self.second_plot_image2)
         self._pa.pulse_analysis_second_PlotWidget.showGrid(x=True, y=True, alpha=0.8)
 
         # Configure the lasertrace plot display:
         self.sig_start_line = pg.InfiniteLine(pos=0, pen=QtGui.QPen(palette.c3, 2), movable=True)
-        self.sig_start_line.setHoverPen(QtGui.QPen(palette.c3))
+        self.sig_start_line.setHoverPen(QtGui.QPen(palette.c3), width=10)
         self.sig_end_line = pg.InfiniteLine(pos=0, pen=QtGui.QPen(palette.c3, 2), movable=True)
-        self.sig_end_line.setHoverPen(QtGui.QPen(palette.c3))
+        self.sig_end_line.setHoverPen(QtGui.QPen(palette.c3), width=10)
         self.ref_start_line = pg.InfiniteLine(pos=0, pen=QtGui.QPen(palettedark.c4, 2), movable=True)
         self.ref_start_line.setHoverPen(QtGui.QPen(palette.c4), width=10)
         self.ref_end_line = pg.InfiniteLine(pos=0, pen=QtGui.QPen(palettedark.c4, 2), movable=True)

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -1285,9 +1285,24 @@ class PulsedMeasurementGui(GUIBase):
         self._fsd.applySettings()
 
         # Configure the main pulse analysis display:
-        self.signal_image = pg.PlotDataItem(np.array(range(10)), np.zeros(10), pen=palette.c1)
+        self.signal_image = pg.PlotDataItem(np.array(range(10)),
+                                            np.zeros(10),
+                                            pen=pg.mkPen(palette.c1,
+                                                         style=QtCore.Qt.DotLine),
+                                            style=QtCore.Qt.DotLine,
+                                            symbol='o',
+                                            symbolPen=palette.c1,
+                                            symbolBrush=palette.c1,
+                                            symbolSize=7)
+
         self._pa.pulse_analysis_PlotWidget.addItem(self.signal_image)
-        self.signal_image2 = pg.PlotDataItem(pen=palette.c4)
+        self.signal_image2 = pg.PlotDataItem(pen=pg.mkPen(palette.c4,
+                                                          style=QtCore.Qt.DotLine),
+                                             style=QtCore.Qt.DotLine,
+                                             symbol='o',
+                                             symbolPen=palette.c4,
+                                             symbolBrush=palette.c4,
+                                             symbolSize=7)
         self._pa.pulse_analysis_PlotWidget.addItem(self.signal_image2)
         self._pa.pulse_analysis_PlotWidget.showGrid(x=True, y=True, alpha=0.8)
 

--- a/logic/fitmethods/sinemethods.py
+++ b/logic/fitmethods/sinemethods.py
@@ -23,7 +23,7 @@ top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi
 
 import numpy as np
 from lmfit.models import Model
-from core.util.units import compute_dft
+from core.util.units import compute_ft
 
 
 ################################################################################
@@ -415,7 +415,7 @@ def estimate_baresine(self, x_axis, data, params):
 
     # calculate dft with zeropadding to obtain nicer interpolation between the
     # appearing peaks.
-    dft_x, dft_y = compute_dft(x_axis, data, zeropad_num=1)
+    dft_x, dft_y = compute_ft(x_axis, data, zeropad_num=1)
 
     stepsize = x_axis[1]-x_axis[0]  # for frequency axis
     frequency_max = np.abs(dft_x[np.log(dft_y).argmax()])
@@ -481,7 +481,7 @@ def estimate_sinewithoutoffset(self, x_axis, data, params):
 
     # calculate dft with zeropadding to obtain nicer interpolation between the
     # appearing peaks.
-    dft_x, dft_y = compute_dft(x_axis, data, zeropad_num=1)
+    dft_x, dft_y = compute_ft(x_axis, data, zeropad_num=1)
 
     stepsize = x_axis[1] - x_axis[0]  # for frequency axis
 
@@ -742,7 +742,7 @@ def estimate_sineexponentialdecay(self, x_axis, data, params=None):
     # estimate amplitude
     ampl_val = max(np.abs(data_level.min()), np.abs(data_level.max()))
 
-    dft_x, dft_y = compute_dft(x_axis, data_level, zeropad_num=1)
+    dft_x, dft_y = compute_ft(x_axis, data_level, zeropad_num=1)
 
     stepsize = x_axis[1] - x_axis[0]  # for frequency axis
 

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -1093,11 +1093,12 @@ class PulsedMeasurementLogic(GenericLogic):
 
         else:
             ax1.plot(x_axis_scaled, self.signal_plot_y, '-o', color=colors[0],
-                     linestyle=':', linewidth=0.5)
+                     linestyle=':', linewidth=0.5, label='data trace 1')
 
             if self.alternating:
                 ax1.plot(x_axis_scaled, self.signal_plot_y2, '-o',
-                         color=colors[3], linestyle=':', linewidth=0.5)
+                         color=colors[3], linestyle=':', linewidth=0.5,
+                         label='data trace 2')
 
         # Do not include fit curve if there is no fit calculated.
         if max(self.signal_plot_y_fit) > 0:
@@ -1169,7 +1170,8 @@ class PulsedMeasurementLogic(GenericLogic):
             x_axis_ft_scaled = self.signal_fft_x / scaled_float.scale_val
 
             ax2.plot(x_axis_ft_scaled, self.signal_fft_y, '-o',
-                     linestyle=':', linewidth=0.5, color=colors[0])
+                     linestyle=':', linewidth=0.5, color=colors[0],
+                     label='FT of data trace 1')
 
             # since no ft units are provided, make a small work around:
             if controlled_val_unit == 's':
@@ -1181,7 +1183,8 @@ class PulsedMeasurementLogic(GenericLogic):
 
             ax2.set_xlabel('Fourier Transformed controlled variable (' + x_axis_prefix + inverse_cont_var + ')')
             ax2.set_ylabel('Fourier amplitude (arb.u.)')
-
+            ax2.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc=3, ncol=2,
+                       mode="expand", borderaxespad=0.)
 
         #FIXME: no fit plot for the alternating graph, use for that graph colors[5]
 
@@ -1189,8 +1192,10 @@ class PulsedMeasurementLogic(GenericLogic):
         ax1.set_ylabel('norm. sig (arb.u.)')
 
         fig.tight_layout()
-        plt.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc=3, ncol=2,
+        ax1.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc=3, ncol=2,
                    mode="expand", borderaxespad=0.)
+        # plt.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc=3, ncol=2,
+        #            mode="expand", borderaxespad=0.)
 
         self._save_logic.save_data(data, timestamp=timestamp,
                                    parameters=parameters, fmt='%.15e',

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -1093,33 +1093,41 @@ class PulsedMeasurementLogic(GenericLogic):
                      label='fit data trace 1')
 
             # add then the fit result to the plot:
+
+            # Parameters for the text plot:
+            # The position of the text annotation is controlled with the
+            # relative offset in x direction and the relative length factor
+            # rel_len_fac of the longest entry in one column
+            rel_offset = 0.02
+            rel_len_fac = 0.011  #
             entries_per_col = 24
+
+            # create the formated fit text:
             fit_res = units.create_formatted_output(self.fc.current_fit_result.result_str_dict)
 
+            # do reverse processing to get each entry in a list
             entry_list = fit_res.split('\n')
+            # slice the entry_list in entries_per_col
             chunks = [entry_list[x:x+entries_per_col] for x in range(0, len(entry_list), entries_per_col)]
 
-            offset = 0.02
-            mult_fact = 0.011
-
-            is_first_column = True
-            shift = offset
+            is_first_column = True  # first entry should contain
+            shift = rel_offset
 
             for column in chunks:
 
-                max_length = max(column, key=len)
-
+                max_length = max(column, key=len)   # get the longest entry
                 column_text = ''
 
                 for entry in column:
                     column_text += entry + '\n'
 
-                column_text = column_text[:-1]
+                column_text = column_text[:-1]  # remove the last new line
 
+                heading = '\n'
                 if is_first_column:
-                    column_text = 'Fit results:\n' + column_text
-                else:
-                    column_text = '\n' + column_text
+                    heading = 'Fit results:\n'
+
+                column_text = heading + '\n' + column_text
 
                 ax1.text(1.00 + shift, 0.99, column_text,
                          verticalalignment='top',
@@ -1127,12 +1135,13 @@ class PulsedMeasurementLogic(GenericLogic):
                          transform=ax1.transAxes,
                          fontsize=12)
 
-                shift += mult_fact * len(max_length)
+                # the shift in position of the text is a linear function
+                # which depends on the longest entry in the column
+                shift += rel_len_fac * len(max_length)
 
                 is_first_column = False
 
-        #FIXME: no plot for the alternating graph, use for that graph colors[5]
-        # ax1.ticklabel_format(style='sci', axis='x', scilimits=(0, 0))
+        #FIXME: no fit plot for the alternating graph, use for that graph colors[5]
 
         ax1.set_xlabel('controlled variable (' + counts_prefix + controlled_val_unit + ')')
         ax1.set_ylabel('norm. sig (arb.u.)')
@@ -1149,6 +1158,7 @@ class PulsedMeasurementLogic(GenericLogic):
         #####################################################################
         ####                Save raw data timetrace                      ####
         #####################################################################
+
         if tag is not None and len(tag) > 0:
             filelabel = tag + '_raw_timetrace'
         else:

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -1104,7 +1104,7 @@ class PulsedMeasurementLogic(GenericLogic):
             x_axis_fit_scaled = self.signal_plot_x_fit / scaled_float.scale_val
             ax1.plot(x_axis_fit_scaled, self.signal_plot_y_fit,
                      color=colors[2], marker='None', linewidth=1.5,
-                     label='fit data trace 1')
+                     label='fit: {0}'.format(self.fc.current_fit))
 
             # add then the fit result to the plot:
 

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -29,7 +29,8 @@ import matplotlib.pyplot as plt
 from core.module import Connector, ConfigOption, StatusVar
 from core.util.mutex import Mutex
 from core.util.network import netobtain
-from core.util.units import ScaledFloat
+from core.util import units
+from core.util.units import create_formatted_output
 from logic.generic_logic import GenericLogic
 
 
@@ -1056,7 +1057,7 @@ class PulsedMeasurementLogic(GenericLogic):
 
         # scale the x_axis for plotting
         max_val = np.max(self.signal_plot_x)
-        scaled_float = ScaledFloat(max_val)
+        scaled_float = units.ScaledFloat(max_val)
         counts_prefix = scaled_float.scale
         x_axis_scaled = self.signal_plot_x / scaled_float.scale_val
 
@@ -1090,6 +1091,45 @@ class PulsedMeasurementLogic(GenericLogic):
             ax1.plot(x_axis_fit_scaled, self.signal_plot_y_fit,
                      color=colors[2], marker='None', linewidth=1.5,
                      label='fit data trace 1')
+
+            # add then the fit result to the plot:
+            entries_per_col = 24
+            fit_res = units.create_formatted_output(self.fc.current_fit_result.result_str_dict)
+
+            entry_list = fit_res.split('\n')
+            chunks = [entry_list[x:x+entries_per_col] for x in range(0, len(entry_list), entries_per_col)]
+
+            offset = 0.02
+            mult_fact = 0.011
+
+            is_first_column = True
+            shift = offset
+
+            for column in chunks:
+
+                max_length = max(column, key=len)
+
+                column_text = ''
+
+                for entry in column:
+                    column_text += entry + '\n'
+
+                column_text = column_text[:-1]
+
+                if is_first_column:
+                    column_text = 'Fit results:\n' + column_text
+                else:
+                    column_text = '\n' + column_text
+
+                ax1.text(1.00 + shift, 0.99, column_text,
+                         verticalalignment='top',
+                         horizontalalignment='left',
+                         transform=ax1.transAxes,
+                         fontsize=12)
+
+                shift += mult_fact * len(max_length)
+
+                is_first_column = False
 
         #FIXME: no plot for the alternating graph, use for that graph colors[5]
         # ax1.ticklabel_format(style='sci', axis='x', scilimits=(0, 0))

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -1073,7 +1073,8 @@ class PulsedMeasurementLogic(GenericLogic):
 
         # Do not include fit curve if there is no fit calculated.
         if max(self.signal_plot_y_fit) > 0:
-            ax1.plot(self.signal_plot_x_fit, self.signal_plot_y_fit,
+            x_axis_fit_scaled = self.signal_plot_x_fit / scaled_float.scale_val
+            ax1.plot(x_axis_fit_scaled, self.signal_plot_y_fit,
                      color=colors[2], marker='None', linewidth=1.5,
                      label='fit data trace 1')
 

--- a/notebooks/fit_testing_N14.ipynb
+++ b/notebooks/fit_testing_N14.ipynb
@@ -6,13 +6,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lmfit import Parameters\n",
-    "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
     "from scipy.interpolate import InterpolatedUnivariateSpline\n",
-    "from scipy.signal import wiener, filtfilt, butter, gaussian, freqz\n",
-    "from scipy.ndimage import filters\n",
-    "from core.util.units import compute_dft"
+    "from scipy.signal import wiener\n",
+    "from scipy.ndimage import filters"
    ]
   },
   {
@@ -236,7 +233,7 @@
     "    plt.ylabel('Counts (#)')\n",
     "    plt.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc=3,\n",
     "               ncol=2, mode=\"expand\", borderaxespad=0.)\n",
-    "    plt.show()\n"
+    "    plt.show()"
    ]
   },
   {
@@ -253,7 +250,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -276,5 +275,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }

--- a/notebooks/fit_testing_N15.ipynb
+++ b/notebooks/fit_testing_N15.ipynb
@@ -7,12 +7,10 @@
    "outputs": [],
    "source": [
     "from lmfit import Parameters\n",
-    "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
     "from scipy.interpolate import InterpolatedUnivariateSpline\n",
-    "from scipy.signal import wiener, filtfilt, butter, gaussian, freqz\n",
-    "from scipy.ndimage import filters\n",
-    "from core.util.units import compute_dft"
+    "from scipy.signal import wiener\n",
+    "from scipy.ndimage import filters"
    ]
   },
   {
@@ -199,7 +197,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -222,5 +222,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }

--- a/notebooks/fit_testing_exponential.ipynb
+++ b/notebooks/fit_testing_exponential.ipynb
@@ -8,13 +8,10 @@
    },
    "outputs": [],
    "source": [
-    "from lmfit import Parameters\n",
-    "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
     "from scipy.interpolate import InterpolatedUnivariateSpline\n",
-    "from scipy.signal import wiener, filtfilt, butter, gaussian, freqz\n",
-    "from scipy.ndimage import filters\n",
-    "from core.util.units import compute_dft"
+    "from scipy.signal import wiener\n",
+    "from scipy.ndimage import filters"
    ]
   },
   {
@@ -81,7 +78,7 @@
     "    print(result.fit_report())\n",
     "    plt.plot(x_axis, result.init_fit, '-y', linewidth=2.0)\n",
     "    plt.plot(x_axis, result.best_fit, '-r', linewidth=2.0)\n",
-    "    plt.show()\n"
+    "    plt.show()"
    ]
   },
   {
@@ -290,7 +287,9 @@
     "collapsed": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -313,5 +312,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }

--- a/notebooks/fit_testing_gaussian.ipynb
+++ b/notebooks/fit_testing_gaussian.ipynb
@@ -6,13 +6,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lmfit import Parameters\n",
-    "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
     "from scipy.interpolate import InterpolatedUnivariateSpline\n",
-    "from scipy.signal import wiener, filtfilt, butter, gaussian, freqz\n",
-    "from scipy.ndimage import filters\n",
-    "from core.util.units import compute_dft"
+    "from scipy.signal import wiener\n",
+    "from scipy.ndimage import filters"
    ]
   },
   {
@@ -402,7 +399,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -425,5 +424,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }

--- a/notebooks/fit_testing_hyperbolicsaturation.ipynb
+++ b/notebooks/fit_testing_hyperbolicsaturation.ipynb
@@ -7,12 +7,10 @@
    "outputs": [],
    "source": [
     "from lmfit import Parameters\n",
-    "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
     "from scipy.interpolate import InterpolatedUnivariateSpline\n",
-    "from scipy.signal import wiener, filtfilt, butter, gaussian, freqz\n",
-    "from scipy.ndimage import filters\n",
-    "from core.util.units import compute_dft"
+    "from scipy.signal import wiener\n",
+    "from scipy.ndimage import filters"
    ]
   },
   {
@@ -48,7 +46,7 @@
     "    plt.legend(bbox_to_anchor=(0, 1.02, 1, .102), loc=3, ncol=2, mode=\"expand\", borderaxespad=0)\n",
     "    plt.show()\n",
     "\n",
-    "    print(result.message)\n"
+    "    print(result.message)"
    ]
   },
   {
@@ -65,7 +63,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -88,5 +88,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/notebooks/fit_testing_lorentzian.ipynb
+++ b/notebooks/fit_testing_lorentzian.ipynb
@@ -7,12 +7,10 @@
    "outputs": [],
    "source": [
     "from lmfit import Parameters\n",
-    "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
     "from scipy.interpolate import InterpolatedUnivariateSpline\n",
-    "from scipy.signal import wiener, filtfilt, butter, gaussian, freqz\n",
-    "from scipy.ndimage import filters\n",
-    "from core.util.units import compute_dft"
+    "from scipy.signal import wiener\n",
+    "from scipy.ndimage import filters"
    ]
   },
   {
@@ -20,7 +18,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   },
   {
    "cell_type": "code",
@@ -450,7 +450,7 @@
     "    plt.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc=3, ncol=2, mode=\"expand\", borderaxespad=0.)\n",
     "\n",
     "    plt.show()\n",
-    "    print(result.fit_report())\n"
+    "    print(result.fit_report())"
    ]
   },
   {
@@ -542,7 +542,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -565,5 +567,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }

--- a/notebooks/fit_testing_poissonian.ipynb
+++ b/notebooks/fit_testing_poissonian.ipynb
@@ -7,12 +7,10 @@
    "outputs": [],
    "source": [
     "from lmfit import Parameters\n",
-    "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
     "from scipy.interpolate import InterpolatedUnivariateSpline\n",
-    "from scipy.signal import wiener, filtfilt, butter, gaussian, freqz\n",
-    "from scipy.ndimage import filters\n",
-    "from core.util.units import compute_dft"
+    "from scipy.signal import wiener, gaussian\n",
+    "from scipy.ndimage import filters"
    ]
   },
   {
@@ -129,7 +127,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -152,5 +152,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }

--- a/notebooks/fit_testing_sine.ipynb
+++ b/notebooks/fit_testing_sine.ipynb
@@ -8,13 +8,11 @@
    },
    "outputs": [],
    "source": [
-    "from lmfit import Parameters\n",
-    "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
     "from scipy.interpolate import InterpolatedUnivariateSpline\n",
-    "from scipy.signal import wiener, filtfilt, butter, gaussian, freqz\n",
+    "from scipy.signal import wiener\n",
     "from scipy.ndimage import filters\n",
-    "from core.util.units import compute_dft"
+    "from core.util.units import compute_ft"
    ]
   },
   {
@@ -57,7 +55,7 @@
     "\n",
     "    # calculate dft with zeropadding to obtain nicer interpolation between the\n",
     "    # appearing peaks.\n",
-    "    dft_x, dft_y = compute_dft(x_axis, data_level, zeropad_num=1)\n",
+    "    dft_x, dft_y = compute_ft(x_axis, data_level, zeropad_num=1)\n",
     "\n",
     "    plt.figure()\n",
     "    plt.plot(dft_x, dft_y, label='dft of data')\n",
@@ -342,7 +340,7 @@
     "    plt.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc=3, ncol=2, mode=\"expand\", borderaxespad=0.)\n",
     "    plt.show()\n",
     "\n",
-    "    print(result.fit_report())\n"
+    "    print(result.fit_report())"
    ]
   },
   {
@@ -390,7 +388,7 @@
     "\n",
     "    noisy_data = data + data.mean() * np.random.normal(size=x_axis.shape)*3\n",
     "\n",
-    "    x_dft1, y_dft1 = compute_dft(x_val=x_axis, y_val=noisy_data, zeropad_num=1)\n",
+    "    x_dft1, y_dft1 = compute_ft(x_val=x_axis, y_val=noisy_data, zeropad_num=1)\n",
     "\n",
     "    plt.figure()\n",
     "    plt.plot(x_axis, noisy_data, 'o--', label='noisy_data')\n",
@@ -403,14 +401,14 @@
     "    res1 = fitlogic.make_sine_fit(x_axis=x_axis, data=noisy_data, estimator=fitlogic.estimate_sine)\n",
     "    data_sub1 = noisy_data - res1.best_fit\n",
     "\n",
-    "    x_dft2, y_dft2 = compute_dft(x_val=x_axis, y_val=data_sub1, zeropad_num=1)\n",
+    "    x_dft2, y_dft2 = compute_ft(x_val=x_axis, y_val=data_sub1, zeropad_num=1)\n",
     "\n",
     "    res2 = fitlogic.make_sine_fit(x_axis=x_axis, data=data_sub1, estimator=fitlogic.estimate_sine)\n",
     "    data_sub2 = data_sub1 - res2.best_fit\n",
     "\n",
     "    res3 = fitlogic.make_sine_fit(x_axis=x_axis, data=data_sub2, estimator=fitlogic.estimate_sine)\n",
     "\n",
-    "    x_dft3, y_dft3 = compute_dft(x_val=x_axis, y_val=data_sub2, zeropad_num=1)\n",
+    "    x_dft3, y_dft3 = compute_ft(x_val=x_axis, y_val=data_sub2, zeropad_num=1)\n",
     "\n",
     "    plt.figure()\n",
     "    plt.plot(x_dft1, y_dft1, '-', label='noisy_data (3 peaks)')\n",
@@ -532,7 +530,9 @@
     "collapsed": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -555,5 +555,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }

--- a/notebooks/fit_testing_sine_exponential.ipynb
+++ b/notebooks/fit_testing_sine_exponential.ipynb
@@ -12,7 +12,7 @@
     "from scipy.interpolate import InterpolatedUnivariateSpline\n",
     "from scipy.signal import wiener, filtfilt, butter, gaussian, freqz\n",
     "from scipy.ndimage import filters\n",
-    "from core.util.units import compute_dft"
+    "from core.util.units import compute_ft"
    ]
   },
   {
@@ -96,7 +96,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "def two_sine_exp_decay_offset_testing():\n",
     "    \"\"\" Testing procedure for the implemented two sine with exponential decay\n",
     "        and offset fit. \"\"\"\n",
@@ -403,7 +402,7 @@
     "\n",
     "    noisy_data = data + data.mean() * np.random.normal(size=x_axis.shape) * 1\n",
     "\n",
-    "    x_dft1, y_dft1 = compute_dft(x_val=x_axis, y_val=noisy_data, zeropad_num=1)\n",
+    "    x_dft1, y_dft1 = compute_ft(x_val=x_axis, y_val=noisy_data, zeropad_num=1)\n",
     "\n",
     "    plt.figure()\n",
     "    plt.plot(x_axis, noisy_data, 'o--', label='noisy_data')\n",
@@ -420,7 +419,7 @@
     "    \n",
     "    \n",
     "    data_sub1 = noisy_data - res1.best_fit\n",
-    "    x_dft2, y_dft2 = compute_dft(x_val=x_axis, y_val=data_sub1, zeropad_num=1)\n",
+    "    x_dft2, y_dft2 = compute_ft(x_val=x_axis, y_val=data_sub1, zeropad_num=1)\n",
     "\n",
     "    res2 = fitlogic.make_sineexponentialdecay_fit(\n",
     "        x_axis=x_axis,\n",
@@ -433,7 +432,7 @@
     "        data=data_sub2,\n",
     "        estimator=fitlogic.estimate_sineexponentialdecay)\n",
     "\n",
-    "    x_dft3, y_dft3 = compute_dft(x_val=x_axis, y_val=data_sub2, zeropad_num=1)\n",
+    "    x_dft3, y_dft3 = compute_ft(x_val=x_axis, y_val=data_sub2, zeropad_num=1)\n",
     "\n",
     "    plt.figure()\n",
     "    plt.plot(x_dft1, y_dft1, '-', label='noisy_data (3 peaks)')\n",
@@ -555,7 +554,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "def three_sine_three_exp_decay_offset_testing():\n",
     "    \"\"\" Testing procedure for the estimator for a three sine with three\n",
     "        exponential decays and with offset fit. \"\"\"\n",
@@ -586,7 +584,7 @@
     "\n",
     "    noisy_data = data + data.mean() * np.random.normal(size=x_axis.shape)*1\n",
     "\n",
-    "    x_dft1, y_dft1 = compute_dft(x_val=x_axis, y_val=noisy_data, zeropad_num=1)\n",
+    "    x_dft1, y_dft1 = compute_ft(x_val=x_axis, y_val=noisy_data, zeropad_num=1)\n",
     "\n",
     "    plt.figure()\n",
     "    plt.plot(x_axis, noisy_data, 'o--', label='noisy_data')\n",
@@ -602,7 +600,7 @@
     "        estimator=fitlogic.estimate_sineexponentialdecay)\n",
     "    \n",
     "    data_sub1 = noisy_data - res1.best_fit\n",
-    "    x_dft2, y_dft2 = compute_dft(x_val=x_axis, y_val=data_sub1, zeropad_num=1)\n",
+    "    x_dft2, y_dft2 = compute_ft(x_val=x_axis, y_val=data_sub1, zeropad_num=1)\n",
     "    res2 = fitlogic.make_sineexponentialdecay_fit(\n",
     "        x_axis=x_axis,\n",
     "        data=data_sub1,\n",
@@ -614,7 +612,7 @@
     "        data=data_sub2,\n",
     "        estimator=fitlogic.estimate_sineexponentialdecay)\n",
     "\n",
-    "    x_dft3, y_dft3 = compute_dft(x_val=x_axis, y_val=data_sub2, zeropad_num=1)\n",
+    "    x_dft3, y_dft3 = compute_ft(x_val=x_axis, y_val=data_sub2, zeropad_num=1)\n",
     "\n",
     "    plt.figure()\n",
     "    plt.plot(x_dft1, y_dft1, '-', label='noisy_data (3 peaks)')\n",
@@ -737,7 +735,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/fit_testing_voigt.ipynb
+++ b/notebooks/fit_testing_voigt.ipynb
@@ -7,12 +7,10 @@
    "outputs": [],
    "source": [
     "from lmfit import Parameters, models\n",
-    "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
     "from scipy.interpolate import InterpolatedUnivariateSpline\n",
-    "from scipy.signal import wiener, filtfilt, butter, gaussian, freqz\n",
-    "from scipy.ndimage import filters\n",
-    "from core.util.units import compute_dft"
+    "from scipy.signal import wiener\n",
+    "from scipy.ndimage import filters"
    ]
   },
   {
@@ -122,7 +120,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {

--- a/tools/fit_logic_standalone.py
+++ b/tools/fit_logic_standalone.py
@@ -55,7 +55,7 @@ import os
 
 #matplotlib.rcParams.update({'font.size': 12})
 
-from core.util.units import compute_dft
+from core.util.units import compute_ft
 
 
 class FitLogic():
@@ -1864,7 +1864,7 @@ def lorentziandip_testing2():
 
     data_nice = mod.eval(x=x_axis,params=params)
     data_noisy = data_nice + 2.0*np.random.normal(size=x_axis.shape)
-    
+
     print(qudi_fitting.estimate_lorentzian_dip)
 
 
@@ -1880,7 +1880,7 @@ def lorentziandip_testing2():
 
     print(result.fit_report())
     print(result.result_str_dict)
-    
+
 
 def lorentzianpeak_testing2():
     """ Test the lorentzian fit directy with simulated data. """
@@ -2142,7 +2142,7 @@ def sine_testing():
 
     # calculate dft with zeropadding to obtain nicer interpolation between the
     # appearing peaks.
-    dft_x, dft_y = compute_dft(x_axis, data_level, zeropad_num=1)
+    dft_x, dft_y = compute_ft(x_axis, data_level, zeropad_num=1)
 
     plt.figure()
     plt.plot(dft_x, dft_y, label='dft of data')
@@ -2307,7 +2307,7 @@ def sine_testing_data():
     # estimate amplitude
     ampl_val = max(np.abs(data_level.min()), np.abs(data_level.max()))
 
-    dft_x, dft_y = compute_dft(x_axis, data_level, zeropad_num=1)
+    dft_x, dft_y = compute_ft(x_axis, data_level, zeropad_num=1)
 
     stepsize = x_axis[1]-x_axis[0]  # for frequency axis
 #            freq = np.fft.fftfreq(data_level_zeropaded.size, stepsize)
@@ -2675,10 +2675,10 @@ def double_poissonian_testing_data():
 
 
 ###############################################################################
-    
+
 def exponentialdecay_testing():
     """ Implementation of the estimator for exponential decay fitting. """
-    
+
     x_axis = np.linspace(1, 51, 30)
     x_nice = np.linspace(x_axis[0], x_axis[-1], 100)
     mod, params = qudi_fitting.make_decayexponential_model()
@@ -2694,7 +2694,7 @@ def exponentialdecay_testing():
     data = mod.eval(x=x_axis, params=params)
     data_nice = mod.eval(x=x_nice, params=params)
     data_noisy = data + 5* np.random.normal(size=x_axis.shape)
-    
+
     plt.figure()
     plt.plot(x_axis, data_noisy, 'ob', label='noisy data')
     plt.plot(x_nice, data_nice, '-g', label='nice data')
@@ -2712,28 +2712,28 @@ def exponentialdecay_testing():
         data_level = offset - data_noisy
     else:
         data_level = data_noisy - offset
-        
+
     # check if the data level contain still negative values and correct
     # the data level therefore. Otherwise problems in the logarithm appear.
     if data_level.min() <= 0:
         data_level = data_level - data_level.min()
-        
+
     for i in range(0, len(x_axis)):
         if data_level[i] <= data_level.std():
             break
     print('Index stopped at "{0}" from total {1}'.format(i, len(x_axis)))
-    
+
     # values and bound of parameter.
     ampl = data_noisy[-max(1, int(len(x_axis) / 10)):].std()
     min_lifetime = 2 * (x_axis[1] - x_axis[0])
-    
+
     data_level_log = np.log(data_level[0:i])
     linear_result = qudi_fitting.make_linear_fit(
-                        x_axis=x_axis[0:i], 
-                        data=data_level_log, 
-                        estimator=qudi_fitting.estimate_linear, 
+                        x_axis=x_axis[0:i],
+                        data=data_level_log,
+                        estimator=qudi_fitting.estimate_linear,
                         add_params=None)
-    
+
     plt.figure()
     plt.plot(x_axis[0:i], data_level_log, 'ob', label='logarithmic data')
     plt.plot(x_axis[0:i], linear_result.best_fit,'-r', label='best fit')
@@ -2752,11 +2752,11 @@ def exponentialdecay_testing():
         params['amplitude'].set(value=-np.exp(linear_result.params['offset'].value), max=-ampl)
     else:
         params['amplitude'].set(value=np.exp(linear_result.params['offset'].value), min=ampl)
-    
+
     params['offset'].set(value=offset)
-    
+
     result = mod.fit(data_noisy, x=x_axis, params=params)
-    
+
 
     plt.figure()
     plt.plot(x_axis, data_noisy, 'ob', label='noisy data')
@@ -2767,13 +2767,13 @@ def exponentialdecay_testing():
                ncol=2, mode="expand", borderaxespad=0.,
                prop={'size':12})
     plt.show()
-    
+
     print(result.fit_report())
-    
-    
+
+
 def exponentialdecay_testing2():
     """ Check the implemented estimator directly from fitlogic"""
-    
+
     #generation of data for testing
     x_axis = np.linspace(1, 51, 20)
     x_nice = np.linspace(x_axis[0], x_axis[-1], 100)
@@ -2790,12 +2790,12 @@ def exponentialdecay_testing2():
     data = mod.eval(x=x_axis, params=params)
     data_nice = mod.eval(x=x_nice, params=params)
     data_noisy = data + 5* np.random.normal(size=x_axis.shape)
-    
+
     # perform fit
     result = qudi_fitting.make_decayexponential_fit(
-                x_axis=x_axis, 
-                data=data_noisy, 
-                estimator=qudi_fitting.estimate_decayexponential, 
+                x_axis=x_axis,
+                data=data_noisy,
+                estimator=qudi_fitting.estimate_decayexponential,
                 add_params=None)
 
     plt.figure()
@@ -2807,12 +2807,12 @@ def exponentialdecay_testing2():
                ncol=2, mode="expand", borderaxespad=0.,
                prop={'size':12})
     plt.show()
-    
+
     print(result.fit_report())
 ###########################################################################################
 def bareexponentialdecay_testing():
     """ Implement the estimator for the bare exponential testing. """
-    
+
     #generation of data for testing
     x_axis = np.linspace(1, 51, 20)
     x_nice = np.linspace(x_axis[0], x_axis[-1], 100)
@@ -2833,7 +2833,7 @@ def bareexponentialdecay_testing():
     for i in range(0, len(x_axis)):
         if data[i] <= data.std():
             break
-        
+
     print('Index stopped at "{0}" from total {1}'.format(i, len(x_axis)))
 
     offset = data_noisy.min()
@@ -2860,9 +2860,9 @@ def bareexponentialdecay_testing():
     data_log = np.log(leveled_data)
 
     linear_result = qudi_fitting.make_linear_fit(
-                        x_axis=x_axis[0:i], 
-                        data=data_log[0:i], 
-                        estimator=qudi_fitting.estimate_linear, 
+                        x_axis=x_axis[0:i],
+                        data=data_log[0:i],
+                        estimator=qudi_fitting.estimate_linear,
                         add_params=None)
 
     plt.figure()
@@ -2876,10 +2876,10 @@ def bareexponentialdecay_testing():
     plt.show()
 
     mod, params = qudi_fitting.make_bareexponentialdecay_model()
-    
+
     min_lifetime = 2 * (x_axis[1] - x_axis[0])
     params['lifetime'].set(value=-1/linear_result.params['slope'].value, min=min_lifetime)
-    
+
     result = mod.fit(data_noisy, x=x_axis, params=params)
 #
     plt.figure()
@@ -2982,7 +2982,7 @@ def sineexponentialdecay_testing_data():
     # estimate amplitude
     ampl_val = max(np.abs(data_level.min()),np.abs(data_level.max()))
 
-    dft_x, dft_y = compute_dft(x_axis, data_level, zeropad_num=1)
+    dft_x, dft_y = compute_ft(x_axis, data_level, zeropad_num=1)
 
     stepsize = x_axis[1] - x_axis[0]  # for frequency axis
 
@@ -3717,7 +3717,7 @@ def three_sine_offset_testing():
 
     noisy_data = data + data.mean() * np.random.normal(size=x_axis.shape)*3
 
-    x_dft1, y_dft1 = compute_dft(x_val=x_axis, y_val=noisy_data, zeropad_num=1)
+    x_dft1, y_dft1 = compute_ft(x_val=x_axis, y_val=noisy_data, zeropad_num=1)
 
     plt.figure()
     plt.plot(x_axis, noisy_data, 'o--', label='noisy_data')
@@ -3731,14 +3731,14 @@ def three_sine_offset_testing():
     res1 = qudi_fitting.make_sine_fit(x_axis=x_axis, data=noisy_data)
     data_sub1 = noisy_data - res1.best_fit
 
-    x_dft2, y_dft2 = compute_dft(x_val=x_axis, y_val=data_sub1, zeropad_num=1)
+    x_dft2, y_dft2 = compute_ft(x_val=x_axis, y_val=data_sub1, zeropad_num=1)
 
     res2 = qudi_fitting.make_sine_fit(x_axis=x_axis, data=data_sub1)
     data_sub2 = data_sub1 - res2.best_fit
 
     res3 = qudi_fitting.make_sine_fit(x_axis=x_axis, data=data_sub2)
 
-    x_dft3, y_dft3 = compute_dft(x_val=x_axis, y_val=data_sub2, zeropad_num=1)
+    x_dft3, y_dft3 = compute_ft(x_val=x_axis, y_val=data_sub2, zeropad_num=1)
 
     plt.figure()
     plt.plot(x_dft1, y_dft1, '-', label='noisy_data (3 peaks)')
@@ -3845,7 +3845,7 @@ def three_sine_exp_decay_offset_testing():
 
     noisy_data = data + data.mean() * np.random.normal(size=x_axis.shape)*1
 
-    x_dft1, y_dft1 = compute_dft(x_val=x_axis, y_val=noisy_data, zeropad_num=1)
+    x_dft1, y_dft1 = compute_ft(x_val=x_axis, y_val=noisy_data, zeropad_num=1)
 
     plt.figure()
     plt.plot(x_axis, noisy_data, 'o--', label='noisy_data')
@@ -3859,14 +3859,14 @@ def three_sine_exp_decay_offset_testing():
     res1 = qudi_fitting.make_sineexponentialdecay_fit(x_axis=x_axis, data=noisy_data)
     data_sub1 = noisy_data - res1.best_fit
 
-    x_dft2, y_dft2 = compute_dft(x_val=x_axis, y_val=data_sub1, zeropad_num=1)
+    x_dft2, y_dft2 = compute_ft(x_val=x_axis, y_val=data_sub1, zeropad_num=1)
 
     res2 = qudi_fitting.make_sineexponentialdecay_fit(x_axis=x_axis, data=data_sub1)
     data_sub2 = data_sub1 - res2.best_fit
 
     res3 = qudi_fitting.make_sineexponentialdecay_fit(x_axis=x_axis, data=data_sub2)
 
-    x_dft3, y_dft3 = compute_dft(x_val=x_axis, y_val=data_sub2, zeropad_num=1)
+    x_dft3, y_dft3 = compute_ft(x_val=x_axis, y_val=data_sub2, zeropad_num=1)
 
     plt.figure()
     plt.plot(x_dft1, y_dft1, '-', label='noisy_data (3 peaks)')
@@ -3984,7 +3984,7 @@ def three_sine_three_exp_decay_offset_testing():
 
     noisy_data = data + data.mean() * np.random.normal(size=x_axis.shape)*1
 
-    x_dft1, y_dft1 = compute_dft(x_val=x_axis, y_val=noisy_data, zeropad_num=1)
+    x_dft1, y_dft1 = compute_ft(x_val=x_axis, y_val=noisy_data, zeropad_num=1)
 
     plt.figure()
     plt.plot(x_axis, noisy_data, 'o--', label='noisy_data')
@@ -3998,14 +3998,14 @@ def three_sine_three_exp_decay_offset_testing():
     res1 = qudi_fitting.make_sineexponentialdecay_fit(x_axis=x_axis, data=noisy_data)
     data_sub1 = noisy_data - res1.best_fit
 
-    x_dft2, y_dft2 = compute_dft(x_val=x_axis, y_val=data_sub1, zeropad_num=1)
+    x_dft2, y_dft2 = compute_ft(x_val=x_axis, y_val=data_sub1, zeropad_num=1)
 
     res2 = qudi_fitting.make_sineexponentialdecay_fit(x_axis=x_axis, data=data_sub1)
     data_sub2 = data_sub1 - res2.best_fit
 
     res3 = qudi_fitting.make_sineexponentialdecay_fit(x_axis=x_axis, data=data_sub2)
 
-    x_dft3, y_dft3 = compute_dft(x_val=x_axis, y_val=data_sub2, zeropad_num=1)
+    x_dft3, y_dft3 = compute_ft(x_val=x_axis, y_val=data_sub2, zeropad_num=1)
 
     plt.figure()
     plt.plot(x_dft1, y_dft1, '-', label='noisy_data (3 peaks)')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enhance mainly the saved output of pulsed measurements. The following changes had to be made for that:
- Changes to the file core/util/units.py:
  - Add to the Class ScaledFloat the ability to retrieve the scaled factor.
  - Implement a variety of window functions (together with their correct amplitude scale factors), which can be applied before performing a fourier transformation. This prevents mainly spectral leakage.
  - Rename the method compute_dft to compute_ft and greatly enhance the capabilities of that function (i.e. add abilities to control window functions, base line correction, zeropadding and calculation of power spectral density instead of fourier transform). Apply this rename throughout the whole qudi repository.
- In pulsed_measurement_logic:
  - Replace the fourier transform function my the more general one from core/util/units.py.
  - Restructure the method save_measurement_data, add doc strings, add the possibility to save the fit parameter directly in the graph. Enhance significantly the appearance of the output graph (see added screenshots below).
  - Add variables to control the fourier transform, right know mainly for scripting abilities. These variables are not connected to the GUI so far, hence, you cannot apply those changes through the pulsed main GUI. The reason for that is that the parameter changes of the fourier transform are not handled separately in the logic. They are all bounded to the signal sigSignalDataUpdated. Making the fourier transform parameter accessible by the GUI requires an adaptation of that signal and its chain to the GUI. That should be done in another pull request to prevent breaking changes by this pull request.
- In pulsed main GUI:
  -  Make the display of the signal graph and the fit graph similar to the saved graphs.
  - Use the excising qudi color codes for a better visual representation of measurement data, errors and fit.  

- Please note, 'a.u.' is the abbreviation for 'atomic units', whereas 'arb.u.' is the one for 'arbitrary units'.  

This branch has been rebase onto master.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Reduce hopefully the need for post processing the data upon save.

Moreover the calculation of a fourier transform should be just in one place (and not individually implemented in several files)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The data shown in the 'Screenshot' section are taken during experiment. The same configuration was also tested in the dummy (default) configuration.

## Screenshots:

This was the output graph before the changes:

![20170822-1143-18_test-pulse_pulsed_measurement_fig](https://user-images.githubusercontent.com/18192374/30240966-d8afb672-957a-11e7-8dd6-5476af816b8e.png)

This pull request enables such output graphs:

### Bare measurement data without fourier transform and fit

![20170908-1959-16_test_pulsed_measurement_fig](https://user-images.githubusercontent.com/18192374/30240987-42d45ba2-957b-11e7-8167-a7376b8e12ff.png)

### Measurement with fit and without fourier transform

![20170908-1959-06_test_pulsed_measurement_fig](https://user-images.githubusercontent.com/18192374/30240972-100d22da-957b-11e7-9604-ef84beebd76b.png)

### Measuremetn with fit and with fourier transform

![20170908-1959-33_test_pulsed_measurement_fig](https://user-images.githubusercontent.com/18192374/30240998-6ae73c0e-957b-11e7-8798-48b3043be823.png)

### Increase Zero padding and apply a hamming window

![20170908-1717-25_test_pulsed_measurement_fig](https://user-images.githubusercontent.com/18192374/30241005-8308a098-957b-11e7-8e21-2de63b28e384.png)

### Appearance in the Pulsed GUI:

If the fourier transform parameters are altered in the pulsed_measurement_logic (e.g. by script or by console) the GUI shows the following graphs (where the plot appearance has been adapted to the output graph). Zeropadding set from 0 to 20 (highly insane value) and hamming window was chosen in Fourier transform:

![screenshot_zeropad20_hamming_with_new_points](https://user-images.githubusercontent.com/18192374/30241037-205fddc0-957c-11e7-91e6-80037c812e4b.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [x] All changed Jupyter notebooks have been stripped of their output cells.

