### PR TITLE
Pulsed aftermath bugfixes

### DIFF
--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -597,7 +597,7 @@ class AWG70K(Base, PulserInterface):
         # Load sequence
         for chnl in range(1, trac_num + 1):
             self.write('SOUR{0:d}:CASS:SEQ "{1}", {2:d}'.format(chnl, sequence_name, chnl))
-            while self.query('SOUR{0:d}:CASS?'.format(chnl))[1:-2] != '{0},{1:d}'.format(
+            while self.query('SOUR{0:d}:CASS?'.format(chnl)) != '{0},{1:d}'.format(
                     sequence_name, chnl):
                 time.sleep(0.2)
 

--- a/logic/pulsed/pulse_objects.py
+++ b/logic/pulsed/pulse_objects.py
@@ -646,7 +646,9 @@ class PulseSequence(object):
         """
         self.name = name
         self.rotating_frame = rotating_frame
-        self.ensemble_list = list() if ensemble_list is None else ensemble_list
+        self.ensemble_list = list()
+        if ensemble_list is not None:
+            self.extend(ensemble_list)
         self.is_finite = True
         self.refresh_parameters()
 
@@ -825,7 +827,7 @@ class PulseSequence(object):
         if len(self.ensemble_list) < position or position < 0:
             raise IndexError('PulseSequence ensemble list index out of range')
 
-        self.ensemble_list.insert(position, tuple(element))
+        self.ensemble_list.insert(position, tuple(copy.deepcopy(element)))
         if element[1]['repetitions'] < 0:
             self.is_finite = False
         self.sampling_information = dict()

--- a/logic/pulsed/pulsed_master_logic.py
+++ b/logic/pulsed/pulsed_master_logic.py
@@ -132,7 +132,9 @@ class PulsedMasterLogic(GenericLogic):
                             'loading_busy': False,
                             'pulser_running': False,
                             'measurement_running': False,
-                            'microwave_running': False}
+                            'microwave_running': False,
+                            'predefined_generation_busy': False,
+                            'fitting_busy': False}
 
         # Connect signals controlling PulsedMeasurementLogic
         self.sigDoFit.connect(
@@ -168,7 +170,7 @@ class PulsedMasterLogic(GenericLogic):
         self.pulsedmeasurementlogic().sigTimerUpdated.connect(
             self.sigTimerUpdated, QtCore.Qt.QueuedConnection)
         self.pulsedmeasurementlogic().sigFitUpdated.connect(
-            self.sigFitUpdated, QtCore.Qt.QueuedConnection)
+            self.fit_updated, QtCore.Qt.QueuedConnection)
         self.pulsedmeasurementlogic().sigMeasurementStatusUpdated.connect(
             self.measurement_status_updated, QtCore.Qt.QueuedConnection)
         self.pulsedmeasurementlogic().sigPulserRunningUpdated.connect(
@@ -232,7 +234,7 @@ class PulsedMasterLogic(GenericLogic):
         self.sequencegeneratorlogic().sigSamplingSettingsUpdated.connect(
             self.sigSamplingSettingsUpdated, QtCore.Qt.QueuedConnection)
         self.sequencegeneratorlogic().sigPredefinedSequenceGenerated.connect(
-            self.sigPredefinedSequenceGenerated, QtCore.Qt.QueuedConnection)
+            self.predefined_sequence_generated, QtCore.Qt.QueuedConnection)
         self.sequencegeneratorlogic().sigSampleEnsembleComplete.connect(
             self.sample_ensemble_finished, QtCore.Qt.QueuedConnection)
         self.sequencegeneratorlogic().sigSampleSequenceComplete.connect(
@@ -554,7 +556,18 @@ class PulsedMasterLogic(GenericLogic):
         @param fit_function:
         """
         if isinstance(fit_function, str):
+            self.status_dict['fitting_busy'] = True
             self.sigDoFit.emit(fit_function)
+        return
+
+    @QtCore.Slot(str, np.ndarray, object)
+    def fit_updated(self, fit_name, fit_data, fit_result):
+        """
+
+        @return:
+        """
+        self.status_dict['fitting_busy'] = False
+        self.sigFitUpdated.emit(fit_name, fit_data, fit_result)
         return
 
     def save_measurement_data(self, tag, with_error):
@@ -857,7 +870,14 @@ class PulsedMasterLogic(GenericLogic):
         """
         if not isinstance(kwarg_dict, dict):
             kwarg_dict = dict()
+        self.status_dict['predefined_generation_busy'] = True
         self.sigGeneratePredefinedSequence.emit(generator_method_name, kwarg_dict)
+        return
+
+    @QtCore.Slot(object)
+    def predefined_sequence_generated(self, generated_name):
+        self.status_dict['predefined_generation_busy'] = False
+        self.sigPredefinedSequenceGenerated.emit(generated_name)
         return
 
     def get_ensemble_info(self, ensemble):

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1370,6 +1370,7 @@ class SequenceGeneratorLogic(GenericLogic):
         It is a dictionary containing:
         TODO: Add parameters that are stored
         """
+        print('Sample Ensemble called: {0}, {1}'.format(ensemble, name_tag))
         # Get PulseBlockEnsemble from saved ensembles if string has been passed as argument
         if isinstance(ensemble, str):
             ensemble = self.get_ensemble(ensemble)
@@ -1629,7 +1630,7 @@ class SequenceGeneratorLogic(GenericLogic):
                 # to make something like 001
                 name_tag = sequence.name + '_' + str(sequence_step).zfill(3)
             else:
-                name_tag = None
+                name_tag = ensemble_name
                 offset_bin = 0  # Keep the offset at 0
 
             # Only sample ensembles if they have not already been sampled

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1370,7 +1370,6 @@ class SequenceGeneratorLogic(GenericLogic):
         It is a dictionary containing:
         TODO: Add parameters that are stored
         """
-        print('Sample Ensemble called: {0}, {1}'.format(ensemble, name_tag))
         # Get PulseBlockEnsemble from saved ensembles if string has been passed as argument
         if isinstance(ensemble, str):
             ensemble = self.get_ensemble(ensemble)

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1628,7 +1628,7 @@ class SequenceGeneratorLogic(GenericLogic):
         for sequence_step, (ensemble_name, seq_param) in enumerate(sequence.ensemble_list):
             if sequence.rotating_frame:
                 # to make something like 001
-                name_tag = sequence.name + '_' + str(sequence_step).zfill(3)
+                name_tag = ensemble_name + '_' + str(sequence_step).zfill(3)
             else:
                 name_tag = ensemble_name
                 offset_bin = 0  # Keep the offset at 0


### PR DESCRIPTION
## Description
Introduced deepcopy operation when adding sequence steps in order to avoid entangled step parameter dictionaries. It's more efficient if the user could take care of copying independent dictionaries before adding them to the PulseSequence object but this way it is bulletproof.

Fixed a bug when sampling a PulseSequence while not preserving rotating frame across  different waveforms. Each different PulseBlockEnsemble should be sampled only once even if they occur in several sequence steps.

Fixed a minor bug in awg70k hardware module related to string formatting.

Added two new status_dict flags in PulsedMasterLogic that could be useful for scripting. One indicates if data fitting is in progress, the other indicates if predefined sequence generation is in progress.

## Motivation and Context
Bugfixes and a minor enhancement

## How Has This Been Tested?
On dummy

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
