### PR TITLE
Pulsed gui enhancements regarding predefined sequences

### DIFF
--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -421,6 +421,8 @@ class PulsedMeasurementGui(GUIBase):
             sauplo_button.setText('GenSaUpLo')
             sauplo_button.setObjectName('sauplo_' + method_name)
             sauplo_button.clicked.connect(self.generate_sauplo_predefined_clicked)
+            gridLayout.addWidget(gen_button, 0, 0, 1, 1)
+            gridLayout.addWidget(sauplo_button, 1, 0, 1, 1)
             # inspect current method to extract the parameters
             inspected = inspect.signature(methods_dict[method_name])
             # run through all parameters of the current method and create the widgets
@@ -470,15 +472,20 @@ class PulsedMeasurementGui(GUIBase):
                                        ' of the valid types str, float, int or bool!\nChoose one of '
                                        'those default values! Creation of the viewbox aborted.'
                                        ''.format('generate_' + method_name, param_name))
-                    gridLayout.addWidget(param_label, 0, param_index, 1, 1)
-                    gridLayout.addWidget(input_obj, 1, param_index, 1, 1)
+                    # Adjust size policy
+                    input_obj.setMinimumWidth(75)
+                    input_obj.setMaximumWidth(100)
+                    gridLayout.addWidget(param_label, 0, param_index+1, 1, 1)
+                    gridLayout.addWidget(input_obj, 1, param_index+1, 1, 1)
                     setattr(self._pm, method_name + '_param_' + param_name + '_Widget', input_obj)
+            h_spacer = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Expanding,
+                                             QtWidgets.QSizePolicy.Minimum)
+            gridLayout.addItem(h_spacer, 1, param_index+2, 1, 1)
 
-            gridLayout.addWidget(gen_button, 0, len(inspected.parameters), 1, 1)
-            gridLayout.addWidget(sauplo_button, 1, len(inspected.parameters), 1, 1)
             # attach the GroupBox widget to the predefined methods widget.
             setattr(self._pm, method_name + '_GroupBox', groupBox)
             self._pm.verticalLayout.addWidget(groupBox)
+        self._pm.verticalLayout.addStretch()
         return
 
     def keep_former_predefined_methods_config(self):

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -257,6 +257,21 @@ class PulsedMeasurementGui(GUIBase):
         self._pm_cfg.rejected.connect(self.keep_former_predefined_methods_config)
         self._pm_cfg.buttonBox.button(QtWidgets.QDialogButtonBox.Apply).clicked.connect(
             self.apply_predefined_methods_config)
+        # Set ranges for the global parameters and default values
+        self._pm.pm_mw_amp_Widget.setRange(0.0, np.inf)
+        self._pm.pm_mw_freq_Widget.setRange(0.0, np.inf)
+        self._pm.pm_channel_amp_Widget.setRange(0.0, np.inf)
+        self._pm.pm_delay_length_Widget.setRange(0.0, np.inf)
+        self._pm.pm_wait_time_Widget.setRange(0.0, np.inf)
+        self._pm.pm_laser_length_Widget.setRange(0.0, np.inf)
+        self._pm.pm_rabi_period_Widget.setRange(0.0, np.inf)
+        self._pm.pm_mw_amp_Widget.setValue(0.125)
+        self._pm.pm_mw_freq_Widget.setValue(2.87e6)
+        self._pm.pm_channel_amp_Widget.setValue(0.0)
+        self._pm.pm_delay_length_Widget.setValue(500.0e-9)
+        self._pm.pm_wait_time_Widget.setValue(1.5e-6)
+        self._pm.pm_laser_length_Widget.setValue(3.0e-6)
+        self._pm.pm_rabi_period_Widget.setValue(200.0e-9)
 
         # connect the menu to the actions:
         self._mw.action_Settings_Block_Generation.triggered.connect(self.show_generator_settings)

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -425,50 +425,54 @@ class PulsedMeasurementGui(GUIBase):
             inspected = inspect.signature(methods_dict[method_name])
             # run through all parameters of the current method and create the widgets
             for param_index, param_name in enumerate(inspected.parameters):
-                # get default value of the parameter
-                default_val = inspected.parameters[param_name].default
-                if default_val is inspect._empty:
-                    self.log.error('The method "{0}" in the logic has an argument "{1}" without a '
-                                   'default value!\nAssign a default value to that, otherwise a '
-                                   'type estimation is not possible!\nCreation of the viewbox '
-                                   'aborted.'.format('generate_' + method_name, param_name))
-                    return
-                # create a label for the parameter
-                param_label = QtWidgets.QLabel(groupBox)
-                param_label.setText(param_name)
-                # create proper input widget for the parameter depending on the type of default_val
-                if type(default_val) is bool:
-                    input_obj = QtWidgets.QCheckBox(groupBox)
-                    input_obj.setChecked(default_val)
-                elif type(default_val) is float:
-                    input_obj = ScienDSpinBox(groupBox)
-                    input_obj.setMaximum(np.inf)
-                    input_obj.setMinimum(-np.inf)
-                    if 'amp' in param_name:
-                        input_obj.setSuffix('V')
-                    elif 'freq' in param_name:
-                        input_obj.setSuffix('Hz')
-                    elif 'length' in param_name or 'time' in param_name or 'period' in param_name or 'tau' in param_name:
-                        input_obj.setSuffix('s')
-                    input_obj.setMinimumSize(QtCore.QSize(80, 0))
-                    input_obj.setValue(default_val)
-                elif type(default_val) is int:
-                    input_obj = ScienSpinBox(groupBox)
-                    input_obj.setMaximum(2**31 - 1)
-                    input_obj.setMinimum(-2**31 + 1)
-                    input_obj.setValue(default_val)
-                elif type(default_val) is str:
-                    input_obj = QtWidgets.QLineEdit(groupBox)
-                    input_obj.setMinimumSize(QtCore.QSize(80, 0))
-                    input_obj.setText(default_val)
-                else:
-                    self.log.error('The method "{0}" in the logic has an argument "{1}" with is not'
-                                   ' of the valid types str, float, int or bool!\nChoose one of '
-                                   'those default values! Creation of the viewbox aborted.'
-                                   ''.format('generate_' + method_name, param_name))
-                gridLayout.addWidget(param_label, 0, param_index, 1, 1)
-                gridLayout.addWidget(input_obj, 1, param_index, 1, 1)
-                setattr(self._pm, method_name + '_param_' + str(param_index) + '_Widget', input_obj)
+                if param_name not in ['mw_channel', 'gate_count_channel', 'sync_trig_channel',
+                                      'mw_amp', 'mw_freq', 'channel_amp', 'delay_length',
+                                      'wait_time', 'laser_length', 'rabi_period']:
+                    # get default value of the parameter
+                    default_val = inspected.parameters[param_name].default
+                    if default_val is inspect._empty:
+                        self.log.error('The method "{0}" in the logic has an argument "{1}" without'
+                                       ' a default value!\nAssign a default value to that, '
+                                       'otherwise a type estimation is not possible!\n'
+                                       'Creation of the viewbox aborted.'
+                                       ''.format('generate_' + method_name, param_name))
+                        return
+                    # create a label for the parameter
+                    param_label = QtWidgets.QLabel(groupBox)
+                    param_label.setText(param_name)
+                    # create proper input widget for the parameter depending on the type of default_val
+                    if type(default_val) is bool:
+                        input_obj = QtWidgets.QCheckBox(groupBox)
+                        input_obj.setChecked(default_val)
+                    elif type(default_val) is float:
+                        input_obj = ScienDSpinBox(groupBox)
+                        input_obj.setMaximum(np.inf)
+                        input_obj.setMinimum(-np.inf)
+                        if 'amp' in param_name:
+                            input_obj.setSuffix('V')
+                        elif 'freq' in param_name:
+                            input_obj.setSuffix('Hz')
+                        elif 'length' in param_name or 'time' in param_name or 'period' in param_name or 'tau' in param_name:
+                            input_obj.setSuffix('s')
+                        input_obj.setMinimumSize(QtCore.QSize(80, 0))
+                        input_obj.setValue(default_val)
+                    elif type(default_val) is int:
+                        input_obj = ScienSpinBox(groupBox)
+                        input_obj.setMaximum(2**31 - 1)
+                        input_obj.setMinimum(-2**31 + 1)
+                        input_obj.setValue(default_val)
+                    elif type(default_val) is str:
+                        input_obj = QtWidgets.QLineEdit(groupBox)
+                        input_obj.setMinimumSize(QtCore.QSize(80, 0))
+                        input_obj.setText(default_val)
+                    else:
+                        self.log.error('The method "{0}" in the logic has an argument "{1}" with is not'
+                                       ' of the valid types str, float, int or bool!\nChoose one of '
+                                       'those default values! Creation of the viewbox aborted.'
+                                       ''.format('generate_' + method_name, param_name))
+                    gridLayout.addWidget(param_label, 0, param_index, 1, 1)
+                    gridLayout.addWidget(input_obj, 1, param_index, 1, 1)
+                    setattr(self._pm, method_name + '_param_' + param_name + '_Widget', input_obj)
 
             gridLayout.addWidget(gen_button, 0, len(inspected.parameters), 1, 1)
             gridLayout.addWidget(sauplo_button, 1, len(inspected.parameters), 1, 1)
