### PR TITLE
Countdata ctype fix

### DIFF
--- a/hardware/fast_counter_dummy.py
+++ b/hardware/fast_counter_dummy.py
@@ -150,9 +150,12 @@ class FastCounterDummy(Base, FastCounterInterface):
         time.sleep(1)
         self.statusvar = 2
         try:
-            self._count_data = np.loadtxt(self.trace_path)
+            self._count_data = np.loadtxt(self.trace_path, dtype='int64')
         except:
             return -1
+
+        if self._gated:
+            self._count_data = self._count_data.transpose()
         return 0
 
     def pause_measure(self):

--- a/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
+++ b/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
@@ -378,7 +378,7 @@ class FastCounterFPGAQO(Base, FastCounterInterface):
         """ Start the fast counter. """
         self.saved_count_data = None
         # initialize the data array
-        self.count_data = np.zeros([self._number_of_gates, self._gate_length_bins])
+        self.count_data = np.zeros([self._number_of_gates, self._gate_length_bins], dtype='int64')
         # Start the counter.
         self._fpga.ActivateTriggerIn(0x40, 0)
         timeout = 5
@@ -445,8 +445,8 @@ class FastCounterFPGAQO(Base, FastCounterInterface):
             buffer_encode = buffer_encode.reshape(512, 65536)[0:self._number_of_gates,
                                                               0:self._gate_length_bins]
 
-            # convert into float values
-            self.count_data = buffer_encode.astype(float, casting='safe')
+            # convert into int64 values
+            self.count_data = buffer_encode.astype('int64', casting='safe')
 
             # Add saved count data (in case of continued measurement)
             if self.saved_count_data is not None:
@@ -511,7 +511,7 @@ class FastCounterFPGAQO(Base, FastCounterInterface):
 
         If fast counter is in pause state, then fast counter will be continued.
         """
-        self.count_data = np.zeros([self._number_of_gates, self._gate_length_bins])
+        self.count_data = np.zeros([self._number_of_gates, self._gate_length_bins], dtype='int64')
         # Check if fastcounter was in pause state
         if self.statusvar != 3:
             self.log.error('Can not continue fast counter since it was not in a paused state.')

--- a/logic/pulse_extraction_methods/basic_extraction_methods.py
+++ b/logic/pulse_extraction_methods/basic_extraction_methods.py
@@ -12,10 +12,15 @@ def gated_conv_deriv(self, count_data):
     @return dict:   The extracted laser pulses of the timetrace as well as the indices for rising
                     and falling flanks.
     """
+    # Create return dictionary
+    return_dict = {'laser_counts_arr': np.empty(0, dtype='int64'),
+                   'laser_indices_rising': -1,
+                   'laser_indices_falling': -1}
+
     if 'conv_std_dev' not in self.extraction_settings:
         self.log.error('Pulse extraction method "gated_conv_dev" will not work. No conv_std_dev '
                        'defined in class PulseExtractionLogic.')
-        return np.ndarray([], dtype=int)
+        return return_dict
     # sum up all gated timetraces to ease flank detection
     timetrace_sum = np.sum(count_data, 0)
 
@@ -30,15 +35,12 @@ def gated_conv_deriv(self, count_data):
     # contains zeros. Check for that and return also only zeros to indicate a
     # failed pulse extraction.
     if len(conv_deriv.nonzero()[0]) == 0:
-        laser_arr = np.zeros(count_data.shape, dtype=int)
+        laser_arr = np.zeros(count_data.shape, dtype='int64')
     else:
         # slice the data array to cut off anything but laser pulses
         laser_arr = count_data[:, rising_ind:falling_ind]
 
-    # Create return dictionary
-    return_dict = dict()
-
-    return_dict['laser_counts_arr'] = laser_arr.astype(int)
+    return_dict['laser_counts_arr'] = laser_arr.astype('int64')
     return_dict['laser_indices_rising'] = rising_ind
     return_dict['laser_indices_falling'] = falling_ind
 
