### PR TITLE
rpyc 4.x.x is not fully backwards compatible

### DIFF
--- a/core/remote.py
+++ b/core/remote.py
@@ -61,13 +61,13 @@ class RemoteObjectManager(QObject):
             def get_service_name():
                 return 'RemoteModule'
 
-            def on_connect(self):
+            def on_connect(self, conn):
                 """ code that runs when a connection is created
                     (to init the service, if needed)
                 """
                 logger.info('Client connected!')
 
-            def on_disconnect(self):
+            def on_disconnect(self, conn):
                 """ code that runs when the connection has already closed
                     (to finalize the service, if needed)
                 """

--- a/documentation/manual-package-installation.md
+++ b/documentation/manual-package-installation.md
@@ -87,7 +87,7 @@ Now you can perform either an installation of each package
     pip install asteval
     pip install fysom
     pip install gitpython    
-    pip install lmfitv
+    pip install lmfit
     pip install pydaqmx
     pip install pyflowgraph-qo
     pip install pyqtgraph-qo 

--- a/documentation/remote_modules.md
+++ b/documentation/remote_modules.md
@@ -1,10 +1,10 @@
-# Remote Modules
+# Remote Modules {#remote_modules}
 
 Using rpyc Qudi modules can be accessed from a remote computer like they were locally used.
 
 ## Requirements
 
-* rpyc in at least version 3.3 has to be installed.
+* rpyc in at least version 4.0.2 has to be installed.
 
 ## Server Configuration
 

--- a/tools/conda-env-linx64-qt5.yml
+++ b/tools/conda-env-linx64-qt5.yml
@@ -119,7 +119,7 @@ dependencies:
     - pyvisa==1.9.0
     - pyvisa-py==0.2
     - pyyaml==3.12
-    - rpyc==3.4.4
+    - rpyc==4.0.2
     - ruamel.yaml==0.15.37
     - serial==0.0.64
     - smmap2==2.0.1

--- a/tools/conda-env-win10-64bit-qt5.yml
+++ b/tools/conda-env-win10-64bit-qt5.yml
@@ -109,7 +109,7 @@ dependencies:
     - pyvisa==1.9.0
     - pyyaml==3.12
     - qtpy==1.4.2
-    - rpyc==3.4.4
+    - rpyc==4.0.2
     - ruamel.yaml==0.15.40
     - scipy==1.1.0
     - serial==0.0.66

--- a/tools/conda-env-win10-64bit-qt5.yml
+++ b/tools/conda-env-win10-64bit-qt5.yml
@@ -109,7 +109,7 @@ dependencies:
     - pyvisa==1.9.0
     - pyyaml==3.12
     - qtpy==1.4.2
-    - rpyc==4.0.1
+    - rpyc==3.4.4
     - ruamel.yaml==0.15.40
     - scipy==1.1.0
     - serial==0.0.66

--- a/tools/conda-env-win7-32bit-qt5.yml
+++ b/tools/conda-env-win7-32bit-qt5.yml
@@ -109,7 +109,7 @@ dependencies:
     - pyvisa==1.9.0
     - pyyaml==3.12
     - qtpy==1.4.2
-    - rpyc==3.4.4
+    - rpyc==4.0.2
     - ruamel.yaml==0.15.40
     - scipy==1.1.0
     - serial==0.0.66

--- a/tools/conda-env-win7-32bit-qt5.yml
+++ b/tools/conda-env-win7-32bit-qt5.yml
@@ -109,7 +109,7 @@ dependencies:
     - pyvisa==1.9.0
     - pyyaml==3.12
     - qtpy==1.4.2
-    - rpyc==4.0.1
+    - rpyc==3.4.4
     - ruamel.yaml==0.15.40
     - scipy==1.1.0
     - serial==0.0.66

--- a/tools/conda-env-win7-64bit-qt5.yml
+++ b/tools/conda-env-win7-64bit-qt5.yml
@@ -116,7 +116,7 @@ dependencies:
   - pyvisa==1.9.0
   - pyyaml==3.12
   - qtpy==1.4.2
-  - rpyc==3.4.4
+  - rpyc==4.0.2
   - ruamel.yaml==0.15.40
   - scipy==1.1.0
   - serial==0.0.66

--- a/tools/conda-env-win7-64bit-qt5.yml
+++ b/tools/conda-env-win7-64bit-qt5.yml
@@ -116,7 +116,7 @@ dependencies:
   - pyvisa==1.9.0
   - pyyaml==3.12
   - qtpy==1.4.2
-  - rpyc==4.0.1
+  - rpyc==3.4.4
   - ruamel.yaml==0.15.40
   - scipy==1.1.0
   - serial==0.0.66

--- a/tools/conda-env-win8-qt5.yml
+++ b/tools/conda-env-win8-qt5.yml
@@ -114,7 +114,7 @@ dependencies:
     - pyvisa==1.9.0
     - pyvisa-py==0.2
     - pyyaml==3.12
-    - rpyc==3.4.4
+    - rpyc==4.0.2
     - ruamel.yaml==0.15.37
     - serial==0.0.64
     - smmap2==2.0.1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Revert rpyc version to 3.4.4 in install environment because 4.0.x does not work out of the box.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not tested, please test.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
