### PR TITLE
Make Qudi kernel for Jupyter notebook read the remote module server configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ install:
     - 'conda env remove --yes --name qudi || exit 0'
     - "conda env create -f %APPVEYOR_BUILD_FOLDER%\\tools\\conda-env-win8-qt5.yml"
     - "activate qudi"
-    - "python %APPVEYOR_BUILD_FOLDER%\\tools\\qudikernel.py install"
+    - "python %APPVEYOR_BUILD_FOLDER%\\core\\qudikernel.py install"
 
 # Not a .NET project, we build in the install step instead
 build: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 
 install:
   - python -c "import matplotlib.pyplot" # generate matplotlib font cache
-  - python tools/qudikernel.py install
+  - python core/qudikernel.py install
   - export PATH=$PATH:$HOME/bin
 
 script:

--- a/documentation/qudi_jupyter_notebook.md
+++ b/documentation/qudi_jupyter_notebook.md
@@ -3,12 +3,21 @@
 1. Install the Qudi Jupyter kernel
   * Ensure that your Anaconda environment or Python installation has
    up-to-date dependencies
-  * In a terminal, go to the `tools` folder in the `qudi` folder
+  * In a terminal, go to the `core` folder in the `qudi` folder
   * Eventually do `activate qudi` to activate the conda environment
   * Do `python qudikernel.py install`
   * This should tell you where the kernel specification was installed
 2. Configure Qudi
-  * Ensure that your Qudi configuration file contains the following 
+ * Ensure that your Qudi configuration file contains the following 
+  entry or an equvalent configuration in the `global` section:
+
+~~~~~~~~~~~~~
+  remote_server:
+    - address: 'localhost'
+    - port: 12345
+~~~~~~~~~~~~~
+
+ * Ensure that your Qudi configuration file contains the following 
   entry in the `logic` section:
 
 ~~~~~~~~~~~~~
@@ -18,7 +27,10 @@
 ~~~~~~~~~~~~~
 
 3. Start the Jupyter notebook server
-  * Run `jupyter notebook` or an equivalent
+  * Run `activate qudi` to activate the conda environment
+  * Run `jupyter notebook` or an equivalent, when starting from the
+  Windows Start menu, be sure to pick the Jupyter notebook installed
+  into the Qudi environment
   * Start Qudi with the configuration you checked before
   * Now, the 'New' menu should have a 'Qudi' entry and in a notebook, 
   the 'Kernel->Change kernel' menu should also have a qudi entry


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The Qudi kernel for Jupyter notebooks will now read the host and port where Qudi is listening for remote connections form the Qudi config file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When the listening address of Qudi is changed from localhost to something else, `qudikernel.py` will fail to connect to Qudi.
Reading the config file allows `qudikernel.py` to always connect to the address and port where Qudi is listening.
For access to the config reader, `qudikernel.py `needs to be moved to the `core` directory, which breaks existing installations.
`qudikernel.py install` needs to be run to make things work again.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Works on my laptop (Linux) and a Win 8.1 lab PC.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