@@ -1094,27 +1098,43 @@ class PulsedMeasurementGui(GUIBase):
             return
 
         # get parameters from input widgets
-        param_index = 0
-        param_list = []
-        while True:
-            if not hasattr(self._pm, method_name + '_param_' + str(param_index) + '_Widget'):
-                break
+        param_searchstr = method_name + '_param_'
+        param_widgets = [widget for widget in dir(self._pm) if widget.startswith(param_searchstr)]
+        # Store parameters together with the parameter names in a dictionary
+        param_dict = dict()
+        for widget_name in param_widgets:
+            input_obj = getattr(self._pm, widget_name)
+            param_name = widget_name.replace(param_searchstr, '').replace('_Widget', '')
 
-            input_obj = getattr(self._pm, method_name + '_param_' + str(param_index) + '_Widget')
             if hasattr(input_obj, 'isChecked'):
-                param_list.append(input_obj.isChecked())
+                param_dict[param_name] = input_obj.isChecked()
             elif hasattr(input_obj, 'value'):
-                param_list.append(input_obj.value())
+                param_dict[param_name] = input_obj.value()
             elif hasattr(input_obj, 'text'):
-                param_list.append(input_obj.text())
+                param_dict[param_name] = input_obj.text()
             else:
                 self.log.error('Not possible to get the value from the widgets, since it does not '
                                'have one of the possible access methods!')
                 return
 
-            param_index += 1
+        # get global parameters and add them to the dictionary
+        for param_name in ['mw_channel', 'gate_count_channel', 'sync_trig_channel', 'mw_amp',
+                           'mw_freq', 'channel_amp', 'delay_length', 'wait_time', 'laser_length',
+                           'rabi_period']:
+            input_obj = getattr(self._pm, 'pm_' + param_name + '_Widget')
 
-        self._pulsed_master_logic.generate_predefined_sequence(method_name, param_list)
+            if hasattr(input_obj, 'isChecked'):
+                param_dict[param_name] = input_obj.isChecked()
+            elif hasattr(input_obj, 'value'):
+                param_dict[param_name] = input_obj.value()
+            elif hasattr(input_obj, 'text'):
+                param_dict[param_name] = input_obj.text()
+            else:
+                self.log.error('Not possible to get the value from the widgets, since it does not '
+                               'have one of the possible access methods!')
+                return
+
+        self._pulsed_master_logic.generate_predefined_sequence(method_name, param_dict)
         return
 
     def generate_sauplo_predefined_clicked(self):
@@ -1122,19 +1142,25 @@ class PulsedMeasurementGui(GUIBase):
         method_name = button_obj.objectName()[7:]
         self.generate_predefined_clicked(button_obj)
         # get name of the generated ensemble
-        input_obj = getattr(self._pm, method_name + '_param_0_Widget')
+        if not hasattr(self._pm, method_name + '_param_name_Widget'):
+            self.log.error('Predefined sequence methods must have an argument called "name" in '
+                           'order to use the sample/upload/load functionality. It must be the '
+                           'naming of the generated asset.\n"{0}" has probably been generated '
+                           'but not sampled/uploaded/loaded'.format(method_name))
+            return
+        input_obj = getattr(self._pm, method_name + '_param_name_Widget')
         if not hasattr(input_obj, 'text'):
             self.log.error('Predefined sequence methods must have as first argument the name of '
                            'the asset to be generated.')
             return
-        name = input_obj.text()
+        asset_name = input_obj.text()
 
         # disable buttons
         self._pg.saup_ensemble_PushButton.setEnabled(False)
         self._pg.sauplo_ensemble_PushButton.setEnabled(False)
         self._pg.load_ensemble_PushButton.setEnabled(False)
 
-        self._pulsed_master_logic.sample_block_ensemble(name, True)
+        self._pulsed_master_logic.sample_block_ensemble(asset_name, True)
         return
 
     ###########################################################################

--- a/gui/pulsed/ui_predefined_methods.ui
+++ b/gui/pulsed/ui_predefined_methods.ui
@@ -16,6 +16,9 @@
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
     <widget class="QScrollArea" name="scrollArea">
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustIgnored</enum>
+     </property>
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -118,7 +121,7 @@ trigger amplitude:</string>
             </widget>
            </item>
            <item row="2" column="3">
-            <widget class="QDoubleSpinBox" name="pm_mw_freq_Widget">
+            <widget class="ScienDSpinBox" name="pm_mw_freq_Widget">
              <property name="minimumSize">
               <size>
                <width>75</width>
@@ -130,6 +133,12 @@ trigger amplitude:</string>
                <width>100</width>
                <height>16777215</height>
               </size>
+             </property>
+             <property name="suffix">
+              <string>Hz</string>
+             </property>
+             <property name="decimals">
+              <number>6</number>
              </property>
             </widget>
            </item>
@@ -148,7 +157,7 @@ trigger amplitude:</string>
             </widget>
            </item>
            <item row="0" column="5">
-            <widget class="QDoubleSpinBox" name="pm_channel_amp_Widget">
+            <widget class="ScienDSpinBox" name="pm_channel_amp_Widget">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -166,6 +175,12 @@ trigger amplitude:</string>
                <width>100</width>
                <height>16777215</height>
               </size>
+             </property>
+             <property name="suffix">
+              <string>V</string>
+             </property>
+             <property name="decimals">
+              <number>6</number>
              </property>
             </widget>
            </item>
@@ -228,7 +243,7 @@ gate channel:</string>
             </widget>
            </item>
            <item row="1" column="3">
-            <widget class="QDoubleSpinBox" name="pm_wait_time_Widget">
+            <widget class="ScienDSpinBox" name="pm_wait_time_Widget">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -246,11 +261,17 @@ gate channel:</string>
                <width>100</width>
                <height>16777215</height>
               </size>
+             </property>
+             <property name="suffix">
+              <string>s</string>
+             </property>
+             <property name="decimals">
+              <number>6</number>
              </property>
             </widget>
            </item>
            <item row="1" column="1">
-            <widget class="QDoubleSpinBox" name="pm_laser_length_Widget">
+            <widget class="ScienDSpinBox" name="pm_laser_length_Widget">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -268,6 +289,12 @@ gate channel:</string>
                <width>100</width>
                <height>16777215</height>
               </size>
+             </property>
+             <property name="suffix">
+              <string>s</string>
+             </property>
+             <property name="decimals">
+              <number>6</number>
              </property>
             </widget>
            </item>
@@ -297,7 +324,7 @@ gate channel:</string>
             </widget>
            </item>
            <item row="1" column="5">
