### PR TITLE
fix conda errors on travisci

### DIFF
--- a/tools/install-python-modules-linux.sh
+++ b/tools/install-python-modules-linux.sh
@@ -2,5 +2,5 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-conda env remove --yes --name qudi
-conda env create -f "${DIR}/conda-env-linx64-qt5.yml"
+conda env remove --quiet --yes --name qudi
+conda env create --quiet -f "${DIR}/conda-env-linx64-qt5.yml"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Prevent conda output which leads to failing travisci builds when installing Python packages.

## Description
<!--- Describe your changes in detail -->
Conda crashes on TravisCI with BlockingIOError exception due to console output.
Workaround by using --quiet.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
TravisCI test suite should now fail in one of the test notebooks due to fitting failure and not error out while installing the Python environment.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Test run on TravisCI when pushing this branch.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
