### PR TITLE
Allow the user to specify a baud rate for the SMIQ GPIB connection

### DIFF
--- a/hardware/microwave/mw_source_smiq.py
+++ b/hardware/microwave/mw_source_smiq.py
@@ -62,7 +62,7 @@ class MicrowaveSmiq(Base, MicrowaveInterface):
         # trying to load the visa connection to the module
         self.rm = visa.ResourceManager()
         try:
-            if not self._gpib_baud_rate:
+            if self._gpib_baud_rate is None:
                 self._gpib_connection = self.rm.open_resource(self._gpib_address,
                                                             timeout=self._gpib_timeout)
             else:

--- a/hardware/microwave/mw_source_smiq.py
+++ b/hardware/microwave/mw_source_smiq.py
@@ -43,6 +43,7 @@ class MicrowaveSmiq(Base, MicrowaveInterface):
     _modtype = 'hardware'
     _gpib_address = ConfigOption('gpib_address', missing='error')
     _gpib_timeout = ConfigOption('gpib_timeout', 10, missing='warn')
+    _gpib_baud_rate = ConfigOption('gpib_baud_rate', None)
 
     # Indicate how fast frequencies within a list or sweep mode can be changed:
     _FREQ_SWITCH_SPEED = 0.003  # Frequency switching speed in s (acc. to specs)
@@ -53,8 +54,13 @@ class MicrowaveSmiq(Base, MicrowaveInterface):
         # trying to load the visa connection to the module
         self.rm = visa.ResourceManager()
         try:
-            self._gpib_connection = self.rm.open_resource(self._gpib_address,
-                                                          timeout=self._gpib_timeout)
+            if not self._gpib_baud_rate:
+                self._gpib_connection = self.rm.open_resource(self._gpib_address,
+                                                            timeout=self._gpib_timeout)
+            else:
+                self._gpib_connection = self.rm.open_resource(self._gpib_address,
+                                                            timeout=self._gpib_timeout,
+                                                            baud_rate=self._gpib_baud_rate)
         except:
             self.log.error('This is MWSMIQ: could not connect to GPIB address >>{}<<.'
                            ''.format(self._gpib_address))

--- a/hardware/microwave/mw_source_smiq.py
+++ b/hardware/microwave/mw_source_smiq.py
@@ -37,6 +37,14 @@ from interface.microwave_interface import TriggerEdge
 class MicrowaveSmiq(Base, MicrowaveInterface):
     """ This is the Interface class to define the controls for the simple
         microwave hardware.
+
+    Example configuration:
+    ```
+    smiq:
+        module.Class: 'microwave.mw_source_smiq.MicrowaveSmiq'
+        gpib_address: 'GPIB0::28::INSTR'
+        gpib_timeout: 20
+    ```
     """
 
     _modclass = 'MicrowaveSmiq'

--- a/hardware/microwave/mw_source_smiq.py
+++ b/hardware/microwave/mw_source_smiq.py
@@ -44,6 +44,7 @@ class MicrowaveSmiq(Base, MicrowaveInterface):
         module.Class: 'microwave.mw_source_smiq.MicrowaveSmiq'
         gpib_address: 'GPIB0::28::INSTR'
         gpib_timeout: 20
+        gpib_baud_rate: 460800  # optional
     ```
     """
 


### PR DESCRIPTION
## Description

- Commit  b2a8e91 allows the user to specify a baud rate for communication with the SMIQ microwave generator. This may be required when using particular GPIB / USB converters.

- Commit 5e8f5c0 adds an example configuration into the class descriptor, to assist new users including the instrument in their config.

## Motivation and Context
If the user is using a GPIB / USB converter that requires a specific baud rate then this value must be parsed into the VISA resource manager to create a connection.

## How Has This Been Tested?
This has been tested creating a connection to the SMIQ06B microwave generator via a [Galvant Industries](http://www.galvant.ca/#!/store/gpibusb) GPIB / USB converter which requires a baud rate of [460800](https://github.com/Galvant/gpibusb-documentation/blob/master/basic_commands.txt).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
