### PR TITLE
Introduced a config option to set the default waveform format.

### DIFF
--- a/config/example/default.cfg
+++ b/config/example/default.cfg
@@ -112,6 +112,7 @@ logic:
 
     sequencegeneratorlogic:
         module.Class: 'sequence_generator_logic.SequenceGeneratorLogic'
+        default_waveform_format: 'wfm' # default value for sequence file format: optional
         #overhead_bytes: 4294967296  Not properly implemented yet
         #additional_methods_dir: 'C:\\Custom_dir\\Methods' optional
 

--- a/logic/sequence_generator_logic.py
+++ b/logic/sequence_generator_logic.py
@@ -30,7 +30,7 @@ import time
 
 from qtpy import QtCore
 from collections import OrderedDict
-from core.module import StatusVar
+from core.module import StatusVar, ConfigOption
 from core.util.modules import get_home_dir
 from core.util.modules import get_main_dir
 
@@ -73,7 +73,9 @@ class SequenceGeneratorLogic(GenericLogic, SamplingFunctions, SamplesWriteMethod
         'amplitude_dict',
         OrderedDict({'a_ch1': 0.5, 'a_ch2': 0.5, 'a_ch3': 0.5, 'a_ch4': 0.5}))
     sample_rate = StatusVar('sample_rate', 25e9)
-    waveform_format = StatusVar('waveform_format', 'wfmx')
+
+    _config_waveform_format = ConfigOption('default_waveform_format', default='wfmx')
+    waveform_format = StatusVar('waveform_format', None)
 
     # define signals
     sigBlockDictUpdated = QtCore.Signal(dict)
@@ -177,6 +179,9 @@ class SequenceGeneratorLogic(GenericLogic, SamplingFunctions, SamplesWriteMethod
         self._get_sequences_from_file()
 
         self._attach_predefined_methods()
+
+        if self.waveform_format is None:
+            self.waveform_format = self._config_waveform_format
 
         self.analog_channels = len([chnl for chnl in self.activation_config if 'a_ch' in chnl])
         self.digital_channels = len([chnl for chnl in self.activation_config if 'd_ch' in chnl])


### PR DESCRIPTION
An additional optional config option is introduced for sequence_generator_logic.

This ConfigOption is optional and sets the waveform format if no waveform format can be found in the corresponding StatusVar.

## Motivation and Context
When deleting the App Status, the waveform format can be set via config.

## How Has This Been Tested?
tested on dummy.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
