### PR TITLE
fixed a bug where the errors of the delta plot were saved incorrectly

### DIFF
--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -1522,10 +1522,6 @@ class PulsedMeasurementGui(GUIBase):
         # apply hardware constraints
         self._analysis_apply_hardware_constraints()
 
-        self.toggle_settings_editor()
-        self.toggle_error_bars()
-        self.change_second_plot()
-
         # initialize values
         self._pulsed_master_logic.request_measurement_init_values()
         return
@@ -2091,6 +2087,8 @@ class PulsedMeasurementGui(GUIBase):
                 self._pa.pulse_analysis_PlotWidget.removeItem(self.signal_image2)
             if self.signal_image_error_bars2 in self._pa.pulse_analysis_PlotWidget.items():
                 self._pa.pulse_analysis_PlotWidget.removeItem(self.signal_image_error_bars2)
+            if self.second_image_error_bars in self._pa.pulse_analysis_second_PlotWidget.items():
+                self._pa.pulse_analysis_second_PlotWidget.removeItem(self.second_image_error_bars)
             if self.measuring_error_image2 in self._pe.measuring_error_PlotWidget.items():
                 self._pe.measuring_error_PlotWidget.removeItem(self.measuring_error_image2)
             if self.second_plot_image2 in self._pa.pulse_analysis_second_PlotWidget.items():
@@ -2103,6 +2101,11 @@ class PulsedMeasurementGui(GUIBase):
         self._pa.ana_param_x_axis_start_ScienDSpinBox.blockSignals(False)
         self._pa.ana_param_x_axis_inc_ScienDSpinBox.blockSignals(False)
         self._pe.laserpulses_ComboBox.blockSignals(False)
+
+        # update dependent GUI elements
+        self.toggle_settings_editor()
+        self.toggle_error_bars()
+        self.change_second_plot()
         return
 
     def toggle_settings_editor(self):
@@ -2161,7 +2164,7 @@ class PulsedMeasurementGui(GUIBase):
             if second_plot == 'Delta':
                 if self.second_plot_image2 in self._pa.pulse_analysis_second_PlotWidget.items():
                     self._pa.pulse_analysis_second_PlotWidget.removeItem(self.second_plot_image2)
-                if self.second_image_error_bars not in self._pa.pulse_analysis_second_PlotWidget.items():
+                if self.second_image_error_bars not in self._pa.pulse_analysis_second_PlotWidget.items() and self._pa.ana_param_errorbars_CheckBox.isChecked():
                     self._pa.pulse_analysis_second_PlotWidget.addItem(self.second_image_error_bars)
             else:
                 # everything but Delta has two plots but no errorbars

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -1037,12 +1037,9 @@ class PulsedMeasurementLogic(GenericLogic):
         if self.alternating:
             data['Signal2 (norm.)'] = self.signal_plot_y2
         if with_error:
-            if self.second_plot_type == 'Delta':
-                data['Error (norm.)'] = np.sqrt(self.measuring_error_plot_y**2 + self.measuring_error_plot_y2**2)
-            else:
-                data['Error (norm.)'] = self.measuring_error_plot_y
-                if self.alternating:
-                    data['Error2 (norm.)'] = self.measuring_error_plot_y2
+            data['Error (norm.)'] = self.measuring_error_plot_y
+            if self.alternating:
+                data['Error2 (norm.)'] = self.measuring_error_plot_y2
 
         # write the parameters:
         parameters = OrderedDict()
@@ -1189,7 +1186,15 @@ class PulsedMeasurementLogic(GenericLogic):
             if self.second_plot_type == 'Delta':
                 x_axis_ft_label = 'controlled variable (' + controlled_val_unit + ')'
                 y_axis_ft_label = 'norm. sig (arb. u.)'
-                ft_label = ''
+                ft_label = 'Delta of data traces'
+
+                if with_error:
+                    delta_plot_y_error = np.sqrt(self.measuring_error_plot_y**2 + self.measuring_error_plot_y2**2)
+                    ax2.errorbar(x=x_axis_ft_scaled, y=self.signal_second_plot_y,
+                                 yerr=delta_plot_y_error, fmt='-o',
+                                 linestyle=':', linewidth=0.5, color=colors[0],
+                                 ecolor=colors[1], capsize=3, capthick=0.9,
+                                 elinewidth=1.2, label=ft_label)
             else:
                 x_axis_ft_label = 'Fourier Transformed controlled variable (' + x_axis_prefix + inverse_cont_var + ')'
                 y_axis_ft_label = 'Fourier amplitude (arb. u.)'
@@ -1198,6 +1203,7 @@ class PulsedMeasurementLogic(GenericLogic):
             ax2.plot(x_axis_ft_scaled, self.signal_second_plot_y, '-o',
                      linestyle=':', linewidth=0.5, color=colors[0],
                      label=ft_label)
+
 
             ax2.set_xlabel(x_axis_ft_label)
             ax2.set_ylabel(y_axis_ft_label)


### PR DESCRIPTION
fixed a bug where the errors of the delta plot were not save correctly (or rather the original errors were not saved anymore).

Also included the errorbars into the saved data of the delta plot.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`) -> minor bugfixes
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
