### PR TITLE
Matplotlib filedescriptor fix

### DIFF
--- a/core/util/helpers.py
+++ b/core/util/helpers.py
@@ -87,7 +87,8 @@ def exit(exitcode=0):
     fd_list = [i for i in range(fd_min, fd_max)]
 
     # in this subprocess we redefine the stdout, therefore on Unix systems we
-    # need to handle the opened file descriptors
+    # need to handle the opened file descriptors, see PEP 446:
+    #       https://www.python.org/dev/peps/pep-0446/
     if sys.platform in ['linux', 'darwin']:
 
         if sys.platform == 'darwin':

--- a/core/util/helpers.py
+++ b/core/util/helpers.py
@@ -78,13 +78,12 @@ def exit(exitcode=0):
     # invoke atexit callbacks
     atexit._run_exitfuncs()
 
-
     # close file handles
     fd_min = 3
     fd_max = 4096
-    fd_except = []
+    fd_except = set()
 
-    fd_list = [i for i in range(fd_min, fd_max)]
+    fd_set = set(range(fd_min, fd_max))
 
     # in this subprocess we redefine the stdout, therefore on Unix systems we
     # need to handle the opened file descriptors, see PEP 446:
@@ -93,29 +92,28 @@ def exit(exitcode=0):
 
         if sys.platform == 'darwin':
             # trying to close 7 produces an illegal instruction on the Mac.
-            fd_except = [7]
+            fd_except.add(7)
 
         # remove specified file descriptor
-        for entry in fd_except:
-            fd_list.remove(entry)
+        fd_set = fd_set - fd_except
 
-        close_fd(fd_list)
+        close_fd(fd_set)
 
     os._exit(exitcode)
 
 
-def close_fd(fd_list):
+def close_fd(fd_set):
     """ Close routine for file descriptor
 
-    @param list fd_list: list of integers indicating the file descriptors which
-                         should be closed (or at least tried to close).
+    @param set fd_set: set of integers indicating the file descriptors which
+                       should be closed (or at least tried to close).
     """
-
-    for fd in fd_list:
+    for fd in fd_set:
         try:
             os.close(fd)
         except OSError:
             pass
+
 
 def import_check():
     """ Checks whether all the necessary modules are present upon start of qudi.


### PR DESCRIPTION
As indicated in #114 and #260, Qudi crashes upon restart when a plot was generated prior to the restart with matplotlib. This patch fixes these issues.


## Description

Some background info related to this fix:

Qudi itself runs in a child process. By restarting Qudi, the current (child) process is terminated and a new one is started. During the cleanup of the process, all [file descriptors](https://en.wikipedia.org/wiki/File_descriptor) are closed. This should normally not harm the main parent process which controls the restart. However, by closing all open file descriptors manually (during the shutdown), we also close those, which were not directly handled by the python interpreter (since they are e.g. handled by an external c-routines, which are executed during runtime). The result is an invalid memory access of the external c-routine, which does not have any more a valid pointer to the file descriptor.

This problem appears specifically in combination with the library [matplotlib](https://github.com/matplotlib/matplotlib). If a plot is drawn to the screen, then a c-routine [ft2font.cpp](https://github.com/matplotlib/matplotlib/blob/master/src/ft2font.cpp) opens a font file ([in line 493](https://github.com/matplotlib/matplotlib/blob/ffc20d40b99c13c5a6f10436f9cef23dcc40092b/src/ft2font.cpp#L493)), which is used to display the text in the generated plot.

You can check that by utilizing the function `get_mapped_fd()` in [this repo](https://github.com/a-stark/script_collection/blob/master/file_descriptor/file_descriptor.py) (this will work for all OS). Run `get_mapped_fd()` before and after the test code shown in #260 and you can see which font file was opened on your OS.

Now, by closing all file descriptors during the exit in the [helper.py file](https://github.com/Ulm-IQO/qudi/blob/master/core/util/helpers.py#L89), the pointer to the font file of the c-routine [FT2Font](https://github.com/matplotlib/matplotlib/blob/ffc20d40b99c13c5a6f10436f9cef23dcc40092b/src/ft2font.cpp#L493) becomes invalid. During the termination of the child process, matplotlib will also handle the opened file descriptors and close them. But since the pointer to the file (which was opened by [FT2Font](https://github.com/matplotlib/matplotlib/blob/ffc20d40b99c13c5a6f10436f9cef23dcc40092b/src/ft2font.cpp#L493)) is invalid now (since it was cleaned up by the garbage collector after closing the file descriptor), the c-routine will access an invalid memory space.

In Windows, it will cause the errors mentioned in #114 (STATUS_INVALID_CRUNTIME_PARAMETER and STATUS_STACK_BUFFER_OVERRUN) which can now be very well understood, since these exceptions cannot be caught by the python interpreter.

This exception causes eventually the parent process to die.
 
## Motivation and Context

The identification of this bug was the hard part, fixing it is the easy one. Since Python 3.4, file descriptors have a well defined inheritance structure related to their child process. [See for this PEP 446](https://www.python.org/dev/peps/pep-0446/). Therefore, closing the child process will terminate all file descriptors (except stdin stdout and stderr) in windows. Special care has to be taken for unix systems. 
The present patch is doing that. 

Fixes  #114 and #260.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested on following platforms:
- Windows 10 Pro
- Windows 7 Pro
- Ubuntu 16.04
- Ubuntu 17.10

Not tested on MacOS.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
