### PR TITLE
change error to warning in _refocus_done method, which is called by e…

### DIFF
--- a/logic/poi_manager_logic.py
+++ b/logic/poi_manager_logic.py
@@ -650,15 +650,14 @@ class PoiManagerLogic(GenericLogic):
                     self.go_to_poi(poikey=self._current_poi_key)
                 return 0
             else:
-                self.log.error('W. The given POI ({0}) does not exist.'.format(
+                self.log.error('The given POI ({0}) does not exist.'.format(
                     self._current_poi_key))
                 return -1
 
         else:
-            self.log.error('Unknown caller_tag for the optimizer. POI '
-                           'Manager does not know what to do with optimized '
-                           'position, and has done nothing.'
-                           )
+            self.log.warning("Unknown caller_tag for the optimizer. POI "
+                             "Manager does not know what to do with optimized "
+                             "position, and has done nothing.")
 
     def reset_roi(self):
 


### PR DESCRIPTION
One line fix in poi manager

<!--- Provide a general summary of your changes in the Title above -->

Just changing error to warning...

## Description
<!--- Describe your changes in detail -->

When optimize position is called from script or error and no caller_tag is given there is no error but a warning

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
 at setup 2

Checked in setup. 
## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
