### PR TITLE
Pulsed analysis show delta

### DIFF
--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -171,7 +171,7 @@ class PulsedMeasurementGui(GUIBase):
     _ana_param_second_plot_y_axis_unit_text = StatusVar('ana_param_second_plot_y_axis_unit_LineEdit', '')
 
     _ana_param_errorbars = StatusVar('ana_param_errorbars_CheckBox', False)
-    _second_plot_ComboBox_text = StatusVar('second_plot_ComboBox_text', '')
+    _second_plot_ComboBox_text = StatusVar('second_plot_ComboBox_text', 'None')
 
     _predefined_methods_to_show = StatusVar('predefined_methods_to_show', [])
     _functions_to_show = StatusVar('functions_to_show', [])
@@ -1225,10 +1225,17 @@ class PulsedMeasurementGui(GUIBase):
         self._ana_param_x_axis_unit_text = self._as.ana_param_x_axis_unit_LineEdit.text()
         self._ana_param_y_axis_name_text = self._as.ana_param_y_axis_name_LineEdit.text()
         self._ana_param_y_axis_unit_text = self._as.ana_param_y_axis_unit_LineEdit.text()
-        self._ana_param_second_plot_x_axis_name_text = self._as.ana_param_second_plot_x_axis_name_LineEdit.text()
-        self._ana_param_second_plot_x_axis_unit_text = self._as.ana_param_second_plot_x_axis_unit_LineEdit.text()
-        self._ana_param_second_plot_y_axis_name_text = self._as.ana_param_second_plot_y_axis_name_LineEdit.text()
-        self._ana_param_second_plot_y_axis_unit_text = self._as.ana_param_second_plot_y_axis_unit_LineEdit.text()
+
+        if self._pa.second_plot_ComboBox.currentText() == 'FFT':
+            self._ana_param_second_plot_x_axis_name_text = self._as.ana_param_second_plot_x_axis_name_LineEdit.text()
+            self._ana_param_second_plot_x_axis_unit_text = self._as.ana_param_second_plot_x_axis_unit_LineEdit.text()
+            self._ana_param_second_plot_y_axis_name_text = self._as.ana_param_second_plot_y_axis_name_LineEdit.text()
+            self._ana_param_second_plot_y_axis_unit_text = self._as.ana_param_second_plot_y_axis_unit_LineEdit.text()
+        else:
+            self._ana_param_second_plot_x_axis_name_text = self._ana_param_x_axis_name_text
+            self._ana_param_second_plot_x_axis_unit_text = self._ana_param_x_axis_unit_text
+            self._ana_param_second_plot_y_axis_name_text = self._ana_param_y_axis_name_text
+            self._ana_param_second_plot_y_axis_unit_text = self._ana_param_y_axis_unit_text
 
         self._pa.pulse_analysis_PlotWidget.setLabel(
             axis='bottom',
@@ -2145,7 +2152,7 @@ class PulsedMeasurementGui(GUIBase):
         else:
             self._pa.second_plot_GroupBox.setVisible(True)
 
-            if self._pa.second_plot_ComboBox.currentText() == 'FFT':
+            if self._pa.second_plot_ComboBox.currentText() in ('FFT', 'Delta'):
                 self._pa.pulse_analysis_second_PlotWidget.setLogMode(x=False, y=False)
             elif self._pa.second_plot_ComboBox.currentText() == 'Log(x)':
                 self._pa.pulse_analysis_second_PlotWidget.setLogMode(x=True, y=False)
@@ -2155,6 +2162,7 @@ class PulsedMeasurementGui(GUIBase):
                 self._pa.pulse_analysis_second_PlotWidget.setLogMode(x=True, y=True)
 
         self._pa.second_plot_GroupBox.setTitle(self._pa.second_plot_ComboBox.currentText())
+        self.update_analysis_settings()
         self.measurement_sequence_settings_changed()
         return
 

--- a/gui/pulsed/ui_pulse_analysis.ui
+++ b/gui/pulsed/ui_pulse_analysis.ui
@@ -215,6 +215,11 @@
             <string>Log(x)Log(y)</string>
            </property>
           </item>
+          <item>
+           <property name="text">
+            <string>Delta</string>
+           </property>
+          </item>
          </widget>
         </item>
         <item row="5" column="2">

--- a/logic/pulsed_master_logic.py
+++ b/logic/pulsed_master_logic.py
@@ -58,7 +58,7 @@ class PulsedMasterLogic(GenericLogic):
     sigStartPulser = QtCore.Signal()
     sigStopPulser = QtCore.Signal()
     sigFastCounterSettingsChanged = QtCore.Signal(float, float)
-    sigMeasurementSequenceSettingsChanged = QtCore.Signal(np.ndarray, int, float, list, bool)
+    sigMeasurementSequenceSettingsChanged = QtCore.Signal(np.ndarray, int, float, list, bool, str)
     sigPulseGeneratorSettingsChanged = QtCore.Signal(float, str, dict, bool)
     sigUploadAsset = QtCore.Signal(str)
     sigDirectWriteEnsemble = QtCore.Signal(str, np.ndarray, np.ndarray)
@@ -111,7 +111,7 @@ class PulsedMasterLogic(GenericLogic):
     sigMeasurementStatusUpdated = QtCore.Signal(bool, bool)
     sigPulserRunningUpdated = QtCore.Signal(bool)
     sigFastCounterSettingsUpdated = QtCore.Signal(float, float)
-    sigMeasurementSequenceSettingsUpdated = QtCore.Signal(np.ndarray, int, float, list, bool)
+    sigMeasurementSequenceSettingsUpdated = QtCore.Signal(np.ndarray, int, float, list, bool, str)
     sigPulserSettingsUpdated = QtCore.Signal(float, str, list, dict, bool)
     sigUploadedAssetsUpdated = QtCore.Signal(list)
     sigLoadedAssetUpdated = QtCore.Signal(str, str)
@@ -389,7 +389,7 @@ class PulsedMasterLogic(GenericLogic):
         return pulsegenerator_constraints, fastcounter_constraints
 
     def measurement_sequence_settings_changed(self, controlled_vals, number_of_lasers,
-                                              sequence_length_s, laser_ignore_list, alternating):
+                                              sequence_length_s, laser_ignore_list, alternating, second_plot_type):
         """
 
         @param controlled_vals:
@@ -397,15 +397,16 @@ class PulsedMasterLogic(GenericLogic):
         @param sequence_length_s:
         @param laser_ignore_list:
         @param alternating:
+        @param second_plot_type:
         @return:
         """
         self.sigMeasurementSequenceSettingsChanged.emit(controlled_vals, number_of_lasers,
                                                         sequence_length_s, laser_ignore_list,
-                                                        alternating)
+                                                        alternating, second_plot_type)
         return
 
     def measurement_sequence_settings_updated(self, controlled_vals, number_of_lasers,
-                                              sequence_length_s, laser_ignore_list, alternating):
+                                              sequence_length_s, laser_ignore_list, alternating, second_plot_type):
         """
 
         @param controlled_vals:
@@ -413,11 +414,12 @@ class PulsedMasterLogic(GenericLogic):
         @param sequence_length_s:
         @param laser_ignore_list:
         @param alternating:
+        @param second_plot_type:
         @return:
         """
         self.sigMeasurementSequenceSettingsUpdated.emit(controlled_vals, number_of_lasers,
                                                         sequence_length_s, laser_ignore_list,
-                                                        alternating)
+                                                        alternating, second_plot_type)
         return
 
     def fast_counter_settings_changed(self, bin_width_s, record_length_s):
