### PR TITLE
improved visual indication for unloaded modules

### DIFF
--- a/gui/manager/managergui.py
+++ b/gui/manager/managergui.py
@@ -620,6 +620,9 @@ class ModuleListItem(QtWidgets.QFrame):
         """ Send signal to load and activate this module.
         """
         self.sigLoadThis.emit(self.base, self.name)
+        
+        # Instant return to checked to prevent visual lag before checkModuleState completes
+        self.loadButton.setChecked(True)
 
     def reloadButtonClicked(self):
         """ Send signal to reload this module.
@@ -651,15 +654,24 @@ class ModuleListItem(QtWidgets.QFrame):
                         and self.name in self.manager.tree['loaded'][self.base]):
                     state = self.manager.tree['loaded'][self.base][self.name].module_state()
 
-                    self.reloadButton.setEnabled(True)
-                    self.deactivateButton.setEnabled(True)
-                    self.cleanupButton.setEnabled(False)
-                    self.loadButton.setChecked(True)
+                    if state != 'deactivated':
+                        self.reloadButton.setEnabled(True)
+                        self.deactivateButton.setEnabled(True)
+                        self.cleanupButton.setEnabled(False)
+                        self.loadButton.setChecked(True)
 
-                    if self.base == 'gui':
-                        self.loadButton.setText('Show {0}'.format(self.name))
+                        if self.base == 'gui':
+                            self.loadButton.setText('Show {0}'.format(self.name))
+                        else:
+                            self.loadButton.setText(self.name)
                     else:
-                        self.loadButton.setText(self.name)
+                        self.reloadButton.setEnabled(True)
+                        self.deactivateButton.setEnabled(False)
+                        self.cleanupButton.setEnabled(True)
+                        self.loadButton.setChecked(True)
+
+                        self.loadButton.setText('Activate {0}'.format(self.name))
+
                 else:
                     state = 'not loaded'
                     self.reloadButton.setEnabled(False)

--- a/gui/manager/managergui.py
+++ b/gui/manager/managergui.py
@@ -648,5 +648,6 @@ class ModuleListItem(QtWidgets.QFrame):
                     self.reloadButton.setEnabled(False)
             except:
                 state = 'exception, cannot get state'
+                self.reloadButton.setEnabled(False)
 
             self.statusLabel.setText(state)

--- a/gui/manager/managergui.py
+++ b/gui/manager/managergui.py
@@ -54,6 +54,7 @@ except:
 
 
 class ManagerGui(GUIBase):
+
     """This class provides a GUI to the Qudi manager.
 
       @signal sigStartAll: sent when all modules should be loaded
@@ -229,7 +230,7 @@ class ManagerGui(GUIBase):
             text,
             QtWidgets.QMessageBox.Yes,
             QtWidgets.QMessageBox.No
-            )
+        )
         if result == QtWidgets.QMessageBox.Yes:
             self.sigRealQuit.emit()
 
@@ -397,7 +398,7 @@ Go, play.
           @param str base: module category to fill
         """
         for module in self._manager.tree['defined'][base]:
-            if not module in self._manager.tree['global']['startup']:
+            if module not in self._manager.tree['global']['startup']:
                 widget = ModuleListItem(self._manager, base, module)
                 self.modlist.append(widget)
                 layout.addWidget(widget)
@@ -516,6 +517,7 @@ Go, play.
 
 
 class ManagerMainWindow(QtWidgets.QMainWindow):
+
     """ This class represents the Manager Window.
     """
 
@@ -540,6 +542,7 @@ class ManagerMainWindow(QtWidgets.QMainWindow):
 
 
 class AboutDialog(QtWidgets.QDialog):
+
     """ This class represents the Qudi About dialog.
     """
 
@@ -556,12 +559,13 @@ class AboutDialog(QtWidgets.QDialog):
 
 
 class ConsoleSettingsDialog(QtWidgets.QDialog):
+
     """ Create the SettingsDialog window, based on the corresponding *.ui
         file.
     """
 
     def __init__(self):
-         # Get the path to the *.ui file
+        # Get the path to the *.ui file
         this_dir = os.path.dirname(__file__)
         ui_file = os.path.join(this_dir, 'ui_console_settings.ui')
 
@@ -571,6 +575,7 @@ class ConsoleSettingsDialog(QtWidgets.QDialog):
 
 
 class ModuleListItem(QtWidgets.QFrame):
+
     """ This class represents a module widget in the Qudi module list.
 
       @signal str str sigLoadThis: gives signal with base and name of module
