### PR TITLE
Save logic threaded saving

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -23,6 +23,7 @@ Changes/New features:
 * Added .ico image to make a desktop shortcut on Windows with explanation in the documentation
 * Added a how-to-participate guide to the documentation
 * Added installation options guide to the documentation
+* Savelogic becomes decoupled from main thread and saving happens in a non blocking way.
 
 Config changes:
 * Add separate conda environments for windows 7 32bit, windows 7 64bit, and windows 10 64bit. 

--- a/logic/save_logic.py
+++ b/logic/save_logic.py
@@ -118,11 +118,17 @@ class FunctionImplementationError(Exception):
 class SaveLogic(GenericLogic):
     """  A general class which saves all kinds of data in a general sense.
 
-    @signal sigSaveData()
+    @signal sigSaveData(object, object, object, object, object, object, object,
+                        object, object, object):
+                        will be used internally to decouple the save procedure.
+    @signal sigSaveComplete(str): Will indicate that the save is complete and
+                                  emit the path where the data has saved to.
     """
 
     sigSaveData = QtCore.Signal(object, object, object, object, object, object,
                                 object, object, object, object)
+
+    sigSaveComplete = QtCore.Signal(str)
 
 
     _modclass = 'savelogic'
@@ -562,6 +568,8 @@ class SaveLogic(GenericLogic):
             plt.close(plotfig)
             self.log.debug('Time needed to save data: {0:.2f}s'.format(time.time()-start_time))
             #----------------------------------------------------------------------------------
+
+        self.sigSaveComplete.emit(filepath)
 
     def save_array_as_text(self, data, filename, filepath='', fmt='%.15e', header='',
                            delimiter='\t', comments='#', append=False):

--- a/logic/save_logic.py
+++ b/logic/save_logic.py
@@ -234,63 +234,60 @@ class SaveLogic(GenericLogic):
         """
         General save routine for data.
 
-        @param dictionary data: Dictionary containing the data to be saved. The keys should be
-                                strings containing the data header/description. The corresponding
-                                items are one or more 1D arrays or one 2D array containing the data
-                                (list or numpy.ndarray). Example:
-
+        @param dict data: Dictionary containing the data to be saved. The keys should be strings
+                          containing the data header/description. The corresponding items are one or
+                          more 1D arrays or one 2D array containing the data (list or numpy.ndarray).
+                          Example:
                                     data = {'Frequency (MHz)': [1,2,4,5,6]}
                                     data = {'Frequency': [1, 2, 4], 'Counts': [234, 894, 743, 423]}
                                     data = {'Frequency (MHz),Counts':[[1,234], [2,894],...[30,504]]}
 
-        @param string filepath: optional, the path to the directory, where the data will be saved.
-                                If the specified path does not exist yet, the saving routine will
-                                try to create it.
-                                If no path is passed (default filepath=None) the saving routine will
-                                create a directory by the name of the calling module inside the
-                                daily data directory.
-                                If no calling module can be inferred and/or the requested path can
-                                not be created the data will be saved in a subfolder of the daily
-                                data directory called UNSPECIFIED
-        @param dictionary parameters: optional, a dictionary with all parameters you want to save in
-                                      the header of the created file.
-        @parem string filename: optional, if you really want to fix your own filename. If passed,
-                                the whole file will have the name
+        @param str filepath: optional, the path to the directory, where the data will be saved. If
+                             the specified path does not exist yet, the saving routine will try to
+                             create it.
+                             If no path is passed (default filepath=None) the saving routine will
+                             create a directory by the name of the calling module inside the daily
+                             data directory.
+                             If no calling module can be inferred and/or the requested path can not
+                             be created the data will be saved in a subfolder of the daily data
+                             directory called UNSPECIFIED.
+        @param dict parameters: optional, a dictionary with all parameters you want to save in the
+                                header of the created file.
+        @parem str filename: optional, if you really want to fix your own filename. If passed, the
+                             whole file will have the name
 
                                     <filename>
 
-                                If nothing is specified the save logic will generate a filename
-                                either based on the module name from which this method was called,
-                                or it will use the passed filelabel if that is speficied.
-                                You also need to specify the ending of the filename!
-        @parem string filelabel: optional, if filelabel is set and no filename was specified, the
-                                 savelogic will create a name which looks like
+                             If nothing is specified the save logic will generate a filename either
+                             based on the module name from which this method was called, or it will
+                             use the passed filelabel if that is speficied. You also need to
+                             specify the ending of the filename!
+        @parem str filelabel: optional, if filelabel is set and no filename was specified, the
+                              savelogic will create a name which looks like
 
-                                     YYYY-MM-DD_HHh-MMm-SSs_<filelabel>.dat
+                                    YYYY-MM-DD_HHh-MMm-SSs_<filelabel>.dat
 
-                                 The timestamp will be created at runtime if no user defined
-                                 timestamp was passed.
-        @param datetime timestamp: optional, a datetime.datetime object. You can create this object
-                                   with datetime.datetime.now() in the calling module if you want to
-                                   fix the timestamp for the filename. Be careful when passing a
-                                   filename and a timestamp, because then the timestamp will be
-                                   ignored.
-        @param string filetype: optional, the file format the data should be saved in. Valid inputs
-                                are 'text', 'xml' and 'npz'. Default is 'text'.
-        @param string or list of strings fmt: optional, format specifier for saved data. See python
-                                              documentation for
-                                              "Format Specification Mini-Language". If you want for
-                                              example save a float in scientific notation with 6
-                                              decimals this would look like '%.6e'. For saving
-                                              integers you could use '%d', '%s' for strings.
-                                              The default is '%.15e' for numbers and '%s' for str.
-                                              If len(data) > 1 you should pass a list of format
-                                              specifiers; one for each item in the data dict. If
-                                              only one specifier is passed but the data arrays have
-                                              different data types this can lead to strange
-                                              behaviour or failure to save right away.
-        @param string delimiter: optional, insert here the delimiter, like '\n' for new line, '\t'
-                                 for tab, ',' for a comma ect.
+                              The timestamp will be created at runtime if no user defined timestamp
+                              was passed.
+        @param datetime.datetime timestamp: optional, a datetime.datetime object. You can create
+                                   this object with datetime.datetime.now() in the calling module
+                                   if you want to fix the timestamp for the filename. Be careful
+                                   when passing a filename and a timestamp, because then the
+                                   timestamp will be ignored.
+        @param str filetype: optional, the file format the data should be saved in. Valid inputs are
+                            'text', 'xml' and 'npz'. Default is 'text'.
+        @param str or list of str fmt: optional, format specifier for saved data. See python
+                                       documentation for "Format Specification Mini-Language". If
+                                       you want for example save a float in scientific notation with
+                                       6 decimals this would look like '%.6e'. For saving integers
+                                       you could use '%d', '%s' for strings. The default is '%.15e'
+                                       for numbers and '%s' for str. If len(data) > 1 you should
+                                       pass a list of format specifiers; one for each item in the
+                                       data dict. If only one specifier is passed but the data
+                                       arrays have different data types this can lead to strange
+                                       behaviour or failure to save right away.
+        @param str delimiter: optional, insert here the delimiter, like '\n' for new line, '\t'
+                              for tab, ',' for a comma ect.
 
         1D data
         =======
@@ -324,8 +321,8 @@ class SaveLogic(GenericLogic):
         self.sigSaveData.emit(data, filepath, parameters, filename, filelabel,
                               timestamp, filetype, fmt, delimiter, plotfig)
 
-    QtCore.Slot(object, object, object, object, object, object, object, object,
-                object, object)
+    @QtCore.Slot(object, object, object, object, object, object, object, object,
+                 object, object)
     def _save_data(self, data, filepath=None, parameters=None, filename=None, filelabel=None,
                   timestamp=None, filetype='text', fmt='%.15e', delimiter='\t', plotfig=None):
         """ The actual method to be called by a signal thread. See in the method