@@ -84,22 +86,27 @@ def ungated_conv_deriv(self, count_data):
         careful in choosing a large conv_std_dev value and using a small
         laser pulse (rule of thumb: conv_std_dev < laser_length/10).
     """
+    # Create return dictionary
+    return_dict = {'laser_counts_arr': np.empty(0, dtype='int64'),
+                   'laser_indices_rising': np.empty(0, dtype='int64'),
+                   'laser_indices_falling': np.empty(0, dtype='int64')}
+
     if 'conv_std_dev' not in self.extraction_settings:
         self.log.error('Pulse extraction method "ungated_conv_dev" will not work. No conv_std_dev '
                        'defined in class PulseExtractionLogic.')
-        return np.ndarray([], dtype=int)
+        return return_dict
     if self.number_of_lasers is None:
         self.log.error('Pulse extraction method "ungated_conv_dev" will not work. No '
                        'number_of_lasers defined in class PulseExtractionLogic.')
-        return np.ndarray([], dtype=int)
+        return return_dict
     # apply gaussian filter to remove noise and compute the gradient of the timetrace
     conv_deriv = self._convolve_derive(count_data.astype(float), self.extraction_settings['conv_std_dev'])
 
     # if gaussian smoothing or derivative failed, the returned array only contains zeros.
     # Check for that and return also only zeros to indicate a failed pulse extraction.
     if len(conv_deriv.nonzero()[0]) == 0:
-        laser_arr = np.zeros([self.number_of_lasers, 10], dtype=int)
-        return laser_arr
+        return_dict['laser_counts_arr'] = np.zeros([self.number_of_lasers, 10], dtype='int64')
+        return return_dict
 
     # use a reference for array, because the exact position of the peaks or dips
     # (i.e. maxima or minima, which are the inflection points in the pulse) are distorted by
@@ -108,8 +115,8 @@ def ungated_conv_deriv(self, count_data):
 
     # initialize arrays to contain indices for all rising and falling
     # flanks, respectively
-    rising_ind = np.empty([self.number_of_lasers], int)
-    falling_ind = np.empty([self.number_of_lasers], int)
+    rising_ind = np.empty([self.number_of_lasers], 'int64')
+    falling_ind = np.empty([self.number_of_lasers], 'int64')
 
     # Find as many rising and falling flanks as there are laser pulses in
     # the trace:
@@ -190,7 +197,7 @@ def ungated_conv_deriv(self, count_data):
     #laser_length = int(self.histo[1][self.histo[0].argmax()])
 
     # initialize the empty output array
-    laser_arr = np.zeros([self.number_of_lasers, laser_length], dtype=int)
+    laser_arr = np.zeros([self.number_of_lasers, laser_length], dtype='int64')
     # slice the detected laser pulses of the timetrace and save them in the
     # output array according to the found rising edge
     for i in range(self.number_of_lasers):
@@ -200,9 +207,7 @@ def ungated_conv_deriv(self, count_data):
         else:
             laser_arr[i] = count_data[rising_ind[i]:rising_ind[i] + laser_length]
 
-    # Create return dictionary
-    return_dict = dict()
-    return_dict['laser_counts_arr'] = laser_arr.astype(int)
+    return_dict['laser_counts_arr'] = laser_arr.astype('int64')
     return_dict['laser_indices_rising'] = rising_ind
     return_dict['laser_indices_falling'] = falling_ind
     return return_dict
@@ -232,14 +237,14 @@ def ungated_threshold(self, count_data):
     if self.number_of_lasers is None:
         self.log.error('Pulse extraction method "ungated_threshold" will not work. No '
                        'number_of_lasers defined in class PulseExtractionLogic.')
-        return_dict['laser_indices_rising'] = np.zeros(1, dtype=int)
-        return_dict['laser_indices_falling'] = np.zeros(1, dtype=int)
-        return_dict['laser_counts_arr'] = np.zeros([1, 3000], dtype=int)
+        return_dict['laser_indices_rising'] = np.zeros(1, dtype='int64')
+        return_dict['laser_indices_falling'] = np.zeros(1, dtype='int64')
+        return_dict['laser_counts_arr'] = np.zeros([1, 3000], dtype='int64')
         return return_dict
     else:
-        return_dict['laser_indices_rising'] = np.zeros(self.number_of_lasers, dtype=int)
-        return_dict['laser_indices_falling'] = np.zeros(self.number_of_lasers, dtype=int)
-        return_dict['laser_counts_arr'] = np.zeros([self.number_of_lasers, 3000], dtype=int)
+        return_dict['laser_indices_rising'] = np.zeros(self.number_of_lasers, dtype='int64')
+        return_dict['laser_indices_falling'] = np.zeros(self.number_of_lasers, dtype='int64')
+        return_dict['laser_counts_arr'] = np.zeros([self.number_of_lasers, 3000], dtype='int64')
 
     if 'min_laser_length' not in self.extraction_settings:
         self.log.error('Pulse extraction method "ungated_threshold" will not work. No '
@@ -271,7 +276,8 @@ def ungated_threshold(self, count_data):
 
     # determine max length of laser pulse and initialize laser array
     max_laser_length = max([index_array.size for index_array in consecutive_indices])
-    return_dict['laser_counts_arr'] = np.zeros([self.number_of_lasers, max_laser_length], dtype=int)
+    return_dict['laser_counts_arr'] = np.zeros([self.number_of_lasers, max_laser_length],
+                                               dtype='int64')
     # fill laser array with slices of raw data array. Also populate the rising/falling index arrays
     for i, index_group in enumerate(consecutive_indices):
         return_dict['laser_indices_rising'][i] = index_group[0]

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -723,6 +723,9 @@ class PulsedMeasurementLogic(GenericLogic):
 
                 # get raw data from fast counter
                 fc_data = netobtain(self._fast_counter_device.get_data_trace())
+                # Convert returned numpy array to int64 dtype if necessary
+                if fc_data.dtype != np.int64:
+                    fc_data = fc_data.astype('int64')
 
                 # add old raw data from previous measurements if necessary
                 if self.recalled_raw_data is not None:


### PR DESCRIPTION
Fixes an issue with numpy array integer elements overflow

## Description
Fixes lasertrace analysis for large count rates.

## Motivation and Context
If you specify a numpy array like `numpy.zeros(1000, dtype=int)` it will result in a signed integer array of 32bit integers. Each operation like `numpy.sum()` on that array will be performed using the same data type. This can lead to overflows in numpy C variables.
This pull request consistently transforms all arrays containing timetrace data to `numpy.int64` data type.

## How Has This Been Tested?
Dummy configuration using a count trace that failed earlier in an experiment.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
