### PR TITLE
fixed poi-manager: a feature that was more a bug

### DIFF
--- a/logic/poi_manager_logic.py
+++ b/logic/poi_manager_logic.py
@@ -256,8 +256,7 @@ class PoiManagerLogic(GenericLogic):
         """ Deactivate the active POI if the confocal microscope scanner position is
         moved by anything other than the optimizer
         """
-        if tag != 'optimizer':
-            self._deactivate_poi()
+        pass
 
     def testing(self):
         """ Debug function for testing. """


### PR DESCRIPTION
The PoiManagerLogic was listening for a signal, that the confocal position was changed and then deleting the active poi (if it wasn't done by the optimizer.

This let to the effect, that you could simply loose your POI by changing the focus between windows.

As far as I know, there wasn't any usecase, where you needed to forget your active POI when changing the position, so this should not hurt anyone.

## Motivation and Context

When changing focus between POI-Manager and Confocal the active POI was lost. This led to some of the scripted measurements crashing.

## How Has This Been Tested?
Tested with dummy, since it is not dependent on hardware (just logic involved).

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
