### PR TITLE
CW frequency and power are updated in odmr GUI when changed in odmr logic

### DIFF
--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -654,6 +654,18 @@ class ODMRGui(GUIBase):
             self._sd.clock_frequency_DoubleSpinBox.blockSignals(True)
             self._sd.clock_frequency_DoubleSpinBox.setValue(param)
             self._sd.clock_frequency_DoubleSpinBox.blockSignals(False)
+
+        param = param_dict.get('cw_mw_frequency')
+        if param is not None:
+            self._mw.cw_frequency_DoubleSpinBox.blockSignals(True)
+            self._mw.cw_frequency_DoubleSpinBox.setValue(param)
+            self._mw.cw_frequency_DoubleSpinBox.blockSignals(False)
+
+        param = param_dict.get('cw_mw_power')
+        if param is not None:
+            self._mw.cw_power_DoubleSpinBox.blockSignals(True)
+            self._mw.cw_power_DoubleSpinBox.setValue(param)
+            self._mw.cw_power_DoubleSpinBox.blockSignals(False)
         return
 
     ############################################################################


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When the cw frequency and power are set in the logic the gui is not updated. Fixed that

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When the cw power and frequency are changed using the logic ('set_cw_parameters(self, frequency, power)')... the values were not updated in the gui. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested with script

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
