### PR TITLE
Small fix for long ensembles

### DIFF
--- a/logic/sequence_generator_logic.py
+++ b/logic/sequence_generator_logic.py
@@ -744,7 +744,7 @@ class SequenceGeneratorLogic(GenericLogic, SamplingFunctions, SamplesWriteMethod
 
         # convert digital rising indices to numpy.ndarrays
         for chnl in range(len(digital_rising_bins)):
-            digital_rising_bins[chnl] = np.array(digital_rising_bins[chnl], dtype=int)
+            digital_rising_bins[chnl] = np.array(digital_rising_bins[chnl], dtype=np.int64)
 
         return number_of_samples, total_elements, elements_length_bins, digital_rising_bins
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Before a ensemble is sampled it is analyzed. Thereby the digital_rising_bins are obtained and converted to an integer array. Integer is limited to around 2e9 while AWG70k might have up to 16e9 samples. So the data type is changed to 'int64'

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Required for long ensembles

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested on setup 3 for long ensemble

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
