### PR TITLE
POI manager fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 /config/qo-config
 /documentation/generated
 /documentation/images
+/Data
 
 # log files
 *.log

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -15,6 +15,7 @@ Changes/New features:
 * Tab order in pulsed measurement GUI is now more useful
 * Added delta plot of alternating sequence in the pulsed analysis window
 * Bug fix for pulsed extraction window where zooming caused InfiteLines to disappear and a switch in lines caused negative width 
+* POI manager keeps POIs as StatusVar across restarts and fixes to distance measurement
 * Various stability improvements and minor bug fixes
 
 Config changes:

--- a/gui/poimanager/poimangui.py
+++ b/gui/poimanager/poimangui.py
@@ -26,6 +26,7 @@ import pyqtgraph as pg
 import time
 
 from core.module import Connector
+from core.util.units import ScaledFloat
 from gui.guibase import GUIBase
 from gui.guiutils import ColorBar
 from gui.colordefs import ColorScaleInferno
@@ -261,16 +262,22 @@ class PoiManagerGui(GUIBase):
         """
 
         # converts the absolute mouse position to a position relative to the axis
-        mouse_point=self.roi_map_image.mapFromScene(event.toPoint())
+        mouse_point = self._mw.roi_map_ViewWidget.getPlotItem().getViewBox().mapSceneToView(
+            event.toPoint())
         #self.log.debug("Mouse at x = {0:0.2e}, y = {1:0.2e}".format(mouse_point.x(), mouse_point.y()))
 
         # only calculate distance, if a POI is selected
         if self._poi_manager_logic.active_poi is not None:
-            cur_poi_pos = self._poi_manager_logic.get_poi_position(poikey=self._poi_manager_logic.active_poi.get_key())
-            self._mw.poi_distance_label.setText('{0:.2e} ({1:.2e}, {2:.2e})'.format(
-                np.sqrt((mouse_point.x() - cur_poi_pos[0])**2+(mouse_point.y() - cur_poi_pos[1])**2),
-                mouse_point.x() - cur_poi_pos[0],
-                mouse_point.y() - cur_poi_pos[1]))
+            cur_poi_pos = self._poi_manager_logic.get_poi_position(
+                poikey=self._poi_manager_logic.active_poi.get_key())
+            dx = ScaledFloat(mouse_point.x() - cur_poi_pos[0])
+            dy = ScaledFloat(mouse_point.y() - cur_poi_pos[1])
+            d_total = ScaledFloat(np.sqrt(
+                    (mouse_point.x() - cur_poi_pos[0])**2
+                    + (mouse_point.y() - cur_poi_pos[1])**2))
+
+            self._mw.poi_distance_label.setText(
+                '{0:.2r}m ({1:.2r}m, {2:.2r}m)'.format(d_total, dx, dy))
 
     def initMainUI(self):
         """ Definition, configuration and initialisation of the POI Manager GUI.
@@ -380,7 +387,10 @@ class PoiManagerGui(GUIBase):
         # Distance Measurement:
         # Introducing a SignalProxy will limit the rate of signals that get fired.
         # Otherwise we will run into a heap of unhandled function calls.
-        proxy = pg.SignalProxy(self.roi_map_image.scene().sigMouseMoved, rateLimit=60, slot=self.mouseMoved)
+        proxy = pg.SignalProxy(
+            self.roi_map_image.scene().sigMouseMoved,
+            rateLimit=60,
+            slot=self.mouseMoved)
         # Connecting a Mouse Signal to trace to mouse movement function.
         self.roi_map_image.scene().sigMouseMoved.connect(self.mouseMoved)
 
@@ -891,12 +901,13 @@ class PoiManagerGui(GUIBase):
             active_poi_key = self._poi_manager_logic.active_poi.get_key()
 
             self._markers[active_poi_key].select()
