### PR TITLE
This is a bug-fix to the odmr_counter_microwave_interfuse introduced …

### DIFF
--- a/logic/interfuse/odmr_counter_microwave_interfuse.py
+++ b/logic/interfuse/odmr_counter_microwave_interfuse.py
@@ -113,11 +113,11 @@ class ODMRCounterMicrowaveInterfuse(GenericLogic, ODMRCounterInterface,
         @return float[]: the photon counts per second
         """
 
-        counts = np.zeros(length)
+        counts = np.zeros((len(self.get_odmr_channels()), length))
         # self.trigger()
         for i in range(length):
             self.trigger()
-            counts[i] = self._sc_device.get_counter(samples=1)[0]
+            counts[:, i] = self._sc_device.get_counter(samples=1)[0]
         self.trigger()
         return counts
 
@@ -135,6 +135,12 @@ class ODMRCounterMicrowaveInterfuse(GenericLogic, ODMRCounterInterface,
         """
         return self._sc_device.close_clock()
 
+    def get_odmr_channels(self):
+        """ Return a list of channel names.
+
+        @return list(str): channels recorded during ODMR measurement
+        """
+        return self._sc_device.get_counter_channels()
 
     ### ----------- Microwave interface commands -----------
 


### PR DESCRIPTION
…by the merge of the PDMR branch.

## Description

A new method (get_odmr_channels) was introduced and forgotten to implement in the interfuse class. Additionally I modified the interfuse-count-method to be able to also handle the analogue channels.

## How Has This Been Tested?
tested with dummy configuration.

## Screenshots (only if appropriate, delete if not):

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ x ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