-            <widget class="QDoubleSpinBox" name="pm_delay_length_Widget">
+            <widget class="ScienDSpinBox" name="pm_delay_length_Widget">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -316,10 +343,19 @@ gate channel:</string>
                <height>16777215</height>
               </size>
              </property>
+             <property name="suffix">
+              <string>s</string>
+             </property>
+             <property name="decimals">
+              <number>6</number>
+             </property>
+             <property name="value">
+              <double>0.000001000000000</double>
+             </property>
             </widget>
            </item>
            <item row="2" column="5">
-            <widget class="QDoubleSpinBox" name="pm_mw_amp_Widget">
+            <widget class="ScienDSpinBox" name="pm_mw_amp_Widget">
              <property name="minimumSize">
               <size>
                <width>75</width>
@@ -331,6 +367,12 @@ gate channel:</string>
                <width>100</width>
                <height>16777215</height>
               </size>
+             </property>
+             <property name="suffix">
+              <string>V</string>
+             </property>
+             <property name="decimals">
+              <number>6</number>
              </property>
             </widget>
            </item>
@@ -355,7 +397,7 @@ gate channel:</string>
             </widget>
            </item>
            <item row="1" column="7">
-            <widget class="QDoubleSpinBox" name="pm_rabi_period_Widget">
+            <widget class="ScienDSpinBox" name="pm_rabi_period_Widget">
              <property name="minimumSize">
               <size>
                <width>75</width>
@@ -367,6 +409,15 @@ gate channel:</string>
                <width>100</width>
                <height>16777215</height>
               </size>
+             </property>
+             <property name="suffix">
+              <string>s</string>
+             </property>
+             <property name="decimals">
+              <number>6</number>
+             </property>
+             <property name="value">
+              <double>0.000001000000000</double>
              </property>
             </widget>
            </item>
@@ -390,6 +441,13 @@ gate channel:</string>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScienDSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qtwidgets.scientific_spinbox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/gui/pulsed/ui_predefined_methods.ui
+++ b/gui/pulsed/ui_predefined_methods.ui
@@ -24,13 +24,136 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1161</width>
-        <height>622</height>
+        <width>1157</width>
+        <height>618</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
        <item row="0" column="0">
         <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <layout class="QGridLayout" name="gridLayout_5">
+           <item row="0" column="5">
+            <widget class="QLineEdit" name="lineEdit_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>50</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="3">
+            <widget class="QLineEdit" name="lineEdit_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>50</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="6">
+            <widget class="QLabel" name="label_4">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>analog
+trigger amplitude:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QLabel" name="label_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>sync
+trigger channel:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="lineEdit">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>50</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>MW channel:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="4">
+            <widget class="QLabel" name="label_3">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>counter
+gate channel:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="7">
+            <widget class="QDoubleSpinBox" name="doubleSpinBox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>70</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
          <item>
           <widget class="QLabel" name="hintLabel">
            <property name="text">

--- a/gui/pulsed/ui_predefined_methods.ui
+++ b/gui/pulsed/ui_predefined_methods.ui
@@ -33,29 +33,19 @@
         <layout class="QVBoxLayout" name="verticalLayout">
          <item>
           <layout class="QGridLayout" name="gridLayout_5">
-           <item row="0" column="5">
-            <widget class="QLineEdit" name="lineEdit_3">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>50</width>
-               <height>16777215</height>
-              </size>
-             </property>
-            </widget>
-           </item>
            <item row="0" column="3">
-            <widget class="QLineEdit" name="lineEdit_2">
+            <widget class="QLineEdit" name="pm_gate_count_channel_Widget">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>50</width>
+               <height>0</height>
+              </size>
              </property>
              <property name="maximumSize">
               <size>
@@ -63,12 +53,15 @@
                <height>16777215</height>
               </size>
              </property>
+             <property name="text">
+              <string>d_ch2</string>
+             </property>
             </widget>
            </item>
-           <item row="0" column="6">
+           <item row="0" column="4">
             <widget class="QLabel" name="label_4">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
@@ -79,27 +72,19 @@ trigger amplitude:</string>
              </property>
             </widget>
            </item>
-           <item row="0" column="2">
-            <widget class="QLabel" name="label_2">
+           <item row="2" column="1">
+            <widget class="QLineEdit" name="pm_mw_channel_Widget">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="text">
-              <string>sync
-trigger channel:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLineEdit" name="lineEdit">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
+             <property name="minimumSize">
+              <size>
+               <width>50</width>
+               <height>0</height>
+              </size>
              </property>
              <property name="maximumSize">
               <size>
@@ -107,12 +92,15 @@ trigger channel:</string>
                <height>16777215</height>
               </size>
              </property>
+             <property name="text">
+              <string>a_ch1</string>
+             </property>
             </widget>
            </item>
-           <item row="0" column="0">
+           <item row="2" column="0">
             <widget class="QLabel" name="label">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
@@ -122,10 +110,113 @@ trigger channel:</string>
              </property>
             </widget>
            </item>
-           <item row="0" column="4">
+           <item row="2" column="4">
+            <widget class="QLabel" name="label_9">
+             <property name="text">
+              <string>MW amplitude:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="3">
+            <widget class="QDoubleSpinBox" name="pm_mw_freq_Widget">
+             <property name="minimumSize">
+              <size>
+               <width>75</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>100</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="2">
+            <widget class="QLabel" name="label_8">
+             <property name="text">
+              <string>MW frequency:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="QLabel" name="label_6">
+             <property name="text">
+              <string>wait time:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="5">
+            <widget class="QDoubleSpinBox" name="pm_channel_amp_Widget">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>75</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>100</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>sync
+trigger channel:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>laser length:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="4">
+            <widget class="QLabel" name="label_7">
+             <property name="text">
+              <string>trigger--&gt;laser
+delay:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
             <widget class="QLabel" name="label_3">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
@@ -136,17 +227,144 @@ gate channel:</string>
              </property>
             </widget>
            </item>
-           <item row="0" column="7">
-            <widget class="QDoubleSpinBox" name="doubleSpinBox">
+           <item row="1" column="3">
+            <widget class="QDoubleSpinBox" name="pm_wait_time_Widget">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
+             <property name="minimumSize">
+              <size>
+               <width>75</width>
+               <height>0</height>
+              </size>
+             </property>
              <property name="maximumSize">
               <size>
-               <width>70</width>
+               <width>100</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QDoubleSpinBox" name="pm_laser_length_Widget">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>75</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>100</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="pm_sync_trig_channel_Widget">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>50</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>50</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>d_ch3</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="5">
+            <widget class="QDoubleSpinBox" name="pm_delay_length_Widget">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>75</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>100</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="5">
+            <widget class="QDoubleSpinBox" name="pm_mw_amp_Widget">
+             <property name="minimumSize">
+              <size>
+               <width>75</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>100</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="8">
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="1" column="6">
+            <widget class="QLabel" name="label_10">
+             <property name="text">
+              <string>rabi period:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="7">
+            <widget class="QDoubleSpinBox" name="pm_rabi_period_Widget">
+             <property name="minimumSize">
+              <size>
+               <width>75</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>100</width>
                <height>16777215</height>
               </size>
              </property>

--- a/gui/pulsed/ui_predefined_methods.ui
+++ b/gui/pulsed/ui_predefined_methods.ui
@@ -56,6 +56,9 @@
                <height>16777215</height>
               </size>
              </property>
+             <property name="toolTip">
+              <string>Pulse generator channel used for a gate signal for fast counter devices supporting this functionality.</string>
+             </property>
              <property name="text">
               <string>d_ch2</string>
              </property>
@@ -70,8 +73,7 @@
               </sizepolicy>
              </property>
              <property name="text">
-              <string>analog
-trigger amplitude:</string>
+              <string>channel_amp:</string>
              </property>
             </widget>
            </item>