@@ -812,7 +814,8 @@ class PulsedMasterLogic(GenericLogic):
                                                                asset_params['num_of_lasers'],
                                                                asset_params['sequence_length'],
                                                                asset_params['laser_ignore_list'],
-                                                               asset_params['is_alternating'])
+                                                               asset_params['is_alternating'],
+                                                               second_plot_type='FFT')
         # Load asset into channel
         self.status_dict['loading_busy'] = True
         self.sigLoadAsset.emit(asset_name, load_dict)

--- a/logic/pulsed_master_logic.py
+++ b/logic/pulsed_master_logic.py
@@ -58,7 +58,7 @@ class PulsedMasterLogic(GenericLogic):
     sigStartPulser = QtCore.Signal()
     sigStopPulser = QtCore.Signal()
     sigFastCounterSettingsChanged = QtCore.Signal(float, float)
-    sigMeasurementSequenceSettingsChanged = QtCore.Signal(np.ndarray, int, float, list, bool, str)
+    sigMeasurementSequenceSettingsChanged = QtCore.Signal(np.ndarray, int, float, list, bool)
     sigPulseGeneratorSettingsChanged = QtCore.Signal(float, str, dict, bool)
     sigUploadAsset = QtCore.Signal(str)
     sigDirectWriteEnsemble = QtCore.Signal(str, np.ndarray, np.ndarray)
