### PR TITLE
 Fix to PulseStreamer pulse generation. 

### DIFF
--- a/logic/samples_write_methods.py
+++ b/logic/samples_write_methods.py
@@ -365,6 +365,39 @@ class SamplesWriteMethods():
         If both flags (is_first_chunk, is_last_chunk) are set to TRUE it means
         that the whole ensemble is written as a whole in one big chunk.
 
+        The PulseStreamer programming interface is based on a sequence of <Pulse> elements,
+        with the following C++ datatype (taken from the documentation available at 
+        https://www.swabianinstruments.com/static/documentation/PulseStreamer/sections/interface.html):
+            struct Pulse {
+                unsigned int ticks; // duration in ns
+                unsigned char digi; // bit mask
+                short ao0;
+                short ao1;
+            };
+
+        Currently the access to the analog channels is not exposed by the Qudi implementation
+        of the PulseStreamer hardware, so we need only deal with the digital side. Thus a new 
+        Pulse element is required every time the digital channels (8 available) change, with a
+        corresponding length computed for that Pulse element. For example, the sequence
+        
+            Channel 01234567
+                    01000000
+                    01000000
+                    01000100
+                    01000100
+                    00000000
+                
+        will be compressed to three Pulse elements with duration 2, 2, 1 and with the correct
+        respective bitmasks for the active channels. 
+        
+        This function traverses the digital_samples array to identify where the active digital
+        channels are modified and compresses it down to a sequence of pulse elements each with 
+        a bitmask and a length. The file is then written to disk. 
+        
+        TODO: This is inefficient, as the original PulseElement representation inside Qudi is
+        first decompressed into a sample stream, then recompressed into the PulseStreamer 
+        representation. Work is required to enable the bypass of the interim stage. 
+
         @param name: string, represents the name of the sampled ensemble
         @param analog_samples: float32 numpy ndarray, contains the
                                        samples for the analog channels that

--- a/logic/samples_write_methods.py
+++ b/logic/samples_write_methods.py
@@ -395,9 +395,13 @@ class SamplesWriteMethods():
                            ''.format(channel_number))
             return -1
 
+        # fetch locations where digital channel states change, and eliminate duplicates
         new_channel_indices = np.where(digital_samples[:-1,:] != digital_samples[1:,:])[0]
-        new_channel_indices = new_channel_indices[np.where(new_channel_indices[:-1] != new_channel_indices[1:])[0]] #get rid of repeats
+        new_channel_indices = np.unique(new_channel_indices)
+
+        # add in indices for the start and end of the sequence to simplify iteration
         new_channel_indices = np.insert(new_channel_indices, 0, [-1])
+        new_channel_indices = np.insert(new_channel_indices, new_channel_indices.size, [digital_samples.shape[0]-1])
 
         pulses = []
         for new_channel_index in range(1, new_channel_indices.size):


### PR DESCRIPTION
Eliminates cases where the final pulse in a sequence isn't propagated into the sequence uploaded to hardware

<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes bug in the sequence generation logic for the Swabian Instruments Pulse Streamer. The raw sequence is compressed into pulses with a given number of channels active and a duration. The previous logic was faulty and could accidentally eliminate a pulse from the end of the sequence. 

## Motivation and Context
This change ensures that the sequence generated is true to the desired sequence.

## How Has This Been Tested?
Tested by generating and inspecting a large number of sequences to check for edge cases.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
