### PR TITLE
Odmr channel selection

### DIFF
--- a/config/example/default.cfg
+++ b/config/example/default.cfg
@@ -42,6 +42,7 @@ hardware:
     mydummyodmrcounter:
         module.Class: 'odmr_counter_dummy.ODMRCounterDummy'
         clock_frequency: 100
+        number_of_channels: 3
         connect:
             fitlogic: 'fitlogic'
 

--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -88,7 +88,7 @@ class ODMRGui(GUIBase):
     sigFitChanged = QtCore.Signal(str)
     sigNumberOfLinesChanged = QtCore.Signal(int)
     sigRuntimeChanged = QtCore.Signal(float)
-    sigDoFit = QtCore.Signal(str)
+    sigDoFit = QtCore.Signal(str, int, arguments=['fit_function', 'channel_index'])
     sigSaveMeasurement = QtCore.Signal(str, list, list)
 
     def __init__(self, config, **kwargs):
@@ -584,7 +584,7 @@ class ODMRGui(GUIBase):
 
     def do_fit(self):
         fit_function = self._mw.fit_methods_ComboBox.getCurrentFit()[0]
-        self.sigDoFit.emit(fit_function)
+        self.sigDoFit.emit(fit_function, self._mw.odmr_channel_ComboBox.currentIndex())
         return
 
     def update_fit(self, x_data, y_data, result_str_dict, current_fit):

--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -88,7 +88,7 @@ class ODMRGui(GUIBase):
     sigFitChanged = QtCore.Signal(str)
     sigNumberOfLinesChanged = QtCore.Signal(int)
     sigRuntimeChanged = QtCore.Signal(float)
-    sigDoFit = QtCore.Signal(str, int, arguments=['fit_function', 'channel_index'])
+    sigDoFit = QtCore.Signal(str, object, object, int)
     sigSaveMeasurement = QtCore.Signal(str, list, list)
 
     def __init__(self, config, **kwargs):
@@ -584,7 +584,7 @@ class ODMRGui(GUIBase):
 
     def do_fit(self):
         fit_function = self._mw.fit_methods_ComboBox.getCurrentFit()[0]
-        self.sigDoFit.emit(fit_function, self._mw.odmr_channel_ComboBox.currentIndex())
+        self.sigDoFit.emit(fit_function, None, None, self._mw.odmr_channel_ComboBox.currentIndex())
         return
 
     def update_fit(self, x_data, y_data, result_str_dict, current_fit):

--- a/hardware/odmr_counter_dummy.py
+++ b/hardware/odmr_counter_dummy.py
@@ -36,6 +36,7 @@ class ODMRCounterDummy(Base, ODMRCounterInterface):
 
     # config options
     _clock_frequency = ConfigOption('clock_frequency', 100, missing='warn')
+    _number_of_channels = ConfigOption('number_of_channels', 2, missing='warn')
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -103,11 +104,7 @@ class ODMRCounterDummy(Base, ODMRCounterInterface):
         @return int: error code (0:OK, -1:error)
         """
 
-
         self._odmr_length = length
-#
-#        self.log.warning('ODMRCounterDummy>set_odmr_length')
-
         return 0
 
     def count_odmr(self, length=100):
@@ -125,10 +122,7 @@ class ODMRCounterDummy(Base, ODMRCounterInterface):
 
         self.module_state.lock()
 
-
         self._odmr_length = length
-
-        count_data = np.random.uniform(0, 5e4, length)
 
         lorentians, params = self._fit_logic.make_lorentziandouble_model()
 
@@ -142,14 +136,17 @@ class ODMRCounterDummy(Base, ODMRCounterInterface):
         params.add('l1_sigma', value=sigma)
         params.add('offset', value=50000.)
 
-        count_data += lorentians.eval(x=np.arange(1, length+1, 1), params=params)
+        ret = np.empty((self._number_of_channels, length))
+
+        for chnl_index in range(self._number_of_channels):
+            count_data = np.random.uniform(0, 5e4, length)
+            count_data += (chnl_index + 1) * lorentians.eval(x=np.arange(1, length + 1, 1),
+                                                             params=params)
+            ret[chnl_index] = count_data
 
         time.sleep(self._odmr_length*1./self._clock_frequency)
 
         self.module_state.unlock()
-
-        ret = np.empty((1, len(count_data)))
-        ret[0] = count_data
         return ret
 
 
@@ -180,4 +177,4 @@ class ODMRCounterDummy(Base, ODMRCounterInterface):
 
         @return list(str): channels recorded during ODMR measurement
         """
-        return ['ch1']
+        return ['ch{0:d}'.format(i) for i in range(1, self._number_of_channels + 1)]


### PR DESCRIPTION
## Description
The recent changes regarding multichannel counter support caused some problems with the fitting routine for ODMR measurements.
The `OdmrGui` already had the possibility to select a count channel to display. However the chosen count channel index was not passed to logic in order to perform a chosen fit on a data set other than index 0.
This has now been fixed.
In order to test that the `odmr_counter_dummy.py` module has been improved to generate multiple channels. The number of desired channels to simulate can be set in the config. Default config has been altered to use this new parameter.

## How Has This Been Tested?
ODMR measurements on dummy modules.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
