### PR TITLE
…

### DIFF
--- a/qtwidgets/scientific_spinbox.py
+++ b/qtwidgets/scientific_spinbox.py
@@ -34,7 +34,7 @@ class FloatValidator(QtGui.QValidator):
     Also supports SI unit prefix like 'M', 'n' etc.
     """
 
-    float_re = re.compile(r'((([+-]?\d+)\.?(\d*))?([eE][+-]?\d+)?\s?([YZEPTGMkmµunpfazy]?))')
+    float_re = re.compile(r'((([+-]?\d+)\.?(\d*))?([eE][+-]?\d+)?\s?([YZEPTGMkmµunpfazy]?)\s*)')
     group_map = {'match': 0,
                  'mantissa': 1,
                  'integer': 2,
@@ -116,7 +116,7 @@ class IntegerValidator(QtGui.QValidator):
     Also supports non-fractional SI unit prefix like 'M', 'k' etc.
     """
 
-    int_re = re.compile(r'(([+-]?\d*)?([eE]+?\d+)?\s?([YZEPTGMk]?))')
+    int_re = re.compile(r'(([+-]?\d*)?([eE]+?\d+)?\s?([YZEPTGMk]?)\s*)')
     group_map = {'match': 0,
                  'mantissa': 1,
                  'exponent': 2,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Allowed scientific spinbox validator to enter trailing whitespaces after the SI-prefix.

## Motivation and Context
When the LineEdit cursor in the SpinBox  was positioned before a trailing whitespace, one could not enter an SI-prefix. Fixed that.

## How Has This Been Tested?
Dummy

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
