### PR TITLE
Pulsed: when sigStopMeasurement got None in parameter Python crashes

### DIFF
--- a/logic/pulsed_master_logic.py
+++ b/logic/pulsed_master_logic.py
@@ -609,6 +609,8 @@ class PulsedMasterLogic(GenericLogic):
 
         @return:
         """
+        if stash_raw_data_tag is None:
+            stash_raw_data_tag = ''
         self.sigStopMeasurement.emit(stash_raw_data_tag)
         return
 

--- a/logic/pulsed_master_logic.py
+++ b/logic/pulsed_master_logic.py
@@ -609,7 +609,9 @@ class PulsedMasterLogic(GenericLogic):
 
         @return:
         """
-        if stash_raw_data_tag is None:
+        if not isinstance(stash_raw_data_tag, str):
+            self.log.warn('PulsedMaster: stop_measurement was called with stash_raw_data_tag not being a string. '
+                          'Setting it to an empty string to avoid crashes.')
             stash_raw_data_tag = ''
         self.sigStopMeasurement.emit(stash_raw_data_tag)
         return


### PR DESCRIPTION
This was a grave error in the pulsed signal chain:

The signal sigStopMeasurement in PulseMasterLogic has one parameter. This parameter is determined by another function call, normally from the pulsed main GUI. The GUI performs the function call without any parameter and things run smoothly.
When you now however call PulseMasterLogic.stop_measurement(None) from a script, this None parameter gets handed to a signal causing Python to crash miserably. it seems you cannot hand over None as a parameter when emitting a signal.

Fixed it by checking for None in the parameter handed over and changing it to an empty string.

## Motivation and Context
Catch Python unconventional usage of pulsed when running measurements from script.

## How Has This Been Tested?
Just concerning logic and its connection to GUI.
Tested on Dummy.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
