### PR TITLE
Save global parameters for predefined methods

### DIFF
--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -50,6 +50,18 @@ from qtwidgets.scientific_spinbox import ScienDSpinBox
 #FIXME: save the length in sample points (bins)
 #FIXME: adjust the length to the bins
 
+predefined_global_parameter_list = [
+    'mw_channel',
+    'gate_count_channel',
+    'sync_trig_channel',
+    'mw_amp',
+    'mw_freq',
+    'channel_amp',
+    'delay_length',
+    'wait_time',
+    'laser_length',
+    'rabi_period',
+    ]
 
 class PulsedMeasurementMainWindow(QtWidgets.QMainWindow):
     def __init__(self):
@@ -175,6 +187,7 @@ class PulsedMeasurementGui(GUIBase):
 
     _predefined_methods_to_show = StatusVar('predefined_methods_to_show', [])
     _functions_to_show = StatusVar('functions_to_show', [])
+    _predefined_global_param_values = StatusVar('predefined_global_parameters', {})
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -278,6 +291,21 @@ class PulsedMeasurementGui(GUIBase):
         self._pm.pm_laser_length_Widget.setValue(3.0e-6)
         self._pm.pm_rabi_period_Widget.setValue(200.0e-9)
 
+        for param_name in predefined_global_parameter_list:
+            if param_name in self._predefined_global_param_values:
+                widget = getattr(self._pm, 'pm_' + param_name + '_Widget')
+
+                if hasattr(widget, 'setChecked'):
+                    widget.setChecked(self._predefined_global_param_values[param_name])
+                elif hasattr(widget, 'setValue'):
+                    widget.setValue(self._predefined_global_param_values[param_name])
+                elif hasattr(widget, 'setText'):
+                    widget.setText(self._predefined_global_param_values[param_name])
+                else:
+                    self.log.error('Not possible to get the value from the widget {0},'
+                                   'since it does not have one of the possible access methods!'
+                                   ''.format(param_name))
+
         # connect the menu to the actions:
         self._mw.action_Settings_Block_Generation.triggered.connect(self.show_generator_settings)
         self._mw.action_Predefined_Methods_Config.triggered.connect(self.show_predefined_methods_config)
@@ -314,6 +342,24 @@ class PulsedMeasurementGui(GUIBase):
         """
         self._gs.exec_()
         return
+
+    @_predefined_global_param_values.representer
+    def repr_global_params(self, val):
+        pdict = {}
+        for param_name in predefined_global_parameter_list:
+            widget = getattr(self._pm, 'pm_' + param_name + '_Widget')
+
+            if hasattr(widget, 'isChecked'):
+                pdict[param_name] = widget.isChecked()
+            elif hasattr(widget, 'value'):
+                pdict[param_name] = widget.value()
+            elif hasattr(widget, 'text'):
+                pdict[param_name] = widget.text()
+            else:
+                self.log.error('Not possible to get the value from the widget {0},'
+                               'since it does not have one of the possible access methods!'
+                               ''.format(param_name))
+        return pdict
 
     def _create_function_config(self):
         # Add in the settings menu within the groupbox widget all the available math_functions,
@@ -447,9 +493,7 @@ class PulsedMeasurementGui(GUIBase):
             inspected = inspect.signature(methods_dict[method_name])
             # run through all parameters of the current method and create the widgets
             for param_index, param_name in enumerate(inspected.parameters):
-                if param_name not in ['mw_channel', 'gate_count_channel', 'sync_trig_channel',
-                                      'mw_amp', 'mw_freq', 'channel_amp', 'delay_length',
-                                      'wait_time', 'laser_length', 'rabi_period']:
+                if param_name not in predefined_global_parameter_list:
                     # get default value of the parameter
                     default_val = inspected.parameters[param_name].default
                     if default_val is inspect._empty:
@@ -1144,9 +1188,7 @@ class PulsedMeasurementGui(GUIBase):
                 return
 
         # get global parameters and add them to the dictionary
-        for param_name in ['mw_channel', 'gate_count_channel', 'sync_trig_channel', 'mw_amp',
-                           'mw_freq', 'channel_amp', 'delay_length', 'wait_time', 'laser_length',
-                           'rabi_period']:
+        for param_name in predefined_global_parameter_list:
             input_obj = getattr(self._pm, 'pm_' + param_name + '_Widget')
 
             if hasattr(input_obj, 'isChecked'):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Save values of the global parameter section of the predefined methods window in the status variables for pulsed GUI.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is annoying to enter these parameters again after restarting Qudi or pulsed GUI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Dummy only.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
