### PR TITLE
Ni card control digital output

### DIFF
--- a/hardware/ni_card.py
+++ b/hardware/ni_card.py
@@ -1987,3 +1987,40 @@ class NICard(Base, SlowCounterInterface, ConfocalScannerInterface, ODMRCounterIn
             retval = -1
         return retval
 
+
+    # ======================== Digital channel control ==========================
+
+
+    def channel_switch(self, channel_name, mode=False):
+        """
+        Switches on or off the voltage output (5V) of one of the digital channels, that
+        can as an example be used to switch on or off the AOM driver or apply a single
+        trigger for ODMR.
+        @param str channel_name: Name of the channel which should be controlled
+                                    for example ('/Dev1/PFI9')
+        @param bool mode: specifies if the voltage output of the chosen channel should be turned on or off
+
+        @return int: error code (0:OK, -1:error)
+        """
+        if channel_name == None:
+            self.log.error('No channel for digital output specified')
+            return -1
+        else:
+
+            self.digital_out_task = daq.TaskHandle()
+            if mode:
+                self.digital_data = daq.c_uint32(0xffffffff)
+            else:
+                self.digital_data = daq.c_uint32(0x0)
+            self.digital_read = daq.c_int32()
+            self.digital_samples_channel = daq.c_int32(1)
+            daq.DAQmxCreateTask('DigitalOut', daq.byref(self.digital_out_task))
+            daq.DAQmxCreateDOChan(self.digital_out_task, channel_name, "", daq.DAQmx_Val_ChanForAllLines)
+            daq.DAQmxStartTask(self.digital_out_task)
+            daq.DAQmxWriteDigitalU32(self.digital_out_task, self.digital_samples_channel, True,
+                                        self._RWTimeout, daq.DAQmx_Val_GroupByChannel,
+                                        np.array(self.digital_data), self.digital_read, None);
+
+            daq.DAQmxStopTask(self.digital_out_task)
+            daq.DAQmxClearTask(self.digital_out_task)
+            return 0

--- a/hardware/ni_card.py
+++ b/hardware/ni_card.py
@@ -1991,7 +1991,7 @@ class NICard(Base, SlowCounterInterface, ConfocalScannerInterface, ODMRCounterIn
     # ======================== Digital channel control ==========================
 
 
-    def channel_switch(self, channel_name, mode=False):
+    def digital_channel_switch(self, channel_name, mode=True):
         """
         Switches on or off the voltage output (5V) of one of the digital channels, that
         can as an example be used to switch on or off the AOM driver or apply a single
@@ -2024,3 +2024,5 @@ class NICard(Base, SlowCounterInterface, ConfocalScannerInterface, ODMRCounterIn
             daq.DAQmxStopTask(self.digital_out_task)
             daq.DAQmxClearTask(self.digital_out_task)
             return 0
+
+


### PR DESCRIPTION
Digital channel of Nicard can now be controlled via software 

## Description
Add a new function in the NIcard hardware file to turn on or off the output of digital channels. At the moment this function has to be called directly in the hardware file (for example via notebook)

## Motivation and Context
There are a lot of unused digital channels for the NIcard and I cannot find a simple function to control them via QuDi.

## How Has This Been Tested?

Tested by triggering AOM


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
