### PR TITLE
Specify Obis laser COM port

### DIFF
--- a/hardware/laser/coherent_obis_laser.py
+++ b/hardware/laser/coherent_obis_laser.py
@@ -35,6 +35,7 @@ class OBISLaser(Base, SimpleLaserInterface):
     ```
     # obis:
     #     module.Class: 'SimpleLaserInterface.OBISLaser'
+    #     com_port: 'COM3'
     ```
     """
 
@@ -44,10 +45,12 @@ class OBISLaser(Base, SimpleLaserInterface):
     eol = '\r'
     _model_name = 'UNKNOWN'
 
+    _com_port = ConfigOption('com_port', missing='error')
+
     def on_activate(self):
         """ Activate module.
         """
-        self.obis = serial.Serial('COM3', timeout=1)
+        self.obis = serial.Serial(self._com_port, timeout=1)
 
         connected = self.connect_laser()
 


### PR DESCRIPTION
The user should be able to specify the COM port to which their Obis laser is connected.

## Description
The previous pull request containing the Coherent Obis laser hardware module (PR #325) did not allow the user to specify the COM port that the laser was connected to. With commit ff3e94a the user can now specify the COM port in the config.

## Motivation and Context
The COM port was previously hard-coded but it should be user definable.

## How Has This Been Tested?
Tested locally with the updated code (commit ff3e94a).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