@@ -500,11 +497,12 @@ class SaveLogic(GenericLogic):
                                     fmt=fmt, header=header, delimiter=delimiter, comments='#',
                                     append=False)
         else:
-            self.log.error('Only saving of data as textfile and npz-file is implemented. Filetype "{0}" is not '
-                           'supported yet. Saving as textfile.'.format(filetype))
-            self.save_array_as_text(data=data[identifier_str], filename=filename, filepath=filepath,
-                                    fmt=fmt, header=header, delimiter=delimiter, comments='#',
-                                    append=False)
+            self.log.error('Only saving of data as textfile and npz-file is implemented. '
+                           'Filetype "{0}" is not supported yet. Saving as textfile.'.format(filetype))
+            for identifier_str in data:
+                self.save_array_as_text(data=data[identifier_str], filename=filename, filepath=filepath,
+                                        fmt=fmt, header=header, delimiter=delimiter, comments='#',
+                                        append=True)
 
         #--------------------------------------------------------------------------------------------
         # Save thumbnail figure of plot
@@ -620,7 +618,7 @@ class SaveLogic(GenericLogic):
             folderlist = [d for d in os.listdir(current_dir) if os.path.isdir(os.path.join(current_dir, d))]
             # Search if there is a folder which starts with the current date:
             for entry in folderlist:
-                if (time.strftime("%Y%m%d") in (entry[:2])):
+                if time.strftime("%Y%m%d") in entry:
                     current_dir = os.path.join(current_dir, str(entry))
                     folder_exists = True
                     break


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Decouple the saving procedure by introducing a queued connection in the save logic. This prevents that Qudi is being blocked during the save procedure. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, the saving procedure is blocking Qudi if large amount of data is saved (e.g. in confocal).
This PR would fix #84. The Save logic introduces a new signal sigSaveComplete to which other modules can connect if they require to know whether the save is finished. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested with various modules on dummy config. Especially confocal scans will take some time to process the data. By pressing several times the save button you can see that the saved data are processed over time and the experiment can still continue.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
