### PR TITLE
Bug Fix: pulsed save_ft

### DIFF
--- a/core/util/units.py
+++ b/core/util/units.py
@@ -77,13 +77,18 @@ class ScaledFloat(float):
     @property
     def scale(self):
         """
-        Returns the scale.
+        Returns the scale. (No prefix if 0)
 
         Examples
         --------
         1e-3: m
         1e6: M
         """
+
+        # Zero makes the log crash and should not have a prefix
+        if self == 0:
+            return ''
+
         exponent = math.floor(math.log10(abs(self)) / 3)
         if exponent < -8:
             exponent = -8
@@ -330,6 +335,10 @@ def get_relevant_digit(entry):
 
     # the log10 can only be calculated of a positive number.
     entry = np.abs(entry)
+
+    # the log of zero crashes, so return 0
+    if entry == 0:
+        return 0
 
     if np.log10(entry) >= 0:
         return int(np.log10(entry))

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -1767,7 +1767,14 @@ class PulsedMeasurementGui(GUIBase):
         save_tag = self._mw.save_tag_LineEdit.text()
         with_error = self._pa.ana_param_errorbars_CheckBox.isChecked()
         controlled_val_unit = self._as.ana_param_x_axis_unit_LineEdit.text()
-        self._pulsed_master_logic.save_measurement_data(controlled_val_unit, save_tag, with_error)
+        if self._pa.second_plot_ComboBox.currentText() == 'None':
+            save_ft = True
+        else:
+            save_ft = False
+        self._pulsed_master_logic.save_measurement_data(controlled_val_unit=controlled_val_unit,
+                                                        tag=save_tag,
+                                                        with_error=with_error,
+                                                        save_ft=save_ft)
         self._mw.action_save.setEnabled(True)
         return
 

--- a/logic/pulsed_master_logic.py
+++ b/logic/pulsed_master_logic.py
@@ -671,16 +671,21 @@ class PulsedMasterLogic(GenericLogic):
         self.sigPulserRunningUpdated.emit(is_running)
         return
 
-    def save_measurement_data(self, controlled_val_unit, save_tag, with_error):
-        """
+    def save_measurement_data(self, controlled_val_unit, tag, with_error, save_ft):
+        """ Prepare data to be saved and create a proper plot of the data.
+        This is just handed over to the measurement logic.
 
-        @param controlled_val_unit:
-        @param save_tag:
-        @param with_error:
-        @return:
+        @param str controlled_val_unit: unit of the x axis of the plot
+        @param str tag: a filetag which will be included in the filename
+        @param bool with_error: select whether errors should be saved/plotted
+        @param bool save_ft: select wether the Fourier Transform is plotted
+
+        @return str: filepath where data were saved
         """
-        self._measurement_logic.save_measurement_data(controlled_val_unit, save_tag, with_error)
-        return
+        return self._measurement_logic.save_measurement_data(controlled_val_unit=controlled_val_unit,
+                                                      tag=tag,
+                                                      with_error=with_error,
+                                                      save_ft=save_ft)
 
     def clear_pulse_generator(self):
         """

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -70,7 +70,7 @@ class PulsedMeasurementLogic(GenericLogic):
     psd = StatusVar(default=False)
     window = StatusVar(default='none')
     base_corr = StatusVar(default=True)
-    save_ft = StatusVar(default=True)
+    save_ft = StatusVar(default=False)
 
     # signals
     sigSignalDataUpdated = QtCore.Signal(np.ndarray, np.ndarray, np.ndarray,
@@ -979,6 +979,7 @@ class PulsedMeasurementLogic(GenericLogic):
         @param str controlled_val_unit: unit of the x axis of the plot
         @param str tag: a filetag which will be included in the filename
         @param bool with_error: select whether errors should be saved/plotted
+        @param bool save_ft: select wether the Fourier Transform is plotted
 
         @return str: filepath where data were saved
         """


### PR DESCRIPTION
Fix the bug that the saving of the pulsed measurements crashes, when no FFT is set.

## Description
 - make the scaling of the units cope with 0 (log of 0 crashed before)
 - consistently hand through the save_ft variable to only save the FT when needed
 - set save_ft=False as default
 - configure the pulser gui to determine save_ft by the checkbox

## Motivation and Context
Saving measures for pulsed crashed, when no Fourier Transform was available.

## How Has This Been Tested?
Tested on Dummy.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