@@ -95,6 +97,9 @@ trigger amplitude:</string>
                <height>16777215</height>
               </size>
              </property>
+             <property name="toolTip">
+              <string>The pulse generator channel used for the microwave output.</string>
+             </property>
              <property name="text">
               <string>a_ch1</string>
              </property>
@@ -109,14 +114,14 @@ trigger amplitude:</string>
               </sizepolicy>
              </property>
              <property name="text">
-              <string>MW channel:</string>
+              <string>mw_channel:</string>
              </property>
             </widget>
            </item>
            <item row="2" column="4">
             <widget class="QLabel" name="label_9">
              <property name="text">
-              <string>MW amplitude:</string>
+              <string>mw_amp:</string>
              </property>
             </widget>
            </item>
@@ -134,6 +139,9 @@ trigger amplitude:</string>
                <height>16777215</height>
               </size>
              </property>
+             <property name="toolTip">
+              <string>If used, the microwave frequency.</string>
+             </property>
              <property name="suffix">
               <string>Hz</string>
              </property>
@@ -145,14 +153,14 @@ trigger amplitude:</string>
            <item row="2" column="2">
             <widget class="QLabel" name="label_8">
              <property name="text">
-              <string>MW frequency:</string>
+              <string>mw_freq:</string>
              </property>
             </widget>
            </item>
            <item row="1" column="2">
             <widget class="QLabel" name="label_6">
              <property name="text">
-              <string>wait time:</string>
+              <string>wait_time:</string>
              </property>
             </widget>
            </item>
@@ -175,6 +183,9 @@ trigger amplitude:</string>
                <width>100</width>
                <height>16777215</height>
               </size>
+             </property>
+             <property name="toolTip">
+              <string>Logical high voltage in case an analog channel is used for digital trigger output.</string>
              </property>
              <property name="suffix">
               <string>V</string>
@@ -199,8 +210,7 @@ trigger amplitude:</string>
               </size>
              </property>
              <property name="text">
-              <string>sync
-trigger channel:</string>
+              <string>sync_trig_channel:</string>
              </property>
             </widget>
            </item>
@@ -213,15 +223,14 @@ trigger channel:</string>
               </sizepolicy>
              </property>
              <property name="text">
-              <string>laser length:</string>
+              <string>laser_length:</string>
              </property>
             </widget>
            </item>
            <item row="1" column="4">
             <widget class="QLabel" name="label_7">
              <property name="text">
-              <string>trigger--&gt;laser
-delay:</string>
+              <string>delay_length:</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -237,8 +246,7 @@ delay:</string>
               </sizepolicy>
              </property>
              <property name="text">
-              <string>counter
-gate channel:</string>
+              <string>gate_count_channel:</string>
              </property>
             </widget>
            </item>
@@ -261,6 +269,9 @@ gate channel:</string>
                <width>100</width>
                <height>16777215</height>
               </size>
+             </property>
+             <property name="toolTip">
+              <string>The waiting time after each laser pulse.</string>
              </property>
              <property name="suffix">
               <string>s</string>
@@ -290,6 +301,9 @@ gate channel:</string>
                <height>16777215</height>
               </size>
              </property>
+             <property name="toolTip">
+              <string>The duration of the laser pulses in the pulse sequence to generate.</string>
+             </property>
              <property name="suffix">
               <string>s</string>
              </property>
@@ -318,6 +332,9 @@ gate channel:</string>
                <height>16777215</height>
               </size>
              </property>
+             <property name="toolTip">
+              <string>Pulse generator channel used for a synchonization trigger for fast counter devices.</string>
+             </property>
              <property name="text">
               <string>d_ch3</string>
              </property>
@@ -342,6 +359,9 @@ gate channel:</string>
                <width>100</width>
                <height>16777215</height>
               </size>
+             </property>
+             <property name="toolTip">
+              <string>The delay between trigger output and actual laser power going high.</string>
              </property>
              <property name="suffix">
               <string>s</string>
@@ -368,6 +388,9 @@ gate channel:</string>
                <height>16777215</height>
               </size>
              </property>
+             <property name="toolTip">
+              <string>If used, the microwave amplitude (NOT peak-to-peak).</string>
+             </property>
              <property name="suffix">
               <string>V</string>
              </property>
@@ -389,14 +412,14 @@ gate channel:</string>
              </property>
             </spacer>
            </item>
-           <item row="1" column="6">
+           <item row="2" column="6">
             <widget class="QLabel" name="label_10">
              <property name="text">
-              <string>rabi period:</string>
+              <string>rabi_period:</string>
              </property>
             </widget>
            </item>
-           <item row="1" column="7">
+           <item row="2" column="7">
             <widget class="ScienDSpinBox" name="pm_rabi_period_Widget">
              <property name="minimumSize">
               <size>
@@ -409,6 +432,9 @@ gate channel:</string>
                <width>100</width>
                <height>16777215</height>
               </size>
+             </property>
+             <property name="toolTip">
+              <string>If used, the Rabi period for the measurement.</string>
              </property>
              <property name="suffix">
               <string>s</string>
@@ -448,6 +474,19 @@ gate channel:</string>
    <header>qtwidgets.scientific_spinbox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>pm_sync_trig_channel_Widget</tabstop>
+  <tabstop>pm_gate_count_channel_Widget</tabstop>
+  <tabstop>pm_channel_amp_Widget</tabstop>
+  <tabstop>pm_laser_length_Widget</tabstop>
+  <tabstop>pm_wait_time_Widget</tabstop>
+  <tabstop>pm_delay_length_Widget</tabstop>
+  <tabstop>pm_mw_channel_Widget</tabstop>
+  <tabstop>pm_mw_freq_Widget</tabstop>
+  <tabstop>pm_mw_amp_Widget</tabstop>
+  <tabstop>pm_rabi_period_Widget</tabstop>
+  <tabstop>scrollArea</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/logic/predefined_methods/basic_methods.py
+++ b/logic/predefined_methods/basic_methods.py
@@ -42,17 +42,18 @@ General Pulse Creation Procedure:
 """
 
 
-def generate_laser_on(self, name='Laser_On', length=3.0e-6, amp=1.0):
+def generate_laser_on(self, name='laser_on', length=3.0e-6, channel_amp=1.0):
     """ Generates Laser on.
 
     @param str name: Name of the PulseBlockEnsemble
     @param float length: laser duration in seconds
-    @param float amp: In case of analogue laser channel this value will be the laser on voltage.
+    @param float channel_amp: In case of analogue laser channel this value will be the laser on
+                              voltage.
 
     @return object: the generated PulseBlockEnsemble object.
     """
     # create the laser element
-    laser_element, delay_element = self._get_laser_element(length, 0.0, False, amp_V=amp)
+    laser_element, delay_element = self._get_laser_element(length, 0.0, False, amp_V=channel_amp)
     # Create the element list
     element_list = [laser_element]
     # create the PulseBlock object.
@@ -75,13 +76,13 @@ def generate_laser_on(self, name='Laser_On', length=3.0e-6, amp=1.0):
     return block_ensemble
 
 
-def generate_laser_mw_on(self, name='Laser_MW_On', length=3.0e-6, laser_amp=1.0, mw_channel='a_ch1',
-                         mw_freq=100.0e6, mw_amp=1.0):
+def generate_laser_mw_on(self, name='laser_mw_on', length=3.0e-6, channel_amp=1.0,
+                         mw_channel='a_ch1', mw_freq=100.0e6, mw_amp=1.0):
     """ General generation method for laser on and microwave on generation.
 
     @param string name: Name of the PulseBlockEnsemble to be generated
     @param float length: Length of the PulseBlockEnsemble in seconds
-    @param float laser_amp: In case of analog laser channel this value will be the laser on voltage.
+    @param float channel_amp: In case of analog laser channel this value will be the laser on voltage.
     @param string mw_channel: The pulser channel controlling the MW. If set to 'd_chX' this will be
                               interpreted as trigger for an external microwave source. If set to
                               'a_chX' the pulser (AWG) will act as microwave source.
