### PR TITLE
Zero value scientific SpinBox fix

### DIFF
--- a/qtwidgets/scientific_spinbox.py
+++ b/qtwidgets/scientific_spinbox.py
@@ -306,7 +306,7 @@ class ScienDSpinBox(QtWidgets.QAbstractSpinBox):
         """
         text = self.cleanText()
         value = self.valueFromText(text)
-        if not value:
+        if value is False:
             return
         value, in_range = self.check_range(value)
 

--- a/qtwidgets/scientific_spinbox.py
+++ b/qtwidgets/scientific_spinbox.py
@@ -1020,7 +1020,7 @@ class ScienSpinBox(QtWidgets.QAbstractSpinBox):
         """
         text = self.cleanText()
         value = self.valueFromText(text)
-        if not value:
+        if value is False:
             return
         value, in_range = self.check_range(value)
 


### PR DESCRIPTION
## Description
It was not possible to enter zero values in the LineEdit of the scientific spinboxes.

## Motivation and Context
This bug was caused by a faulty sanity check that triggered to return early when the value to set was zero.

## How Has This Been Tested?
Dummy config

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
