### PR TITLE
MCS6A is now usable as a gated counter

### DIFF
--- a/hardware/fastcomtec/fastcomtecmcs6.py
+++ b/hardware/fastcomtec/fastcomtecmcs6.py
@@ -25,7 +25,7 @@ top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi
 
 
 
-from core.module import Base
+from core.module import Base, ConfigOption
 from interface.fast_counter_interface import FastCounterInterface
 import time
 import os
@@ -131,6 +131,33 @@ class ACQDATA(ctypes.Structure):
                 ('hcm', ctypes.c_int),
                 ('hct', ctypes.c_int), ]
 
+
+class BOARDSETTING(ctypes.Structure):
+    _fields_ = [('sweepmode',   ctypes.c_long),
+                ('prena',       ctypes.c_long),
+                ('cycles',      ctypes.c_long),
+                ('sequences',   ctypes.c_long),
+                ('syncout',     ctypes.c_long),
+                ('digio',       ctypes.c_long),
+                ('digval',      ctypes.c_long),
+                ('dac0',        ctypes.c_long),
+                ('dac1',        ctypes.c_long),
+                ('dac2',        ctypes.c_long),
+                ('dac3',        ctypes.c_long),
+                ('dac4',        ctypes.c_long),
+                ('dac5',        ctypes.c_long),
+                ('fdac',        ctypes.c_int),
+                ('tagbits',     ctypes.c_int),
+                ('extclk',      ctypes.c_int),
+                ('maxchan',     ctypes.c_long),
+                ('serno',       ctypes.c_long),
+                ('ddruse',      ctypes.c_long),
+                ('active',      ctypes.c_long),
+                ('holdafter',   ctypes.c_double),
+                ('swpreset',    ctypes.c_double),
+                ('fstchan',     ctypes.c_double),
+                ('timepreset',  ctypes.c_double), ]
+
 class FastComtec(Base, FastCounterInterface):
     """
     unstable: Jochen Scheuer, Simon Schmitt
@@ -139,6 +166,7 @@ class FastComtec(Base, FastCounterInterface):
     """
     _modclass = 'FastComtec'
     _modtype = 'hardware'
+    GATED = ConfigOption('gated', False, missing='warn')
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -154,13 +182,17 @@ class FastComtec(Base, FastCounterInterface):
         #this variable has to be added because there is no difference
         #in the fastcomtec it can be on "stopped" or "halt"
         self.stopped_or_halt = "stopped"
+        self.timetrace_tmp = []
 
     def on_activate(self):
         """ Initialisation performed during activation of the module.
         """
 
         self.dll = ctypes.windll.LoadLibrary('C:\Windows\System32\DMCS6.dll')
-
+        if self.GATED:
+            self.change_sweep_mode(gated=True)
+        else:
+            self.change_sweep_mode(gated=False)
         return
 
     def on_deactivate(self):
@@ -211,8 +243,7 @@ class FastComtec(Base, FastCounterInterface):
         constraints['max_sweep_len'] = 6.8
         return constraints
 
-
-    def configure(self, bin_width_s, record_length_s, number_of_gates = 0,filename=None):
+    def configure(self, bin_width_s, record_length_s, number_of_gates=0, filename=None):
         """ Configuration of the fast counter.
 
         @param float bin_width_s: Length of a single time bin in the time trace
@@ -229,15 +260,22 @@ class FastComtec(Base, FastCounterInterface):
                     None if not-gated
         """
 
-        # to make sure no sequence trigger is missed
-        record_length_FastComTech_s = record_length_s - 20e-9
+        # when not gated, record length = total sequence length, when gated, record length = laser length.
+        # subtract 200 ns to make sure no sequence trigger is missed
+        record_length_FastComTech_s = record_length_s
+        if self.GATED:
+            # add 400 ns to account for AOM delay
+            no_of_bins = int((record_length_FastComTech_s + 400e-9) / self.set_binwidth(bin_width_s))
+        else:
+            # subtract 200 ns to make sure no sequence trigger is missed
+            no_of_bins = int((record_length_FastComTech_s - 200e-9) / self.set_binwidth(bin_width_s))
 
-        no_of_bins = int(record_length_FastComTech_s / self.set_binwidth(bin_width_s))
-        self.set_length(no_of_bins)
+        self.set_length(no_of_bins, preset=1, cycles=number_of_gates)
 
         if filename is not None:
             self._change_filename(filename)
-        return (self.get_binwidth(), record_length_FastComTech_s, None)
+
+        return (self.get_binwidth(), record_length_FastComTech_s, number_of_gates)
 
     #card if running or halt or stopped ...
     def get_status(self):
@@ -285,6 +323,9 @@ class FastComtec(Base, FastCounterInterface):
         status = self.dll.Halt(0)
         while self.get_status() != 3:
             time.sleep(0.05)
+
+        if self.GATED:
+            self.timetrace_tmp = self.get_data_trace()
         return status
 
     def stop_measure(self):
@@ -293,13 +334,19 @@ class FastComtec(Base, FastCounterInterface):
         status = self.dll.Halt(0)
         while self.get_status() != 1:
             time.sleep(0.05)
+
+        if self.GATED:
+            self.timetrace_tmp = []
         return status
 
     def continue_measure(self):
         """Continue a paused measurement. """
-        status = self.dll.Continue(0)
-        while self.get_status() != 2:
-            time.sleep(0.05)
+        if self.GATED:
+            status = self.start_measure()
+        else:
+            status = self.dll.Continue(0)
+            while self.get_status() != 2:
+                time.sleep(0.05)
         return status
 
     def get_binwidth(self):