@@ -96,8 +97,9 @@ def generate_laser_mw_on(self, name='Laser_MW_On', length=3.0e-6, laser_amp=1.0,
         return
 
     laser_mw_element, delay_element = self._get_mw_laser_element(length, 0.0, mw_channel, False,
-                                                                 laser_amp=laser_amp, mw_amp=mw_amp,
-                                                                 mw_freq=mw_freq)
+                                                                 0.0, laser_amp=channel_amp,
+                                                                 mw_amp=mw_amp, mw_freq=mw_freq,
+                                                                 mw_phase=0.0)
     # Create the element list.
     element_list = [laser_mw_element]
     # create the PulseBlock object.
@@ -118,7 +120,7 @@ def generate_laser_mw_on(self, name='Laser_MW_On', length=3.0e-6, laser_amp=1.0,
     return block_ensemble
 
 
-def generate_idle(self, name='Idle', length=3.0e-6):
+def generate_idle(self, name='idle', length=3.0e-6):
     """ Generate just a simple idle ensemble.
 
     @param str name: Name of the PulseBlockEnsemble to be generated
@@ -148,20 +150,21 @@ def generate_idle(self, name='Idle', length=3.0e-6):
     return block_ensemble
 
 
-def generate_rabi(self, name='Rabi', tau_start=10.0e-9, tau_step=10.0e-9, number_of_taus=50,
+def generate_rabi(self, name='rabi', tau_start=10.0e-9, tau_step=10.0e-9, number_of_taus=50,
                   mw_freq=2870.0e6, mw_amp=1.0, mw_channel='a_ch1', laser_length=3.0e-6,
-                  channel_amp=1.0, delay_length=0.7e-6, wait_time=1.0e-6, seq_trig_channel='',gate_count_channel=''):
+                  channel_amp=1.0, delay_length=0.7e-6, wait_time=1.0e-6, sync_trig_channel='',
+                  gate_count_channel=''):
     """
 
     """
     # Sanity checks
     if gate_count_channel == '':
         gate_count_channel = None
-    if seq_trig_channel == '':
-        seq_trig_channel = None
+    if sync_trig_channel == '':
+        sync_trig_channel = None
     err_code = self._do_channel_sanity_checks(mw_channel=mw_channel,
                                               gate_count_channel=gate_count_channel,
-                                              seq_trig_channel=seq_trig_channel)
+                                              sync_trig_channel=sync_trig_channel)
     if err_code != 0:
         return
 
@@ -172,9 +175,10 @@ def generate_rabi(self, name='Rabi', tau_start=10.0e-9, tau_step=10.0e-9, number
     # get laser and delay element
     laser_element, delay_element = self._get_laser_element(laser_length, 0.0, False, delay_length,
                                                            channel_amp, gate_count_channel)
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         # get sequence trigger element
-        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, seq_trig_channel, amp=channel_amp)
+        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, sync_trig_channel,
+                                                    amp=channel_amp)
         # Create its own block out of the element
         seq_block = PulseBlock('seq_trigger', [seqtrig_element])
         # save block
@@ -190,7 +194,7 @@ def generate_rabi(self, name='Rabi', tau_start=10.0e-9, tau_step=10.0e-9, number
     # Create Block list with repetitions and sequence trigger if needed.
     # remember number_of_taus=0 also counts as first round.
     block_list = [(rabi_block, number_of_taus-1)]
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         block_list.append((seq_block, 0))
 
     # create ensemble out of the block(s)
@@ -207,21 +211,21 @@ def generate_rabi(self, name='Rabi', tau_start=10.0e-9, tau_step=10.0e-9, number
     return block_ensemble
 
 
-def generate_pulsedodmr(self, name='PulsedODMR', pi_length=1.0e-6, mw_freq_start=2870.0e6,
+def generate_pulsedodmr(self, name='pulsedODMR', rabi_period=1.0e-6, mw_freq_start=2870.0e6,
                         mw_freq_incr=0.2e6, num_of_points=50, mw_amp=1.0, mw_channel='a_ch1',
                         laser_length=3.0e-6, channel_amp=1.0, delay_length=0.7e-6, wait_time=1.0e-6,
-                        seq_trig_channel='', gate_count_channel=''):
+                        sync_trig_channel='', gate_count_channel=''):
     """
 
     """
     # Sanity checks
     if gate_count_channel == '':
         gate_count_channel = None
-    if seq_trig_channel == '':
-        seq_trig_channel = None
+    if sync_trig_channel == '':
+        sync_trig_channel = None
     err_code = self._do_channel_sanity_checks(mw_channel=mw_channel,
                                               gate_count_channel=gate_count_channel,
-                                              seq_trig_channel=seq_trig_channel)
+                                              sync_trig_channel=sync_trig_channel)
     if err_code != 0:
         return
 
@@ -230,9 +234,10 @@ def generate_pulsedodmr(self, name='PulsedODMR', pi_length=1.0e-6, mw_freq_start
     # get laser and delay element
     laser_element, delay_element = self._get_laser_element(laser_length, 0.0, False, delay_length,
                                                            channel_amp, gate_count_channel)
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         # get sequence trigger element
-        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, seq_trig_channel, amp=channel_amp)
+        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, sync_trig_channel,
+                                                    amp=channel_amp)
         # Create its own block out of the element
         seq_block = PulseBlock('seq_trigger', [seqtrig_element])
         # save block
@@ -244,7 +249,8 @@ def generate_pulsedodmr(self, name='PulsedODMR', pi_length=1.0e-6, mw_freq_start
     # Create element list for PulsedODMR PulseBlock
     element_list = []
     for mw_freq in freq_array:
-        mw_element = self._get_mw_element(pi_length, 0.0, mw_channel, False, mw_amp, mw_freq, 0.0)
+        mw_element = self._get_mw_element(rabi_period/2, 0.0, mw_channel, False, mw_amp, mw_freq,
+                                          0.0)
         element_list.append(mw_element)
         element_list.append(laser_element)
         element_list.append(delay_element)
@@ -257,7 +263,7 @@ def generate_pulsedodmr(self, name='PulsedODMR', pi_length=1.0e-6, mw_freq_start
     # Create Block list with repetitions and sequence trigger if needed.
     # remember number_of_taus=0 also counts as first round.
     block_list = [(pulsedodmr_block, 0)]
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         block_list.append((seq_block, 0))
 
     # create ensemble out of the block(s)
@@ -275,21 +281,21 @@ def generate_pulsedodmr(self, name='PulsedODMR', pi_length=1.0e-6, mw_freq_start
     return block_ensemble
 
 
-def generate_ramsey(self, name='Ramsey', rabi_period=1.0e-6, mw_freq=2870.0e6, mw_amp=0.1,
+def generate_ramsey(self, name='ramsey', rabi_period=1.0e-6, mw_freq=2870.0e6, mw_amp=0.1,
                     tau_start=1.0e-6, tau_incr=1.0e-6, num_of_points=50, mw_channel='a_ch1',
                     laser_length=3.0e-6, channel_amp=1.0, delay_length=0.7e-6, wait_time=1.0e-6,
-                    seq_trig_channel='', gate_count_channel=''):
+                    sync_trig_channel='', gate_count_channel=''):
     """
 
     """
     # Sanity checks
     if gate_count_channel == '':
         gate_count_channel = None
-    if seq_trig_channel == '':
-        seq_trig_channel = None
+    if sync_trig_channel == '':
+        sync_trig_channel = None
     err_code = self._do_channel_sanity_checks(mw_channel=mw_channel,
                                               gate_count_channel=gate_count_channel,
-                                              seq_trig_channel=seq_trig_channel)
+                                              sync_trig_channel=sync_trig_channel)
     if err_code != 0:
         return
 
@@ -312,9 +318,10 @@ def generate_ramsey(self, name='Ramsey', rabi_period=1.0e-6, mw_freq=2870.0e6, m
     # get tau element
     tau_element = self._get_idle_element(real_tau_start, tau_incr, True)
 
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         # get sequence trigger element
-        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, seq_trig_channel, amp=channel_amp)
+        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, sync_trig_channel,
+                                                    amp=channel_amp)
         # Create its own block out of the element
         seq_block = PulseBlock('seq_trigger', [seqtrig_element])
         # save block
@@ -344,7 +351,7 @@ def generate_ramsey(self, name='Ramsey', rabi_period=1.0e-6, mw_freq=2870.0e6, m
     # Create Block list with repetitions and sequence trigger if needed.
     # remember number_of_taus=0 also counts as first round.
     block_list = [(ramsey_block, num_of_points - 1)]
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         block_list.append((seq_block, 0))
 
     # create ensemble out of the block(s)
@@ -362,21 +369,21 @@ def generate_ramsey(self, name='Ramsey', rabi_period=1.0e-6, mw_freq=2870.0e6, m
     return block_ensemble
 
 
-def generate_hahnecho(self, name='HahnEcho', rabi_period=1.0e-6, mw_freq=2870.0e6, mw_amp=0.1,
+def generate_hahnecho(self, name='hahn_echo', rabi_period=1.0e-6, mw_freq=2870.0e6, mw_amp=0.1,
                       tau_start=1.0e-6, tau_incr=1.0e-6, num_of_points=50, mw_channel='a_ch1',
                       laser_length=3.0e-6, channel_amp=1.0, delay_length=0.7e-6, wait_time=1.0e-6,
-                      seq_trig_channel='', gate_count_channel=''):
+                      sync_trig_channel='', gate_count_channel=''):
     """
 
     """
     # Sanity checks
     if gate_count_channel == '':
         gate_count_channel = None
-    if seq_trig_channel == '':
-        seq_trig_channel = None
+    if sync_trig_channel == '':
+        sync_trig_channel = None
     err_code = self._do_channel_sanity_checks(mw_channel=mw_channel,
                                               gate_count_channel=gate_count_channel,
-                                              seq_trig_channel=seq_trig_channel)
+                                              sync_trig_channel=sync_trig_channel)
     if err_code != 0:
         return
 
@@ -401,9 +408,10 @@ def generate_hahnecho(self, name='HahnEcho', rabi_period=1.0e-6, mw_freq=2870.0e
     # get tau element
     tau_element = self._get_idle_element(real_tau_start, tau_incr, False)
 
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         # get sequence trigger element
-        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, seq_trig_channel, amp=channel_amp)
+        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, sync_trig_channel,
+                                                    amp=channel_amp)
         # Create its own block out of the element
         seq_block = PulseBlock('seq_trigger', [seqtrig_element])
         # save block
@@ -437,7 +445,7 @@ def generate_hahnecho(self, name='HahnEcho', rabi_period=1.0e-6, mw_freq=2870.0e
     # Create Block list with repetitions and sequence trigger if needed.
     # remember number_of_taus=0 also counts as first round.
     block_list = [(hahn_block, num_of_points - 1)]
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         block_list.append((seq_block, 0))
 
     # create ensemble out of the block(s)
@@ -455,21 +463,21 @@ def generate_hahnecho(self, name='HahnEcho', rabi_period=1.0e-6, mw_freq=2870.0e
     return block_ensemble
 
 
-def generate_HHamp(self, name='HHamp', rabi_period=1.0e-6, spinlock_length=20e-6, mw_freq=2870.0e6,
-                   pulse_amp=0.5, start_amp=0.05, incr_amp=0.01, num_of_points=50,
+def generate_HHamp(self, name='hh_amp', rabi_period=1.0e-6, spinlock_length=20e-6, mw_freq=2870.0e6,
+                   mw_amp=0.5, start_amp=0.05, incr_amp=0.01, num_of_points=50,
                    mw_channel='a_ch1', laser_length=3.0e-6, channel_amp=1.0, delay_length=0.7e-6,
-                   wait_time=1.0e-6, seq_trig_channel='', gate_count_channel=''):
+                   wait_time=1.0e-6, sync_trig_channel='', gate_count_channel=''):
     """
 
     """
     # Sanity checks
     if gate_count_channel == '':
         gate_count_channel = None
-    if seq_trig_channel == '':
-        seq_trig_channel = None
+    if sync_trig_channel == '':
+        sync_trig_channel = None
     err_code = self._do_channel_sanity_checks(mw_channel=mw_channel,
                                               gate_count_channel=gate_count_channel,
-                                              seq_trig_channel=seq_trig_channel)
+                                              sync_trig_channel=sync_trig_channel)
     if err_code != 0:
         return
 
@@ -479,15 +487,16 @@ def generate_HHamp(self, name='HHamp', rabi_period=1.0e-6, spinlock_length=20e-6
     laser_element, delay_element = self._get_laser_element(laser_length, 0.0, False, delay_length,
                                                            channel_amp, gate_count_channel)
     # get pihalf element
-    pihalf_element = self._get_mw_element(rabi_period / 4, 0.0, mw_channel, False, pulse_amp,
+    pihalf_element = self._get_mw_element(rabi_period / 4, 0.0, mw_channel, False, mw_amp,
                                           mw_freq, 0.0)
     # get 3pihalf element
-    pi3half_element = self._get_mw_element(3 * rabi_period / 4, 0.0, mw_channel, False, pulse_amp,
+    pi3half_element = self._get_mw_element(3 * rabi_period / 4, 0.0, mw_channel, False, mw_amp,
                                            mw_freq, 0.0)
 
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         # get sequence trigger element
-        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, seq_trig_channel, amp=channel_amp)
+        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, sync_trig_channel,
+                                                    amp=channel_amp)
         # Create its own block out of the element
         seq_block = PulseBlock('seq_trigger', [seqtrig_element])
         # save block
@@ -524,7 +533,7 @@ def generate_HHamp(self, name='HHamp', rabi_period=1.0e-6, spinlock_length=20e-6
     # Create Block list with repetitions and sequence trigger if needed.
     # remember number_of_taus=0 also counts as first round.
     block_list = [(hhamp_block, 0)]
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         block_list.append((seq_block, 0))
 
     # create ensemble out of the block(s)
@@ -541,21 +550,21 @@ def generate_HHamp(self, name='HHamp', rabi_period=1.0e-6, spinlock_length=20e-6
     self.save_ensemble(name, block_ensemble)
     return block_ensemble
 
-def generate_HHtau(self, name='HHtau', rabi_period=1.0e-6, spinlock_amp=0.1, mw_freq=2870.0e6,
-                   pulse_amp=0.5, start_tau=0.05, incr_tau=0.01, num_of_points=50,
+def generate_HHtau(self, name='hh_tau', rabi_period=1.0e-6, spinlock_amp=0.1, mw_freq=2870.0e6,
+                   mw_amp=0.5, start_tau=0.001, incr_tau=0.001, num_of_points=50,
                    mw_channel='a_ch1', laser_length=3.0e-6, channel_amp=1.0, delay_length=0.7e-6,
-                   wait_time=1.0e-6, seq_trig_channel='', gate_count_channel=''):
+                   wait_time=1.0e-6, sync_trig_channel='', gate_count_channel=''):
     """
 
     """
     # Sanity checks
     if gate_count_channel == '':
         gate_count_channel = None
-    if seq_trig_channel == '':
-        seq_trig_channel = None
+    if sync_trig_channel == '':
+        sync_trig_channel = None
     err_code = self._do_channel_sanity_checks(mw_channel=mw_channel,
                                               gate_count_channel=gate_count_channel,
-                                              seq_trig_channel=seq_trig_channel)
+                                              sync_trig_channel=sync_trig_channel)
     if err_code != 0:
         return
 
@@ -565,18 +574,19 @@ def generate_HHtau(self, name='HHtau', rabi_period=1.0e-6, spinlock_amp=0.1, mw_
     laser_element, delay_element = self._get_laser_element(laser_length, 0.0, False, delay_length,
                                                            channel_amp, gate_count_channel)
     # get pihalf element
-    pihalf_element = self._get_mw_element(rabi_period / 4, 0.0, mw_channel, False, pulse_amp,
+    pihalf_element = self._get_mw_element(rabi_period / 4, 0.0, mw_channel, False, mw_amp,
                                           mw_freq, 0.0)
     # get 3pihalf element
-    pi3half_element = self._get_mw_element(3 * rabi_period / 4, 0.0, mw_channel, False, pulse_amp,
+    pi3half_element = self._get_mw_element(3 * rabi_period / 4, 0.0, mw_channel, False, mw_amp,
                                            mw_freq, 0.0)
     # get spinlock element
     sl_element = self._get_mw_element(start_tau, incr_tau, mw_channel, True, spinlock_amp, mw_freq,
                                       90.0)
 
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         # get sequence trigger element
-        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, seq_trig_channel, amp=channel_amp)
+        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, sync_trig_channel,
+                                                    amp=channel_amp)
         # Create its own block out of the element
         seq_block = PulseBlock('seq_trigger', [seqtrig_element])
         # save block
@@ -607,7 +617,7 @@ def generate_HHtau(self, name='HHtau', rabi_period=1.0e-6, spinlock_amp=0.1, mw_
     # Create Block list with repetitions and sequence trigger if needed.
     # remember number_of_taus=0 also counts as first round.
     block_list = [(hhtau_block, num_of_points-1)]
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         block_list.append((seq_block, 0))
 
     # create ensemble out of the block(s)
@@ -624,21 +634,21 @@ def generate_HHtau(self, name='HHtau', rabi_period=1.0e-6, spinlock_amp=0.1, mw_
     return block_ensemble
 
 
-def generate_HHpol(self, name='HHpol', rabi_period=1.0e-6, spinlock_length=20.0e-6,
-                   spinlock_amp=0.1, mw_freq=2870.0e6, pulse_amp=0.5, polarization_steps=50,
+def generate_HHpol(self, name='hh_pol', rabi_period=1.0e-6, spinlock_length=20.0e-6,
+                   spinlock_amp=0.1, mw_freq=2870.0e6, mw_amp=0.5, polarization_steps=50,
                    mw_channel='a_ch1', laser_length=3.0e-6, channel_amp=1.0, delay_length=0.7e-6,
-                   wait_time=1.0e-6, seq_trig_channel='', gate_count_channel=''):
+                   wait_time=1.0e-6, sync_trig_channel='', gate_count_channel=''):
     """
 
     """
     # Sanity checks
     if gate_count_channel == '':
         gate_count_channel = None
-    if seq_trig_channel == '':
-        seq_trig_channel = None
+    if sync_trig_channel == '':
+        sync_trig_channel = None
     err_code = self._do_channel_sanity_checks(mw_channel=mw_channel,
                                               gate_count_channel=gate_count_channel,
-                                              seq_trig_channel=seq_trig_channel)
+                                              sync_trig_channel=sync_trig_channel)
     if err_code != 0:
         return
 
@@ -648,18 +658,19 @@ def generate_HHpol(self, name='HHpol', rabi_period=1.0e-6, spinlock_length=20.0e
     laser_element, delay_element = self._get_laser_element(laser_length, 0.0, False, delay_length,
                                                            channel_amp, gate_count_channel)
     # get pihalf element
-    pihalf_element = self._get_mw_element(rabi_period / 4, 0.0, mw_channel, False, pulse_amp,
+    pihalf_element = self._get_mw_element(rabi_period / 4, 0.0, mw_channel, False, mw_amp,
                                           mw_freq, 0.0)
     # get 3pihalf element
-    pi3half_element = self._get_mw_element(3 * rabi_period / 4, 0.0, mw_channel, False, pulse_amp,
+    pi3half_element = self._get_mw_element(3 * rabi_period / 4, 0.0, mw_channel, False, mw_amp,
                                            mw_freq, 0.0)
     # get spinlock element
     sl_element = self._get_mw_element(spinlock_length, 0.0, mw_channel, False, spinlock_amp,
                                       mw_freq, 90.0)
 
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         # get sequence trigger element
-        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, seq_trig_channel, amp=channel_amp)
+        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, sync_trig_channel,
+                                                    amp=channel_amp)
         # Create its own block out of the element
         seq_block = PulseBlock('seq_trigger', [seqtrig_element])
         # save block
@@ -695,7 +706,7 @@ def generate_HHpol(self, name='HHpol', rabi_period=1.0e-6, spinlock_length=20.0e
     # remember number_of_taus=0 also counts as first round
     block_list = [(HHpolup_block, polarization_steps - 1),
                   (HHpoldown_block, polarization_steps - 1)]
-    if seq_trig_channel:
+    if sync_trig_channel:
         block_list.append((seq_block, 0))
 
     # create ensemble out of the block(s)
@@ -713,21 +724,22 @@ def generate_HHpol(self, name='HHpol', rabi_period=1.0e-6, spinlock_length=20.0e
     return block_ensemble
 
 
-def generate_xy8_tau(self, name='XY8_tau', rabi_period=1.0e-6, mw_freq=2870.0e6, mw_amp=0.1,
+def generate_xy8_tau(self, name='xy8_tau', rabi_period=1.0e-6, mw_freq=2870.0e6, mw_amp=0.1,
                      start_tau=0.5e-6, incr_tau=0.01e-6, num_of_points=50, xy8_order=4,
                      mw_channel='a_ch1', laser_length=3.0e-6, channel_amp=1.0, delay_length=0.7e-6,
-                     wait_time=1.0e-6, seq_trig_channel='', gate_count_channel='',alternating=True):
+                     wait_time=1.0e-6, sync_trig_channel='', gate_count_channel='',
+                     alternating=True):
     """
 
     """
     # Sanity checks
     if gate_count_channel == '':
         gate_count_channel = None
-    if seq_trig_channel == '':
-        seq_trig_channel = None
+    if sync_trig_channel == '':
+        sync_trig_channel = None
     err_code = self._do_channel_sanity_checks(mw_channel=mw_channel,
                                               gate_count_channel=gate_count_channel,
-                                              seq_trig_channel=seq_trig_channel)
+                                              sync_trig_channel=sync_trig_channel)
     if err_code != 0:
         return
 
@@ -762,9 +774,10 @@ def generate_xy8_tau(self, name='XY8_tau', rabi_period=1.0e-6, mw_freq=2870.0e6,
     # get tau element
     tau_element = self._get_idle_element(real_start_tau, incr_tau, False)
 
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         # get sequence trigger element
-        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, seq_trig_channel, amp=channel_amp)
+        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, sync_trig_channel,
+                                                    amp=channel_amp)
         # Create its own block out of the element
         seq_block = PulseBlock('seq_trigger', [seqtrig_element])
         # save block
@@ -777,8 +790,8 @@ def generate_xy8_tau(self, name='XY8_tau', rabi_period=1.0e-6, mw_freq=2870.0e6,
     xy8_elem_list.append(tauhalf_element)
     for n in range(xy8_order):
         if n==0:
-            xy8_elem_list.append( self._get_mw_element(rabi_period / 2, 0.0, mw_channel, True, mw_amp,
-                                                       mw_freq,0.0))
+            xy8_elem_list.append( self._get_mw_element(rabi_period / 2, 0.0, mw_channel, True,
+                                                       mw_amp, mw_freq,0.0))
             xy8_elem_list.append(self._get_idle_element(real_start_tau, incr_tau, True))
         else:
             xy8_elem_list.append(pix_element)
@@ -837,7 +850,7 @@ def generate_xy8_tau(self, name='XY8_tau', rabi_period=1.0e-6, mw_freq=2870.0e6,
 
     # create block list and ensemble object
     block_list = [(xy8_block, num_of_points - 1)]
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         block_list.append((seq_block, 0))
 
     # create ensemble out of the block(s)
@@ -855,21 +868,21 @@ def generate_xy8_tau(self, name='XY8_tau', rabi_period=1.0e-6, mw_freq=2870.0e6,
     return block_ensemble
 
 
-def generate_xy8_freq(self, name='XY8_freq', rabi_period=1.0e-6, mw_freq=2870.0e6, mw_amp=0.1,
+def generate_xy8_freq(self, name='xy8_freq', rabi_period=1.0e-6, mw_freq=2870.0e6, mw_amp=0.1,
                       start_freq=0.1e6, incr_freq=0.01e6, num_of_points=50, xy8_order=4,
                       mw_channel='a_ch1', laser_length=3.0e-6, channel_amp=1.0, delay_length=0.7e-6,
-                      wait_time=1.0e-6, seq_trig_channel='', gate_count_channel=''):
+                      wait_time=1.0e-6, sync_trig_channel='', gate_count_channel=''):
     """
 
     """
     # Sanity checks
     if gate_count_channel == '':
         gate_count_channel = None
-    if seq_trig_channel == '':
-        seq_trig_channel = None
+    if sync_trig_channel == '':
+        sync_trig_channel = None
     err_code = self._do_channel_sanity_checks(mw_channel=mw_channel,
                                               gate_count_channel=gate_count_channel,
-                                              seq_trig_channel=seq_trig_channel)
+                                              sync_trig_channel=sync_trig_channel)
     if err_code != 0:
         return
 
@@ -902,9 +915,10 @@ def generate_xy8_freq(self, name='XY8_freq', rabi_period=1.0e-6, mw_freq=2870.0e
     piy_element = self._get_mw_element(rabi_period / 2, 0.0, mw_channel, False, mw_amp, mw_freq,
                                        90.0)
 
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         # get sequence trigger element
-        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, seq_trig_channel, amp=channel_amp)
+        seqtrig_element = self._get_trigger_element(20.0e-9, 0.0, sync_trig_channel,
+                                                    amp=channel_amp)
         # Create its own block out of the element
         seq_block = PulseBlock('seq_trigger', [seqtrig_element])
         # save block
@@ -977,7 +991,7 @@ def generate_xy8_freq(self, name='XY8_freq', rabi_period=1.0e-6, mw_freq=2870.0e
 
     # create block list and ensemble object
     block_list = [(xy8_block, num_of_points - 1)]
-    if seq_trig_channel is not None:
+    if sync_trig_channel is not None:
         block_list.append((seq_block, 0))
 
     # create ensemble out of the block(s)
@@ -1065,7 +1079,8 @@ def _get_trigger_element(self, length, increment, channel, use_as_tick=False, am
     return trig_element
 
 
-def _get_laser_element(self, length, increment, use_as_tick, delay_time=None, amp_V=None, gate_count_chnl=None):
+def _get_laser_element(self, length, increment, use_as_tick, delay_time=None, amp_V=None,
+                       gate_count_chnl=None):
     """
     Creates laser and gate trigger PulseBlockElements
 
@@ -1164,11 +1179,11 @@ def _get_mw_element(self, length, increment, mw_channel, use_as_tick, amp=None, 
                                    parameters=mw_params, use_as_tick=use_as_tick)
     return mw_element
 
-def _get_multiple_mw_element(self, length, increment, mw_channel, use_as_tick, amps = None, freqs = None,
-                                                                          phases = None):
+def _get_multiple_mw_element(self, length, increment, mw_channel, use_as_tick, amps = None,
+                             freqs = None, phases = None):
     """
-    Creates at the mment double or triple mw element. Is easily extended when further methods are developed in the
-    module sampling_functions.
+    Creates at the mment double or triple mw element. Is easily extended when further methods are
+    developed in the module sampling_functions.
 
     @param float length: MW pulse duration in seconds
     @param float increment: MW pulse duration increment in seconds

--- a/logic/pulsed_master_logic.py
+++ b/logic/pulsed_master_logic.py
@@ -87,7 +87,7 @@ class PulsedMasterLogic(GenericLogic):
     sigSampleSequence = QtCore.Signal(str, bool)
     sigGeneratorSettingsChanged = QtCore.Signal(list, str, float, dict, str)
     sigRequestGeneratorInitValues = QtCore.Signal()
-    sigGeneratePredefinedSequence = QtCore.Signal(str, list)
+    sigGeneratePredefinedSequence = QtCore.Signal(str, dict)
 
     # signals for master module (i.e. GUI)
     sigSavedPulseBlocksUpdated = QtCore.Signal(dict)
@@ -1240,14 +1240,14 @@ class PulsedMasterLogic(GenericLogic):
                                                    self._measurement_logic.interleave_on)
         return
 
-    def generate_predefined_sequence(self, generator_method_name, arg_list):
+    def generate_predefined_sequence(self, generator_method_name, kwarg_dict):
         """
 
         @param generator_method_name:
-        @param arg_list:
+        @param kwarg_dict:
         @return:
         """
-        self.sigGeneratePredefinedSequence.emit(generator_method_name, arg_list)
+        self.sigGeneratePredefinedSequence.emit(generator_method_name, kwarg_dict)
         return
 
     def predefined_sequence_generated(self, generator_method_name):

--- a/logic/sequence_generator_logic.py
+++ b/logic/sequence_generator_logic.py
@@ -582,16 +582,27 @@ class SequenceGeneratorLogic(GenericLogic, SamplingFunctions, SamplesWriteMethod
                              'ensembles.\nTherefore nothing is removed.'.format(name))
         return
 
-    def generate_predefined_sequence(self, predefined_sequence_name, args):
+    def generate_predefined_sequence(self, predefined_sequence_name, kwargs_dict):
         """
 
         @param predefined_sequence_name:
-        @param args:
+        @param kwargs_dict:
         @return:
         """
         gen_method = self.generate_methods[predefined_sequence_name]
+        # match parameters to method and throw out unwanted ones
+        method_params = inspect.signature(gen_method).parameters
+        thrown_out_params = list()
+        for param in kwargs_dict:
+            if param not in method_params:
+                thrown_out_params.append(param)
+        for param in thrown_out_params:
+            del kwargs_dict[param]
+        if len(thrown_out_params) > 0:
+            self.log.debug('Unused params during predefined sequence generation "{0}":\n'
+                           '{1}'.format(predefined_sequence_name, thrown_out_params))
         try:
-            gen_method(*args)
+            gen_method(**kwargs_dict)
         except:
             self.log.error('Generation of predefined sequence "{0}" failed.'
                            ''.format(predefined_sequence_name))


### PR DESCRIPTION
## Description
The GUI elements for predefined sequences were mostly redundant. This changeset reduces this issue quite a lot by introducing global parameters (like "laser_length", "sync_trig_channel", etc.) that are always shown and shared for each "generate_*" method used.

These changes will not break existing custom predefined sequence generate-methods but they will not make use of the global parameters if not adapted properly. (I will send an email with instructions after merge)

Global parameters can be one of the following and are automatically used if the name of the global parameter matches the one in the generate-method call:
`['mw_channel', 'gate_count_channel', 'sync_trig_channel', 'mw_amp', 'mw_freq', 'channel_amp', 'delay_length', 'wait_time', 'laser_length', 'rabi_period']`

Also tweaked the overall appearance of the predefined methods tab.

## Motivation and Context
Filling out redundant information for each predefined "generate_*" method was not very convenient.
Addresses issue #262 by simplifying the GUI usage for predefined sequences.

## How Has This Been Tested?
Tested with dummy modules since no hardware is needed/affected. 
All generate-methods in basic_methods.py have been tested. Can of course not test custom method definition modules that are not part of this repo.

## Screenshots:
![pulsedgui](https://user-images.githubusercontent.com/18266223/31139931-585a7a78-a873-11e7-8610-32a7e65c216c.PNG)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation (not existent).
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
