### PR TITLE
Qdplotter didn't plot anything, fixed that

### DIFF
--- a/logic/qdplot_logic.py
+++ b/logic/qdplot_logic.py
@@ -80,8 +80,8 @@ class QdplotLogic(GenericLogic):
     def set_data(self, x=None, y=None, clear_old=True):
         """Set the data to plot
 
-        @param np.ndarray/list or list of np.ndarrays/lists x: data of independents variable(s)
-        @param np.ndarray/list or list of np.ndarrays/lists y: data of dependent variable(s)
+        @param np.ndarray or list of np.ndarrays x: data of independents variable(s)
+        @param np.ndarray or list of np.ndarrays y: data of dependent variable(s)
         @param bool clear_old: clear old plots in GUI if True
         """
 
@@ -94,13 +94,13 @@ class QdplotLogic(GenericLogic):
             return -1
 
         self.clear_old = clear_old
-        # check if input is only an array (single plot) or a list of arrays (several plots)
-        if len(x) == 1:
-            self.indep_vals = [x]
-            self.depen_vals = [y]
-        else:
+        # check if input is only an array (single plot) or a list of arrays (one or several plots)
+        if type(x[0]) is np.ndarray:  # if x is an array, type(x[0]) is a np.float
             self.indep_vals = x
             self.depen_vals = y
+        else:
+            self.indep_vals = [x]
+            self.depen_vals = [y]
 
         self.sigPlotDataUpdated.emit()
         self.sigPlotParamsUpdated.emit()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
There was a little bug, that didn't make the qdplotter plot anything. I must have messed up something before I merged the last branch about the qdplotter that included the possibility to make several plots. I have fixed this now in the qdplotlocig.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
qdplotter didn't plot anything, now it does.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
tested on dummy with windows 10 and on setup3
## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
