### PR TITLE
fixed a bug: the gui was applying the save_ft option

### DIFF
--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -1768,9 +1768,9 @@ class PulsedMeasurementGui(GUIBase):
         with_error = self._pa.ana_param_errorbars_CheckBox.isChecked()
         controlled_val_unit = self._as.ana_param_x_axis_unit_LineEdit.text()
         if self._pa.second_plot_ComboBox.currentText() == 'None':
-            save_ft = True
-        else:
             save_ft = False
+        else:
+            save_ft = True
         self._pulsed_master_logic.save_measurement_data(controlled_val_unit=controlled_val_unit,
                                                         tag=save_tag,
                                                         with_error=with_error,


### PR DESCRIPTION
fixed a bug: the gui was applying the save_ft option the wrong way around

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ x ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
