### PR TITLE
add helper functions for sequence generation

### DIFF
--- a/logic/pulsed/pulse_objects.py
+++ b/logic/pulsed/pulse_objects.py
@@ -25,6 +25,7 @@ import os
 import sys
 import inspect
 import importlib
+import numpy as np
 from collections import OrderedDict
 
 from logic.pulsed.sampling_functions import SamplingFunctions
@@ -1173,6 +1174,69 @@ class PredefinedGeneratorBase:
             mw_laser_element.pulse_function[self.laser_channel] = SamplingFunctions.DC(
                 voltage=self.analog_trigger_voltage)
         return mw_laser_element
+
+    def _get_readout_element(self):
+
+        waiting_element = self._get_idle_element(length=self.wait_time, increment=0)
+        laser_element = self._get_laser_gate_element(length=self.laser_length, increment=0)
+        delay_element = self._get_delay_gate_element()
+        return [laser_element, delay_element, waiting_element]
+
+
+    def _add_trigger(self, created_blocks, block_ensemble):
+        if self.sync_channel:
+            sync_block = PulseBlock(name='sync_trigger')
+            sync_block.append(self._get_sync_element())
+            created_blocks.append(sync_block)
+            block_ensemble.append((sync_block.name, 0))
+        return created_blocks, block_ensemble
+
+
+    def _add_metadata_to_settings(self, block_ensemble, created_blocks, alternating = False, laser_ignore_list = list(),
+                                  controlled_variable = [0,1], units=('s', ''), number_of_lasers = None,
+                                  counting_length=None):
+
+        block_ensemble.measurement_information['alternating'] = alternating
+        block_ensemble.measurement_information['laser_ignore_list'] = laser_ignore_list
+        block_ensemble.measurement_information['controlled_variable'] = controlled_variable
+        block_ensemble.measurement_information['units'] = units
+        if number_of_lasers is None:
+            if alternating:
+                block_ensemble.measurement_information['number_of_lasers'] = len(controlled_variable) * 2
+            else:
+                block_ensemble.measurement_information['number_of_lasers'] = len(controlled_variable)
+        else:
+            block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
+        if counting_length is None:
+            block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
+                ensemble=block_ensemble, created_blocks=created_blocks)
+        else:
+            block_ensemble.measurement_information['counting_length'] = counting_length
+
+        return block_ensemble
+
+
+    def _adjust_to_samplingrate(self,value,divisibility):
+        '''
+        @param self: Every pulsing device has a sampling rate which is most of the time adjustable
+        but always limited. Thus it is not possible to generate any arbitrary time value. This function
+        should check if the timing value is generateable with the current sampling rate and if nout round
+        it to the next possible value...
+        @param value: the desired timing value
+        @param divisibility: Takes into account that vonly parts of variables might be used (for example for a pi/2 pulse...)
+        @return: value matching to the current sampling rate of pulser
+        '''
+        resolution=1/self.pulse_generator_settings['sample_rate']*divisibility
+        mod=value%(resolution)
+        if mod<resolution/2:
+            self.log.debug('Adjusted to sampling rate:' + str(value) + ' to ' + str(value-mod))
+            value=value-mod
+        else:
+            value=value+resolution-mod
+        # correct for computational errors
+        value=np.around(value,13)
+        return float(value)
+
 
     def _get_ensemble_count_length(self, ensemble, created_blocks):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add helpful functions for sequence generations to 'pulse_objects.py'. The idea is to simplify and accelerate sequence generation.

_get_readout_element: In most measurements have a readout-block consisting of laser-, delay, and waiting_element. This function generate this three element and returns them

_add_trigger: Most sequences have a trigger for synchronization to the fat counter. This function should simplify the add of these triggers.

_add_metadata_to_settings: Most of the time the metadata is the same. This function should simplify the generation of the measurement information

_adjust_to_samplingrate: Pulser usually have a certain sample rate, so not all arbitrary element-lengths are realizable. This function rounds input values to the closest realizable length. This is also useful for pulser if granularity conditions. 

Please let me know if their location is inappropriate.






## Description
<!--- Describe your changes in detail -->

added simple helper functions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

simplifies sequence generation

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested on setup 3

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