@@ -615,8 +620,6 @@ class ModuleListItem(QtWidgets.QFrame):
         """ Send signal to load and activate this module.
         """
         self.sigLoadThis.emit(self.base, self.name)
-        if self.base == 'gui':
-            self.loadButton.setText('Show {0}'.format(self.name))
 
     def reloadButtonClicked(self):
         """ Send signal to reload this module.
@@ -634,7 +637,12 @@ class ModuleListItem(QtWidgets.QFrame):
         self.sigCleanupStatus.emit(self.base, self.name)
 
     def checkModuleState(self):
-        """ Get the state of this module and display it in the statusLabel
+        """ Get the state of this module and update visual indications in the GUI.
+
+            Modules cannot be unloaded, but they can be deactivated.
+
+            Once loaded, the "load <module>" button will remain checked and its text
+            will be updated to indicate that loading is no longer possible.
         """
         state = ''
         if self.statusLabel.text() != 'exception, cannot get state':
@@ -642,14 +650,21 @@ class ModuleListItem(QtWidgets.QFrame):
                 if (self.base in self.manager.tree['loaded']
                         and self.name in self.manager.tree['loaded'][self.base]):
                     state = self.manager.tree['loaded'][self.base][self.name].module_state()
+
                     self.reloadButton.setEnabled(True)
                     self.deactivateButton.setEnabled(True)
-                    self.cleanupButton.setEnabled(True)
+                    self.cleanupButton.setEnabled(False)
+                    self.loadButton.setChecked(True)
+
+                    if self.base == 'gui':
+                        self.loadButton.setText('Show {0}'.format(self.name))
+                    else:
+                        self.loadButton.setText(self.name)
                 else:
                     state = 'not loaded'
                     self.reloadButton.setEnabled(False)
                     self.deactivateButton.setEnabled(False)
-                    self.cleanupButton.setEnabled(False)
+                    self.cleanupButton.setEnabled(True)
             except:
                 state = 'exception, cannot get state'
                 self.reloadButton.setEnabled(False)

--- a/gui/manager/managergui.py
+++ b/gui/manager/managergui.py
@@ -643,11 +643,17 @@ class ModuleListItem(QtWidgets.QFrame):
                         and self.name in self.manager.tree['loaded'][self.base]):
                     state = self.manager.tree['loaded'][self.base][self.name].module_state()
                     self.reloadButton.setEnabled(True)
+                    self.deactivateButton.setEnabled(True)
+                    self.cleanupButton.setEnabled(True)
                 else:
                     state = 'not loaded'
                     self.reloadButton.setEnabled(False)
+                    self.deactivateButton.setEnabled(False)
+                    self.cleanupButton.setEnabled(False)
             except:
                 state = 'exception, cannot get state'
                 self.reloadButton.setEnabled(False)
+                self.deactivateButton.setEnabled(True)
+                self.cleanupButton.setEnabled(True)
 
             self.statusLabel.setText(state)

--- a/gui/manager/managergui.py
+++ b/gui/manager/managergui.py
@@ -642,8 +642,10 @@ class ModuleListItem(QtWidgets.QFrame):
                 if (self.base in self.manager.tree['loaded']
                         and self.name in self.manager.tree['loaded'][self.base]):
                     state = self.manager.tree['loaded'][self.base][self.name].module_state()
+                    self.reloadButton.setEnabled(True)
                 else:
                     state = 'not loaded'
+                    self.reloadButton.setEnabled(False)
             except:
                 state = 'exception, cannot get state'
 

--- a/gui/manager/ui_module_widget.ui
+++ b/gui/manager/ui_module_widget.ui
@@ -59,6 +59,9 @@
      <property name="text">
       <string>Load something.</string>
      </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="1" column="0" colspan="3">


### PR DESCRIPTION
## Description
This update deactivate the module reload button in `managergui.py` if the module is not yet loaded. The button reactivates once the module has been loaded.

## Motivation and Context
This was initiated in the teaching labs where inexperienced users were unsure whether modules had been loaded. They requested additional visual feedback, see issue QMAPP-mq/qudi#23

## How Has This Been Tested?
This has been tested by loading modules in the dummy configuration.

## Screenshots:

![image](https://user-images.githubusercontent.com/13956283/35490016-8519e8a8-04f0-11e8-92d3-8b61ba6ba947.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
