### PR TITLE
Quickfix confocal logic gui bridge

### DIFF
--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -1089,8 +1089,6 @@ class ConfocalGui(GUIBase):
         if self._optimizer_logic.module_state() == 'locked':
             self._optimizer_logic.stop_refocus()
 
-        self.enable_scan_actions()
-
     def xy_scan_clicked(self):
         """ Manages what happens if the xy scan is started. """
         self.disable_scan_actions()

--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -520,7 +520,7 @@ class ConfocalGui(GUIBase):
         #################################################################
         # Connect the scan actions to the events if they are clicked. Connect
         # also the adjustment of the displayed windows.
-        self._mw.action_stop_scanning.triggered.connect(self.ready_clicked)
+        self._mw.action_stop_scanning.triggered.connect(self.stop_scanning_clicked)
 
         self._scan_xy_start_proxy = pg.SignalProxy(
             self._mw.action_scan_xy_start.triggered,

--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -630,6 +630,9 @@ class ConfocalGui(GUIBase):
         self._optimizer_logic.sigRefocusStarted.connect(self.logic_started_refocus)
         self._scanning_logic.signal_stop_requested.connect(self.scanning_stop_requested)
 
+        self._scanning_logic.signal_image_ranges_changed.connect(self.update_displayed_scan_range)
+        self._scanning_logic.signal_image_resolution_changed.connect(self.update_displayed_resolution)
+
         # Connect the tracker
         self.sigStartOptimizer.connect(self._optimizer_logic.start_refocus)
         self._optimizer_logic.sigRefocusFinished.connect(self._refocus_finished_wrapper)
@@ -894,7 +897,7 @@ class ConfocalGui(GUIBase):
     def disable_scan_actions(self):
         """ Disables the buttons for scanning.
         """
-        # Ensable the stop scanning button
+        # Enable the stop scanning button
         self._mw.action_stop_scanning.setEnabled(True)
 
         # Disable the start scan buttons
@@ -1152,7 +1155,7 @@ class ConfocalGui(GUIBase):
             self.update_input_z(z_pos)
 
     def roi_xy_bounds_check(self, roi):
-        """ Check if the focus cursor is oputside the allowed range after drag
+        """ Check if the focus cursor is outside the allowed range after drag
             and set its position to the limit
         """
         h_pos = roi.pos()[0] + 0.5 * roi.size()[0]
@@ -1165,7 +1168,7 @@ class ConfocalGui(GUIBase):
             self.update_roi_xy(new_h_pos, new_v_pos)
 
     def roi_depth_bounds_check(self, roi):
-        """ Check if the focus cursor is oputside the allowed range after drag
+        """ Check if the focus cursor is outside the allowed range after drag
             and set its position to the limit """
         h_pos = roi.pos()[0] + 0.5 * roi.size()[0]
         v_pos = roi.pos()[1] + 0.5 * roi.size()[1]
@@ -2233,6 +2236,41 @@ class ConfocalGui(GUIBase):
         """
         if tag == 'logic':
             self.disable_scan_actions()
+
+    def update_displayed_scan_range(self):
+        """ Update displayed scan range if the logic had it changed somewhere else.
+        """
+        self._mw.x_min_InputWidget.setValue(
+            self._scanning_logic.image_x_range[0]
+        )
+        self._mw.x_max_InputWidget.setValue(
+            self._scanning_logic.image_x_range[1]
+        )
+ 
+        self._mw.y_min_InputWidget.setValue(
+            self._scanning_logic.image_y_range[0]
+        )
+        self._mw.y_max_InputWidget.setValue(
+            self._scanning_logic.image_y_range[1]
+        )
+ 
+        self._mw.z_min_InputWidget.setValue(
+            self._scanning_logic.image_z_range[0]
+        )
+        self._mw.z_max_InputWidget.setValue(
+            self._scanning_logic.image_z_range[1]
+        )
+ 
+    def update_displayed_resolution(self):
+        """ Update displayed resolution if the logic had it changed somewhere else.
+        """
+        self._mw.xy_res_InputWidget.setValue(
+            self._scanning_logic.xy_resolution
+        )
+ 
+        self._mw.z_res_InputWidget.setValue(
+            self._scanning_logic.z_resolution
+        )
 
     def scanning_stop_requested(self):
         """ Disable the stop scanning button if a scanning stop has been requested elsewhere.

--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -628,7 +628,7 @@ class ConfocalGui(GUIBase):
         self._scanning_logic.signal_start_scanning.connect(self.logic_started_scanning)
         self._scanning_logic.signal_continue_scanning.connect(self.logic_continued_scanning)
         self._optimizer_logic.sigRefocusStarted.connect(self.logic_started_refocus)
-        # self._scanning_logic.signal_stop_scanning.connect()
+        self._scanning_logic.signal_stop_requested.connect(self.scanning_stop_requested)
 
         # Connect the tracker
         self.sigStartOptimizer.connect(self._optimizer_logic.start_refocus)
@@ -1081,8 +1081,8 @@ class ConfocalGui(GUIBase):
         self.update_roi_xy_size()
         self.update_roi_depth_size()
 
-    def ready_clicked(self):
-        """ Stopp the scan if the state has switched to ready. """
+    def stop_scanning_clicked(self):
+        """ Stop the scan if the state has switched to ready. """
         if self._scanning_logic.module_state() == 'locked':
             self._scanning_logic.permanent_scan = False
             self._scanning_logic.stop_scanning()
@@ -2236,3 +2236,7 @@ class ConfocalGui(GUIBase):
         if tag == 'logic':
             self.disable_scan_actions()
 
+    def scanning_stop_requested(self):
+        """ Disable the stop scanning button if a scanning stop has been requested elsewhere.
+        """
+        self._mw.action_stop_scanning.setEnabled(False)

--- a/logic/confocal_logic.py
+++ b/logic/confocal_logic.py
@@ -267,7 +267,7 @@ class ConfocalLogic(GenericLogic):
     # signals
     signal_start_scanning = QtCore.Signal(str)
     signal_continue_scanning = QtCore.Signal(str)
-    signal_stop_scanning = QtCore.Signal()
+    signal_stop_requested = QtCore.Signal()
     signal_scan_lines_next = QtCore.Signal()
     signal_xy_image_updated = QtCore.Signal()
     signal_depth_image_updated = QtCore.Signal()
@@ -425,7 +425,7 @@ class ConfocalLogic(GenericLogic):
         with self.threadlock:
             if self.module_state() == 'locked':
                 self.stopRequested = True
-        self.signal_stop_scanning.emit()
+        self.signal_stop_requested.emit()
         return 0
 
     def initialize_image(self):

--- a/logic/confocal_logic.py
+++ b/logic/confocal_logic.py
@@ -278,6 +278,7 @@ class ConfocalLogic(GenericLogic):
     signal_tilt_correction_update = QtCore.Signal()
     signal_draw_figure_completed = QtCore.Signal()
     signal_image_ranges_changed = QtCore.Signal()
+    signal_image_resolution_changed = QtCore.Signal()
 
     sigImageXYInitialized = QtCore.Signal()
     sigImageDepthInitialized = QtCore.Signal()
@@ -436,6 +437,64 @@ class ConfocalLogic(GenericLogic):
             return False
         
         return True
+
+    @property
+    def xy_resolution(self):
+        """ Get image xy resolution."""
+        return self._xy_resolution
+
+    @xy_resolution.setter
+    def xy_resolution(self, new_res):
+        """ Set the xy scan resolution.
+ 
+        @param int new_res: new resolution
+        """
+        if not self.image_resolution_ok(new_res, axis='xy'):
+            return -1
+
+        self._xy_resolution = new_res
+
+        # Tell the GUI or anything else that might need to update display.
+        self.signal_image_resolution_changed.emit()
+
+
+    @property
+    def z_resolution(self):
+        """ Get image z resolution."""
+        return self._z_resolution
+
+    @z_resolution.setter
+    def z_resolution(self, new_res):
+        """ Set the z scan resolution.
+ 
+        @param int new_res: new resolution
+        """
+        if not self.image_resolution_ok(new_res, axis='z'):
+            return -1
+
+        self._z_resolution = new_res
+
+        # Tell the GUI or anything else that might need to update display.
+        self.signal_image_resolution_changed.emit()
+
+    def image_resolution_ok(self, resolution, axis=''):
+        """ Check input resolution satisfies requirements.
+
+        @param int resolution: requested resolution.
+
+        @param string axis: name of axis to make error messages more readable.
+
+        @return Boolean True means the resolution is ok.
+        """
+        if isinstance(resolution, int):
+            return True
+        else:
+            self.log.error(
+                    'Resolution is number of pixels, and must be integer'
+                    'instead of type {0} (requested for {1} image).'
+                    .format(type(resolution), axis)
+                    )
+            return False
 
     def switch_hardware(self, to_on=False):
         """ Switches the Hardware off or on.

--- a/logic/confocal_logic.py
+++ b/logic/confocal_logic.py
@@ -277,7 +277,7 @@ class ConfocalLogic(GenericLogic):
     signal_tilt_correction_active = QtCore.Signal(bool)
     signal_tilt_correction_update = QtCore.Signal()
     signal_draw_figure_completed = QtCore.Signal()
-    signal_position_changed = QtCore.Signal()
+    signal_image_ranges_changed = QtCore.Signal()
 
     sigImageXYInitialized = QtCore.Signal()
     sigImageDepthInitialized = QtCore.Signal()
@@ -357,6 +357,85 @@ class ConfocalLogic(GenericLogic):
             self._statusVariables['history_{0}'.format(histindex)] = state.serialize()
             histindex += 1
         return 0
+
+    @property
+    def image_x_range(self):
+        """ Get image_x_range """
+        return self._image_x_range
+    
+    @image_x_range.setter
+    def image_x_range(self, range):
+        """ Set the new x-range of the region to be scanned.
+
+        @param list range: 2-element list of floats giving new range
+        """
+        if not self._image_range_ok(range, axis='x'):
+            return -1
+        
+        self._image_x_range = range
+
+        # Tell the GUI or anything else that might need to update display.
+        self.image_ranges_changed_Signal.emit()
+
+    @property
+    def image_y_range(self):
+        """ Get image_y_range """
+        return self._image_y_range
+    
+    @image_y_range.setter
+    def image_y_range(self, range):
+        """ Set the new y-range of the region to be scanned.
+
+        @param list range: 2-element list of floats giving new range
+        """
+        if not self._image_range_ok(range, axis='y'):
+            return -1
+        
+        self._image_y_range = range
+
+        # Tell the GUI or anything else that might need to update display.
+        self.image_ranges_changed_Signal.emit()
+
+    @property
+    def image_z_range(self):
+        """ Get image_z_range """
+        return self._image_z_range
+    
+    @image_z_range.setter
+    def image_z_range(self, range):
+        """ Set the new z-range of the region to be scanned.
+
+        @param list range: 2-element list of floats giving new range
+        """
+        if not self._image_range_ok(range, axis='z'):
+            return -1
+        
+        self._image_z_range = range
+
+        # Tell the GUI or anything else that might need to update display.
+        self.image_ranges_changed_Signal.emit()
+
+    def _image_range_ok(self, range, axis=''):
+        """ Sanity check any image_range before setting it.
+
+        @param list range: the desired image range.
+
+        @param str axis: Axis label to give better error messages.
+        """
+        if len(range) != 2:
+            self.log.error(
+                'image_{ax}_range must be a 2-element list, [min, max].'
+                'It is not possible to set it to {0}'.format(range, ax=axis)
+            )
+            return False
+        if range[1] < range[0]:
+            self.log.error(
+                '{ax}_min must be smaller than {ax}_max, but they are '
+                '({0:.3f},{1:.3f}).'.format(range[0], range[1], ax=axis)
+            )
+            return False
+        
+        return True
 
     def switch_hardware(self, to_on=False):
         """ Switches the Hardware off or on.

--- a/logic/confocal_logic.py
+++ b/logic/confocal_logic.py
@@ -375,7 +375,7 @@ class ConfocalLogic(GenericLogic):
         self._image_x_range = range
 
         # Tell the GUI or anything else that might need to update display.
-        self.image_ranges_changed_Signal.emit()
+        self.signal_image_ranges_changed.emit()
 
     @property
     def image_y_range(self):
@@ -394,7 +394,7 @@ class ConfocalLogic(GenericLogic):
         self._image_y_range = range
 
         # Tell the GUI or anything else that might need to update display.
-        self.image_ranges_changed_Signal.emit()
+        self.signal_image_ranges_changed.emit()
 
     @property
     def image_z_range(self):
@@ -413,7 +413,7 @@ class ConfocalLogic(GenericLogic):
         self._image_z_range = range
 
         # Tell the GUI or anything else that might need to update display.
-        self.image_ranges_changed_Signal.emit()
+        self.signal_image_ranges_changed.emit()
 
     def _image_range_ok(self, range, axis=''):
         """ Sanity check any image_range before setting it.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Set and Get methods have been added to confocal logic for the scan ranges and scan resolutions. These are now used when confocal GUI gets and sets these scan parameters. Additional signals and update-handling methods have been written, so that now the GUI updates these parameters if they are changed in the logic by something else (console, etc).

Also, the deactivation of the "Stop Scanning" action button in Confocal GUI has been separated from the re-activation of the other scan actions. This makes the GUI state visually map to the real situation, where hardware needs to stop the scan_line before it is truely finished.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It is important for the GUI to reflect the state of the logic, and there was a bug where setting the confocal scan ranges and resolutions in the logic was *not* updated in the confocal GUI. This has been fixed in this pull request in the simplest possible way:
  - The GUI relies on the following public attributes of confocal logic: image_x_range, image_y_range, image_z_range, xy_resolution, z_resolution.
  - Set/get methods have been written for these attributes using @property decorators, and so the external facing "API" does not change for the GUI and minimal code changes are required.
  - Two new signals have been added to confocal logic, which are emitted when scan ranges or resolutions (respectively) are changed. The GUI catches these signals and updates its displayed values accordingly.

The scan action buttons state is now better mapped to the hardware/logic state, and this is important for slow scans. Slow scans can arise from slow hardware or from high resolution imaging.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on default config with dummy hardware. These changes only relate to the communication between Confocal logic and GUI modules.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