@@ -111,7 +111,7 @@ class PulsedMasterLogic(GenericLogic):
     sigMeasurementStatusUpdated = QtCore.Signal(bool, bool)
     sigPulserRunningUpdated = QtCore.Signal(bool)
     sigFastCounterSettingsUpdated = QtCore.Signal(float, float)
-    sigMeasurementSequenceSettingsUpdated = QtCore.Signal(np.ndarray, int, float, list, bool, str)
+    sigMeasurementSequenceSettingsUpdated = QtCore.Signal(np.ndarray, int, float, list, bool)
     sigPulserSettingsUpdated = QtCore.Signal(float, str, list, dict, bool)
     sigUploadedAssetsUpdated = QtCore.Signal(list)
     sigLoadedAssetUpdated = QtCore.Signal(str, str)
@@ -389,7 +389,7 @@ class PulsedMasterLogic(GenericLogic):
         return pulsegenerator_constraints, fastcounter_constraints
 
     def measurement_sequence_settings_changed(self, controlled_vals, number_of_lasers,
-                                              sequence_length_s, laser_ignore_list, alternating, second_plot_type):
+                                              sequence_length_s, laser_ignore_list, alternating):
         """
 
         @param controlled_vals:
@@ -397,16 +397,15 @@ class PulsedMasterLogic(GenericLogic):
         @param sequence_length_s:
         @param laser_ignore_list:
         @param alternating:
-        @param second_plot_type:
         @return:
         """
         self.sigMeasurementSequenceSettingsChanged.emit(controlled_vals, number_of_lasers,
                                                         sequence_length_s, laser_ignore_list,
-                                                        alternating, second_plot_type)
+                                                        alternating)
         return
 
     def measurement_sequence_settings_updated(self, controlled_vals, number_of_lasers,
-                                              sequence_length_s, laser_ignore_list, alternating, second_plot_type):
+                                              sequence_length_s, laser_ignore_list, alternating):
         """
 
         @param controlled_vals:
@@ -414,12 +413,11 @@ class PulsedMasterLogic(GenericLogic):
         @param sequence_length_s:
         @param laser_ignore_list:
         @param alternating:
-        @param second_plot_type:
         @return:
         """
         self.sigMeasurementSequenceSettingsUpdated.emit(controlled_vals, number_of_lasers,
                                                         sequence_length_s, laser_ignore_list,
-                                                        alternating, second_plot_type)
+                                                        alternating)
         return
 
     def fast_counter_settings_changed(self, bin_width_s, record_length_s):
@@ -673,21 +671,21 @@ class PulsedMasterLogic(GenericLogic):
         self.sigPulserRunningUpdated.emit(is_running)
         return
 
-    def save_measurement_data(self, controlled_val_unit, tag, with_error, save_ft):
+    def save_measurement_data(self, controlled_val_unit, tag, with_error, save_second_plot):
         """ Prepare data to be saved and create a proper plot of the data.
         This is just handed over to the measurement logic.
 
         @param str controlled_val_unit: unit of the x axis of the plot
         @param str tag: a filetag which will be included in the filename
         @param bool with_error: select whether errors should be saved/plotted
-        @param bool save_ft: select wether the Fourier Transform is plotted
+        @param bool save_second_plot: select wether the second plot (FFT, diff etc.) is saved
 
         @return str: filepath where data were saved
         """
         return self._measurement_logic.save_measurement_data(controlled_val_unit=controlled_val_unit,
                                                       tag=tag,
                                                       with_error=with_error,
-                                                      save_ft=save_ft)
+                                                      save_second_plot=save_second_plot)
 
     def clear_pulse_generator(self):
         """

--- a/logic/pulsed_master_logic.py
+++ b/logic/pulsed_master_logic.py
@@ -812,8 +812,7 @@ class PulsedMasterLogic(GenericLogic):
                                                                asset_params['num_of_lasers'],
                                                                asset_params['sequence_length'],
                                                                asset_params['laser_ignore_list'],
-                                                               asset_params['is_alternating'],
-                                                               second_plot_type='FFT')
+                                                               asset_params['is_alternating'])
         # Load asset into channel
         self.status_dict['loading_busy'] = True
         self.sigLoadAsset.emit(asset_name, load_dict)


### PR DESCRIPTION
The GUI for pulsed analysis can show a second plot. Introduced a feature that shows the delta between two measurements in this plot.

Before, the FFT was hardcoded in GUI, logic and measurement. Changed it to have a selection, so it is easier to add more plot types in the future. Also updated the saved pictures to change axes between delta in fft plots.

This feature is only available if an alternating sequence is running.

## How Has This Been Tested?
Tested on dummy: Win7 64x.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
