### PR TITLE
Pulsed raw data save type

### DIFF
--- a/config/example/default.cfg
+++ b/config/example/default.cfg
@@ -124,6 +124,7 @@ logic:
 
     pulsedmeasurementlogic:
         module.Class: 'pulsed_measurement_logic.PulsedMeasurementLogic'
+        raw_data_save_type: 'text'
         connect:
             fastcounter: 'mydummyfastcounter'
             pulseanalysislogic: 'pulseanalysislogic'
@@ -132,6 +133,8 @@ logic:
             fitlogic: 'fitlogic'
             savelogic: 'savelogic'
             microwave: 'microwave_dummy'
+
+
 
     counterlogic:
         module.Class: 'counter_logic.CounterLogic'

--- a/config/example/default.cfg
+++ b/config/example/default.cfg
@@ -134,8 +134,6 @@ logic:
             savelogic: 'savelogic'
             microwave: 'microwave_dummy'
 
-
-
     counterlogic:
         module.Class: 'counter_logic.CounterLogic'
         connect:

--- a/logic/pulsed_measurement_logic.py
+++ b/logic/pulsed_measurement_logic.py
@@ -49,6 +49,8 @@ class PulsedMeasurementLogic(GenericLogic):
     microwave = Connector(interface='MWInterface')
     pulsegenerator = Connector(interface='PulserInterface')
 
+    raw_data_save_type = ConfigOption('raw_data_save_type', 'text')
+
     # status vars
     fast_counter_record_length = StatusVar(default=3.e-6)
     sequence_length_s = StatusVar(default=100e-6)
@@ -1252,7 +1254,7 @@ class PulsedMeasurementLogic(GenericLogic):
         self._save_logic.save_data(data, timestamp=timestamp,
                                    parameters=parameters, fmt='%d',
                                    filepath=filepath, filelabel=filelabel,
-                                   delimiter='\t')
+                                   delimiter='\t',filetype=self.raw_data_save_type)
         return filepath
 
     def _compute_second_plot(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The raw time trace can be a large array (especially for ungated counting) and thus a text-file can be several tens of MB. Then it also takes quite some time to write the file. 
Now it is possible to specify the file type of the file, where this array is saved in, in the config which allows to use compressed formats as for example .npz
If nothing is specified, the file type is still 'text'...

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Saves time and memory

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested on dummy

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [ ] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