-            cur_poi_pos = self._poi_manager_logic.get_poi_position(poikey=key)
+            cur_poi_pos = self._poi_manager_logic.get_poi_position(poikey=active_poi_key)
             self._mw.poi_coords_label.setText(
-                '({0:.2e}, {1:.2e}, {2:.2e})'.format(cur_poi_pos[0],
-                                                     cur_poi_pos[1],
-                                                     cur_poi_pos[2]
-                                                     )
+                '({0:.2r}m, {1:.2r}m, {2:.2r}m)'.format(
+                    ScaledFloat(cur_poi_pos[0]),
+                    ScaledFloat(cur_poi_pos[1]),
+                    ScaledFloat(cur_poi_pos[2])
+                    )
                 )
         self.log.debug('finished redraw at {0}'.format(time.time()))
 

--- a/gui/poimanager/poimangui.py
+++ b/gui/poimanager/poimangui.py
@@ -392,7 +392,6 @@ class PoiManagerGui(GUIBase):
         self._mw.autofind_pois_Action.triggered.connect(self.do_autofind_poi_procedure)
         self._mw.optimize_roi_Action.triggered.connect(self.optimize_roi)
 
-
         self._mw.new_poi_Action.triggered.connect(self.set_new_poi)
         self._mw.goto_poi_Action.triggered.connect(self.goto_poi)
         self._mw.refind_poi_Action.triggered.connect(self.update_poi_pos)
@@ -409,7 +408,6 @@ class PoiManagerGui(GUIBase):
         self._mw.delete_poi_PushButton.clicked.connect(self.delete_poi)
 
         self._mw.goto_poi_after_update_checkBox.toggled.connect(self.toggle_follow)
-
 
         # This needs to be activated so that it only listens to user input, and ignores
         # algorithmic index changes

--- a/tools/fit_logic_standalone.py
+++ b/tools/fit_logic_standalone.py
@@ -21,8 +21,7 @@ the Free Software Foundation, either version 3 of the License, or
 
 QuDi is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.  See the
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
@@ -36,23 +35,17 @@ top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi
 import logging
 logger = logging.getLogger(__name__)
 
-import importlib
-import sys
-import os
-
 import numpy as np
-
+import sys
 from scipy.interpolate import InterpolatedUnivariateSpline
+from lmfit import Parameters, models
+import matplotlib.pylab as plt
 from scipy.signal import wiener, filtfilt, butter, gaussian, freqz
 from scipy.ndimage import filters
-
-from lmfit import Parameters, models
-
-import matplotlib.pylab as plt
-
+import importlib
 from os import listdir,getcwd
 from os.path import isfile, join
-
+import os
 
 #from scipy import special
 #from scipy.special import gammaln as gamln

--- a/tools/fit_logic_standalone.py
+++ b/tools/fit_logic_standalone.py
@@ -21,7 +21,8 @@ the Free Software Foundation, either version 3 of the License, or
 
 QuDi is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
@@ -35,17 +36,23 @@ top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi
 import logging
 logger = logging.getLogger(__name__)
 
-import numpy as np
+import importlib
 import sys
+import os
+
+import numpy as np
+
 from scipy.interpolate import InterpolatedUnivariateSpline
-from lmfit import Parameters, models
-import matplotlib.pylab as plt
 from scipy.signal import wiener, filtfilt, butter, gaussian, freqz
 from scipy.ndimage import filters
-import importlib
+
+from lmfit import Parameters, models
+
+import matplotlib.pylab as plt
+
 from os import listdir,getcwd
 from os.path import isfile, join
-import os
+
 
 #from scipy import special
 #from scipy.special import gammaln as gamln


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Persistent POIs are an (unofficially) requested feature.
GUI fixes were done as I was working on POI manager anyway.

## Description
<!--- Describe your changes in detail -->
POIs and active POI are stored in StatusVar, saving them when closing Qudi and restoring them when loading.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solves the annoyance that you have to manually store POIs to load them back later on or after software restarts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested only with dummy modules, please do further testing with hardware/scripts.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