@@ -320,6 +367,16 @@ class FastComtec(Base, FastCounterInterface):
         """
         return self.GATED
 
+    def set_gated(self, gated):
+        """ Check the gated counting possibility.
+
+        @return bool: Boolean value indicates if the fast counter is a gated
+                      counter (TRUE) or not (FALSE).
+        """
+        self.GATED = gated
+        self.change_sweep_mode(gated)
+        return self.GATED
+
     def get_data_trace(self):
         """
         Polls the current timetrace data from the fast counter and returns it as a numpy array (dtype = int64).
@@ -330,14 +387,28 @@ class FastComtec(Base, FastCounterInterface):
 
           @return arrray: Time trace.
         """
-
         setting = AcqSettings()
         self.dll.GetSettingData(ctypes.byref(setting), 0)
-        NN = setting.range
-        data = np.empty((NN,), dtype=np.uint32)
-        self.dll.LVGetDat(data.ctypes.data, 0)
+        N = setting.range
 
-        return np.int64(data)
+        if self.GATED:
+            bsetting=BOARDSETTING()
+            self.dll.GetMCSSetting(ctypes.byref(bsetting), 0)
+            H = bsetting.cycles
+            data = np.empty((H, int(N / H)), dtype=np.uint32)
+
+        else:
+            data = np.empty((N,), dtype=np.uint32)
+
+        p_type_ulong = ctypes.POINTER(ctypes.c_uint32)
+        ptr = data.ctypes.data_as(p_type_ulong)
+        self.dll.LVGetDat(ptr, 0)
+        time_trace = np.int64(data)
+
+        if self.GATED and self.timetrace_tmp != []:
+            time_trace = time_trace + self.timetrace_tmp
+
+        return time_trace
 
 
 
@@ -387,7 +458,7 @@ class FastComtec(Base, FastCounterInterface):
         return self.MINIMAL_BINWIDTH*(2**new_bitshift)
 
     #TODO: Check such that only possible lengths are set.
-    def set_length(self, length_bins):
+    def set_length(self, length_bins, preset=None, cycles=None):
         """ Sets the length of the length of the actual measurement.
 
         @param int length_bins: Length of the measurement in bins
@@ -400,6 +471,12 @@ class FastComtec(Base, FastCounterInterface):
             self.dll.RunCmd(0, bytes(cmd, 'ascii'))
             cmd = 'roimax={0}'.format(int(length_bins))
             self.dll.RunCmd(0, bytes(cmd, 'ascii'))
+            if preset != None:
+                cmd = 'swpreset={0}'.format(preset)
+                self.dll.RunCmd(0, bytes(cmd, 'ascii'))
+            if cycles != None and cycles != 0:
+                cmd = 'cycles={0}'.format(cycles)
+                self.dll.RunCmd(0, bytes(cmd, 'ascii'))
             return self.get_length()
         else:
             self.log.error(
@@ -420,6 +497,23 @@ class FastComtec(Base, FastCounterInterface):
         cmd = 'mpaname=%s'%name
         self.dll.RunCmd(0, bytes(cmd, 'ascii'))
         return name
+
+    def change_sweep_mode(self, gated):
+        if gated:
+            cmd = 'sweepmode={0}'.format(hex(1978500))
+            self.dll.RunCmd(0, bytes(cmd, 'ascii'))
+            cmd = 'prena={0}'.format(hex(16)) #To select starts preset
+            # cmd = 'prena={0}'.format(hex(4)) #To select sweeps preset
+            self.dll.RunCmd(0, bytes(cmd, 'ascii'))
+            self.GATED = True
+        else:
+            # fastcomtch standard settings for ungated acquisition (check manual)
+            cmd = 'sweepmode={0}'.format(hex(1978496))
+            self.dll.RunCmd(0, bytes(cmd, 'ascii'))
+            cmd = 'prena={0}'.format(hex(0))
+            self.dll.RunCmd(0, bytes(cmd, 'ascii'))
+            self.GATED = False
+        return gated
 
 
     # =========================================================================

--- a/hardware/fastcomtec/fastcomtecp7887.py
+++ b/hardware/fastcomtec/fastcomtecp7887.py
@@ -240,6 +240,7 @@ class FastComtec(Base, FastCounterInterface):
         binwidth_s = self.set_binwidth(bin_width_s)
         no_of_bins = record_length_s / binwidth_s
         if sweep_reset:
+            self.load_setup('')
             self.set_length(no_of_bins, preset=preset, cycles=cycles)
         else:
             self.set_length(no_of_bins)
@@ -501,3 +502,8 @@ class FastComtec(Base, FastCounterInterface):
         status = AcqStatus()
         self.dll.GetStatusData(ctypes.byref(status), 0)
         return status
+
+
+    def load_setup(self, configname):
+        cmd = 'loadcnf={0}'.format(configname)
+        self.dll.RunCmd(0, bytes(cmd, 'ascii'))


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

mcs6 is useable as a gated counter
also small bug fixes

## Description
<!--- Describe your changes in detail -->

msc6 is usable as a fastcounter. the mode (gated or ungated) has to be set in the config otherwise ungated will be used as a default. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Not the full time trace has to be recorded but only the laser pulses. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Full pulsed measurement cycle (from generation to result) has been tested multiple times. Measurement should be paused if a refocus is done since this can come into conflict with triggers.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
