### PR TITLE
Allow reloading when module breaks

### DIFF
--- a/gui/manager/managergui.py
+++ b/gui/manager/managergui.py
@@ -679,7 +679,7 @@ class ModuleListItem(QtWidgets.QFrame):
                     self.cleanupButton.setEnabled(True)
             except:
                 state = 'exception, cannot get state'
-                self.reloadButton.setEnabled(False)
+                self.reloadButton.setEnabled(True)
                 self.deactivateButton.setEnabled(True)
                 self.cleanupButton.setEnabled(True)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Broken modules need to be reloadable to fix things.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When a remote module breaks because the connection to the remote Qudi instance is interrupted, reload is necessary to get things working without restarting Qudi.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Please test in the lab, testgui is broken right now and cannot simulate module_state() causing exceptions.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
