### PR TITLE
Awg7122c fixes

### DIFF
--- a/hardware/awg/tektronix_awg7122c.py
+++ b/hardware/awg/tektronix_awg7122c.py
@@ -86,7 +86,7 @@ class AWG7122C(Base, PulserInterface):
         else:
             self.awg = self._rm.open_resource(self._visa_address)
             # set timeout by default to 30 sec
-            self.awg.timeout = self._visa_timeout * 1000
+            self.awg.timeout = self._visa_timeout * 2
 
         # try connecting to AWG using FTP protocol
         with FTP(self._ip_address) as ftp:
@@ -248,7 +248,7 @@ class AWG7122C(Base, PulserInterface):
             # wait until the AWG is actually running
             while not self._is_output_on():
                 time.sleep(0.2)
-        return self.get_status()
+        return self.get_status()[0]
 
     def pulser_off(self):
         """ Switches the pulsing device off.
@@ -1048,7 +1048,7 @@ class AWG7122C(Base, PulserInterface):
         """
         wfm_list_len = int(self.query('WLIS:SIZE?'))
         wfm_list = list()
-        for index in range(1, wfm_list_len + 1):
+        for index in range(1, wfm_list_len):
             wfm_list.append(self.query('WLIS:NAME? {0:d}'.format(index)))
         return sorted(wfm_list)
 

--- a/hardware/awg/tektronix_awg7122c.py
+++ b/hardware/awg/tektronix_awg7122c.py
@@ -263,7 +263,7 @@ class AWG7122C(Base, PulserInterface):
             # wait until the AWG has actually stopped
             while self._is_output_on():
                 time.sleep(0.2)
-        return self.get_status()
+        return self.get_status()[0]
 
     def load_waveform(self, load_dict):
         """ Loads a waveform to the specified channel of the pulsing device.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
get_status is returning a tuple of status + a dictionary. 
visa timeout was very long 15000 s.

In get_waveform_names a generator object with
1 element too much was created.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To run the tool chain
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
On the hardware
<!--- Include details of your testing environment, tests ran to see how -->
Loading the modules

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x ] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
