### PR TITLE
Correcting calculation of length of sequence

### DIFF
--- a/logic/pulse_objects.py
+++ b/logic/pulse_objects.py
@@ -316,7 +316,7 @@ class PulseSequence:
                     break
                 else:
                     reps = 0
-            self.length_s += (ensemble.length_s * (reps+1))
+            self.length_s += (ensemble.length_s * reps)
 
             if ensemble.analog_channels > self.analog_channels:
                 self.analog_channels = ensemble.analog_channels


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

When the length of the sequence is calculated the repetitions were taken as reps+1, but in sequences the repetition of 1 means 1 not as in a Pulse ensemble where 0 means 1

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The total length of sequences was calculated incorrectly

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

On setup 2 

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
