### PR TITLE
Fixed issue #303

### DIFF
--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -607,17 +607,11 @@ class ODMRGui(GUIBase):
         The update will block the GUI signals from emitting a change back to the
         logic.
         """
-        param = param_dict.get('mw_power')
+        param = param_dict.get('sweep_mw_power')
         if param is not None:
-            self._mw.power_DoubleSpinBox.blockSignals(True)
-            self._mw.power_DoubleSpinBox.setValue(param)
-            self._mw.power_DoubleSpinBox.blockSignals(False)
-
-        param = param_dict.get('mw_frequency')
-        if param is not None:
-            self._mw.frequency_DoubleSpinBox.blockSignals(True)
-            self._mw.frequency_DoubleSpinBox.setValue(param)
-            self._mw.frequency_DoubleSpinBox.blockSignals(False)
+            self._mw.sweep_power_DoubleSpinBox.blockSignals(True)
+            self._mw.sweep_power_DoubleSpinBox.setValue(param)
+            self._mw.sweep_power_DoubleSpinBox.blockSignals(False)
 
         param = param_dict.get('mw_start')
         if param is not None:

--- a/logic/odmr_logic.py
+++ b/logic/odmr_logic.py
@@ -270,7 +270,7 @@ class ODMRLogic(GenericLogic):
         else:
             self.log.warning('set_runtime failed. Input parameter runtime is no integer or float.')
 
-        update_dict = {'runtime': self.run_time}
+        update_dict = {'run_time': self.run_time}
         self.sigParameterUpdated.emit(update_dict)
         return self.run_time
 


### PR DESCRIPTION
All microwave and runtime parameters now get properly updated in `ODMRGui` upon calling `set_sweep_parameters` or `set_runtime` in `ODMRLogic.`

## Description
A late renaming of SpinBoxes in the `ODMRGui` ui-file and the subsequent renaming of the parameter string descriptor in `update_parameter` of `ODMRGui` caused that issue.
This change was inconsequently applied to `ODMRLogic.`

## How Has This Been Tested?
Since it's just a logic<-->GUI synchronization issue it has just been tested with the dummy config.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
