### PR TITLE
I have met with memory stacking up problem, when I tried to save mass…

### DIFF
--- a/logic/save_logic.py
+++ b/logic/save_logic.py
@@ -543,6 +543,7 @@ class SaveLogic(GenericLogic):
             png_image.save(fig_fname_image, "png", pnginfo=png_metadata)
 
             # close matplotlib figure
+            plt.gcf().clear()
             plt.close(plotfig)
             self.log.debug('Time needed to save data: {0:.2f}s'.format(time.time()-start_time))
             #----------------------------------------------------------------------------------


### PR DESCRIPTION
The line added in savelogic, reduces half of stacking up memory from image saving.

<!--- Provide a general summary of your changes in the Title above -->
The image saving causes memory stack up, more or less on different PCs. This change does not essentially solve this problem, but it reduces half of the memory stack. 
## Description
This line removes current fig in matploitlib.pyplot.

## Motivation and Context
I have met with memory stacking up problem, when I tried to save massive odmr figures. 
computer just goes slower with more and more image-saving, and when memory is fully stacked your measurements would be aborted.
## How Has This Been Tested?
It was tested on my office computer, memory stack reduced from ~20MB/fig to 10 MB/fig.
It was tested in Setup 5, memory stack reduced from ~7 MB/fig to 3.5 MB/fig

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
