### PR TITLE
Pi motor stage extract information from an answer in a smart way

### DIFF
--- a/hardware/motor/motor_stage_pi.py
+++ b/hardware/motor/motor_stage_pi.py
@@ -264,10 +264,10 @@ class MotorStagePI(Base, MotorInterface):
         try:
             if param_list is not None:
                 for axis_label in param_list:
-                    for attempt in range(25):
+                    for attempt in range(5):
                         # self.log.debug(attempt)
                         try:
-                            pos = int(self._ask_xyz(axis_label,'TT')[8:])
+                            pos = int(self._ask_xyz(axis_label,'TT').split(":",1)[1])
                             param_dict[axis_label] = pos * 1e-7
                         except:
                             continue
@@ -275,10 +275,11 @@ class MotorStagePI(Base, MotorInterface):
                             break
             else:
                 for axis_label in constraints:
-                    for attempt in range(25):
+                    for attempt in range(5):
                         #self.log.debug(attempt)
                         try:
-                            pos = int(self._ask_xyz(axis_label,'TT')[8:])
+                            #pos = int(self._ask_xyz(axis_label,'TT')[8:])
+                            pos = int(self._ask_xyz(axis_label, 'TT').split(":",1)[1])
                             param_dict[axis_label] = pos * 1e-7
                         except:
                             continue
@@ -288,6 +289,7 @@ class MotorStagePI(Base, MotorInterface):
         except:
             self.log.error('Could not find current xyz motor position')
             return -1
+
 
     def get_status(self, param_list=None):
         """ Get the status of the position
@@ -308,11 +310,11 @@ class MotorStagePI(Base, MotorInterface):
         try:
             if param_list is not None:
                 for axis_label in param_list:
-                    status = self._ask_xyz(axis_label,'TS')[8:]
+                    status = self._ask_xyz(axis_label,'TS').split(":",1)[1]
                     param_dict[axis_label] = status
             else:
                 for axis_label in constraints:
-                    status = self._ask_xyz(axis_label, 'TS')[8:]
+                    status = self._ask_xyz(axis_label, 'TS').split(":",1)[1]
                     param_dict[axis_label] = status
             return param_dict
         except:
@@ -371,11 +373,11 @@ class MotorStagePI(Base, MotorInterface):
         try:
             if param_list is not None:
                 for axis_label in param_list:
-                    vel = int(self._ask_xyz(axis_label, 'TY')[8:])
+                    vel = int(self._ask_xyz(axis_label, 'TY').split(":",1)[1])
                     param_dict[axis_label] = vel * 1e-7
             else:
                 for axis_label in constraints:
-                    vel = int(self._ask_xyz(axis_label, 'TY')[8:])
+                    vel = int(self._ask_xyz(axis_label, 'TY').split(":",1)[1])
                     param_dict[axis_label] = vel * 1e-7
             return param_dict
         except:
@@ -479,7 +481,7 @@ class MotorStagePI(Base, MotorInterface):
             current_pos = self.get_pos(axis)[axis]
             move = current_pos + step
             self._do_move_abs(axis, move)
-        return axis,move
+        return axis, move
 
     def _do_move_abs(self, axis, move):
         """internal method for the absolute move in meter
@@ -538,6 +540,10 @@ class MotorStagePI(Base, MotorInterface):
             #########################################################################################
 #########################################################################################
 #########################################################################################
+
+
+
+
 
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Pi motor stage extract information from an answer in a smart way

## Description
<!--- Describe your changes in detail -->



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The answer of the pi motor looks something like '3TT3tt:54676' and only the number after the ':' is relevant. Before this number was extracted by doing something like answer[8:]. However, this caused unexpected behaviour from time to time (1 out of 10). Now the number is extracted by splitting the answer string after the ':'

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested on setup


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
