### PR TITLE
Enum in sampling functions and predefined methods

### DIFF
--- a/documentation/pulsed/how_to_add_predefined_methods.md
+++ b/documentation/pulsed/how_to_add_predefined_methods.md
@@ -33,6 +33,7 @@ laser_channel etc.)
 * `laser_length` (dict containing the current settings for the fast counter hardware)
 * `wait_time` (the wait time after a laser pulse before any microwave irradiation takes place)
 * `rabi_period` (the rabi period of the spin to manipulate in seconds)
+* `sample_rate` (the sampling rate of the hardware device)
 
 If you need access to another attribute of the logic module simply add it as property to 
 `PredefinedGeneratorBase` but make sure to protect it properly against changes to the logic module.
@@ -63,7 +64,7 @@ Each generation method must meet the following requirements:
 * Method name starts with prefix `generate_`
 * Must contain the optional keyword argument `name` to give the instance to created a name
 * Additional parameters must be defined as optional keyword arguments
-* Default values for additional arguments must be of type `int`, `float`, `str` or `bool`. 
+* Default values for additional arguments must be of type `int`, `float`, `str`, `bool` or Enum subclass. 
 Depending on the default argument type the GUI will automatically create the proper input widget.
 
 ## Adding new methods procedure
@@ -88,6 +89,15 @@ altered unless you intend to contribute your methods to the _qudi_ repository.
 
 A template for a new `PredefinedGenerator` class could look like:
 ```python
+from enum import Enum
+
+
+class Colour(Enum):
+    red = 1
+    green = 2
+    blue = 3
+
+
 class MyPredefinedGeneratorBase(PredefinedGeneratorBase):
     """ Description goes here """
     def __init__(self, *args, **kwargs):
@@ -97,10 +107,46 @@ class MyPredefinedGeneratorBase(PredefinedGeneratorBase):
         # Do something
         pass
         
-    def generate_my_method_name2(self, name='my_name', my_str_param='derp', my_bool_param=True):
+    def generate_my_method_name2(self, name='my_name', my_str_param='derp', my_bool_param=True, my_enum_param=Colour.green):
         # Do something
         pass
         
     def _some_helper_method(self):
         pass
 ```
+
+### Advanced use of Enum subclass
+If you have used an Enum subclass as a parameter type of a sampling function 
+than you might want to wish to use the same Enum subclass in the predefined functions.
+
+To do so, you will have to access the sampling function and grab the Enum subclass from there.
+
+**Attention:** Be aware however that this requires the sampling function to be loaded 
+and you have to make sure, that the Enum subclass you are wanting to access really exists. 
+If you access an Enum subclass that does not exist without checking, the loading of qudi will fail!
+
+The following example is requiring the template from the [sampling functions](@ref sampling_functions):
+
+
+```python
+from logic.pulsed.sampling_functions import SamplingFunctions
+import sys
+
+if 'MyFunc' not in SamplingFunctions.parameters or 'my_enum_param' not in SamplingFunctions.parameters['MyFunc']:
+    print('Error: Cannot find the sampling function DDSymmetric and therefore cannot supply the required Enums.\n'
+          'Aborting the import of predefined methods in module {}.'.format(__name__), file=sys.stderr)
+else:
+    Colour = SamplingFunctions.parameters['MyFunc']['my_enum_param']['type']
+
+    class MyPredefinedGeneratorBase(PredefinedGeneratorBase):
+        """ Description goes here """
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+    
+        def generate_my_enum_method(self, name='my_enum_method', my_enum_param=Colour.green):
+            # Do something
+            pass
+```
+
+Notice that the whole class definition is encapsulated in an if-clause and only is loaded, 
+if the Enum-subclass-parameter can be found int the sampling functions.

--- a/documentation/pulsed/how_to_add_predefined_methods.md
+++ b/documentation/pulsed/how_to_add_predefined_methods.md
@@ -117,7 +117,7 @@ class MyPredefinedGeneratorBase(PredefinedGeneratorBase):
 
 ### Advanced use of Enum subclass
 If you have used an Enum subclass as a parameter type of a sampling function 
-than you might want to wish to use the same Enum subclass in the predefined functions.
+then you might want to wish to use the same Enum subclass in the predefined functions.
 
 To do so, you will have to access the sampling function and grab the Enum subclass from there.
 
@@ -133,12 +133,12 @@ from logic.pulsed.sampling_functions import SamplingFunctions
 import sys
 
 if 'MyFunc' not in SamplingFunctions.parameters or 'my_enum_param' not in SamplingFunctions.parameters['MyFunc']:
-    print('Error: Cannot find the sampling function DDSymmetric and therefore cannot supply the required Enums.\n'
+    print('Error: Cannot find the sampling function and therefore cannot supply the required Enums.\n'
           'Aborting the import of predefined methods in module {}.'.format(__name__), file=sys.stderr)
 else:
     Colour = SamplingFunctions.parameters['MyFunc']['my_enum_param']['type']
 
-    class MyPredefinedGeneratorBase(PredefinedGeneratorBase):
+    class MyPredefinedGenerator(PredefinedGeneratorBase):
         """ Description goes here """
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)

--- a/documentation/pulsed/how_to_add_sampling_functions.md
+++ b/documentation/pulsed/how_to_add_sampling_functions.md
@@ -47,10 +47,10 @@ The attributes for each parameter are:
     * `'init'` (The default value of the parameter)
     * `'min'` (The minimum allowed value of the parameter)
     * `'max'` (The maximum allowed value of the parameter)
-    * `'type'` (The python type of the parameter. allowed types: `int`, `float`, `str`, `bool`)
+    * `'type'` (The python type of the parameter. allowed types: `int`, `float`, `str`, `bool` and Enum subclass)
 * If a parameter is not given in a call to `__init__`, it must be set using its default value 
 defined in `params`
-* Allowed parameter types are `int`, `float`, `str` and `bool`. 
+* Allowed parameter types are `int`, `float`, `str`, `bool` and subclasses of Enum (see example). 
 Depending on the type the GUI will automatically create the proper input widget.
 * Must implement a method `get_samples` which has only one argument `time_array`. This function will
 calculate and return the analog voltages corresponding to the time bins provided by `time_array`.
@@ -75,13 +75,23 @@ altered unless you intend to contribute your sampling functions to the _qudi_ re
 
 A template for a new sampling function class could look like:
 ```python
+from enum import Enum
+
+
+class Colour(Enum):
+    red = 1
+    green = 2
+    blue = 3
+
+
 class MyFunc(SamplingBase):
     """ Description goes here """
     params = OrderedDict()
     params['my_float_param'] = {'unit': 'V', 'init': 0.0, 'min': 0.0, 'max': np.inf, 'type': float}
     params['my_int_param'] = {'unit': '', 'init': 0, 'min': 0, 'max': 42, 'type': int}
+    params['my_enum_param'] = {'unit': '', 'init': Colour.green, 'min': Colour.red, 'max': Colour.blue, 'type': Colour}
     
-    def __init__(self, my_float_param=None, my_int_param=None):
+    def __init__(self, my_float_param=None, my_int_param=None, my_enum_param=None):
         if my_float_param is None:
             self.my_float_param = params['my_float_param']['init']
         else:
@@ -90,6 +100,10 @@ class MyFunc(SamplingBase):
             self.my_int_param = params['my_int_param']['init']
         else:
             self.my_int_param = my_int_param
+        if my_enum_param is None:
+            self.my_enum_param = params['my_enum_param']['init']
+        else:
+            self.my_enum_param = my_enum_param
         return
 
     def get_samples(self, time_array):
@@ -102,4 +116,5 @@ class MyFunc(SamplingBase):
 
 class MyFuncWithNewName(MyFunc):
     """ This is the same sampling function as MyFunc but it is now called MyFuncWithNewName """
+    pass
 ```

--- a/gui/pulsed/pulsed_custom_widgets.py
+++ b/gui/pulsed/pulsed_custom_widgets.py
@@ -23,6 +23,7 @@ top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi
 from qtpy import QtCore, QtGui
 from collections import OrderedDict
 from qtwidgets.scientific_spinbox import ScienDSpinBox, ScienSpinBox
+from enum import Enum
 
 
 class DigitalChannelsWidget(QtGui.QWidget):
@@ -137,6 +138,15 @@ class AnalogParametersWidget(QtGui.QWidget):
                 widget.setFixedWidth(90)
                 # Forward editingFinished signal of child widget
                 widget.stateChanged.connect(self.editingFinished)
+            elif issubclass(self._parameters[param]['type'], Enum):
+                widget = QtGui.QComboBox()
+                for option in self._parameters[param]['type']:
+                    widget.addItem(option.name, option.value)
+                widget.setCurrentText(self._parameters[param]['init'].name)
+                # Set size constraints
+                widget.setFixedWidth(90)
+                # Forward editingFinished signal of child widget
+                widget.currentIndexChanged.connect(self.editingFinished)
 
             self._ach_widgets[param] = {'label': label, 'widget': widget}
 
@@ -162,6 +172,8 @@ class AnalogParametersWidget(QtGui.QWidget):
                 widget.setText(data[param])
             elif self._parameters[param]['type'] == bool:
                 widget.setChecked(data[param])
+            elif issubclass(self._parameters[param]['type'], Enum):
+                widget.setCurrentText(data[param].name)
 
         self.editingFinished.emit()
         return
@@ -177,6 +189,8 @@ class AnalogParametersWidget(QtGui.QWidget):
                 analog_params[param] = widget.text()
             elif self._parameters[param]['type'] == bool:
                 analog_params[param] = widget.isChecked()
+            elif issubclass(self._parameters[param]['type'], Enum):
+                analog_params[param] = self._parameters[param]['type'][widget.currentText()]
         return analog_params
 
     def sizeHint(self):

--- a/gui/pulsed/pulsed_custom_widgets.py
+++ b/gui/pulsed/pulsed_custom_widgets.py
@@ -141,7 +141,7 @@ class AnalogParametersWidget(QtGui.QWidget):
             elif issubclass(self._parameters[param]['type'], Enum):
                 widget = QtGui.QComboBox()
                 for option in self._parameters[param]['type']:
-                    widget.addItem(option.name, option.value)
+                    widget.addItem(option.name, option)
                 widget.setCurrentText(self._parameters[param]['init'].name)
                 # Set size constraints
                 widget.setFixedWidth(90)
@@ -190,7 +190,7 @@ class AnalogParametersWidget(QtGui.QWidget):
             elif self._parameters[param]['type'] == bool:
                 analog_params[param] = widget.isChecked()
             elif issubclass(self._parameters[param]['type'], Enum):
-                analog_params[param] = self._parameters[param]['type'][widget.currentText()]
+                analog_params[param] = widget.itemData(widget.currentIndex())
         return analog_params
 
     def sizeHint(self):

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -32,6 +32,7 @@ from gui.fitsettings import FitSettingsDialog
 from gui.guibase import GUIBase
 from qtpy import QtCore, QtWidgets, uic
 from qtwidgets.scientific_spinbox import ScienDSpinBox, ScienSpinBox
+from enum import Enum
 
 
 # TODO: Display the Pulse graphically (similar to AWG application)
@@ -1277,10 +1278,17 @@ class PulsedMeasurementGui(GUIBase):
                         input_obj = QtWidgets.QLineEdit(groupBox)
                         input_obj.setMinimumSize(QtCore.QSize(80, 0))
                         input_obj.setText(param)
+                    elif issubclass(type(param), Enum):
+                        input_obj = QtWidgets.QComboBox(groupBox)
+                        for option in type(param):
+                            input_obj.addItem(option.name, option)
+                        input_obj.setCurrentText(param.name)
+                        # Set size constraints
+                        input_obj.setMinimumSize(QtCore.QSize(80, 0))
                     else:
-                        self.log.error('The predefined method "{0}" has an argument "{1}" which is '
+                        self.log.error('The predefined method "{0}" has an argument "{1}" which '
                                        'has no default argument or an invalid type (str, float, '
-                                       'int or bool allowed)!\nCreation of the viewbox aborted.'
+                                       'int, bool or Enum allowed)!\nCreation of the viewbox aborted.'
                                        ''.format('generate_' + method_name, param_name))
                         continue
                     # Adjust size policy
@@ -1871,6 +1879,8 @@ class PulsedMeasurementGui(GUIBase):
                 param_dict[param_name] = input_obj.value()
             elif hasattr(input_obj, 'text'):
                 param_dict[param_name] = input_obj.text()
+            elif hasattr(input_obj, 'currentIndex') and hasattr(input_obj, 'itemData'):
+                param_dict[param_name] = input_obj.itemData(input_obj.currentIndex())
             else:
                 self.log.error('Not possible to get the value from the widgets, since it does not '
                                'have one of the possible access methods!')

--- a/logic/pulsed/pulse_objects.py
+++ b/logic/pulsed/pulse_objects.py
@@ -964,6 +964,10 @@ class PredefinedGeneratorBase:
     def rabi_period(self):
         return self.generation_parameters.get('rabi_period')
 
+    @property
+    def sample_rate(self):
+        return self.pulse_generator_settings['sample_rate']
+
     ################################################################################################
     #                                   Helper methods                                          ####
     ################################################################################################

--- a/logic/pulsed/pulse_objects.py
+++ b/logic/pulsed/pulse_objects.py
@@ -968,7 +968,7 @@ class PredefinedGeneratorBase:
 
     @property
     def sample_rate(self):
-        return self.pulse_generator_settings['sample_rate']
+        return self.pulse_generator_settings.get('sample_rate')
 
     ################################################################################################
     #                                   Helper methods                                          ####

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -735,12 +735,11 @@ class SequenceGeneratorLogic(GenericLogic):
         @param PulseBlock block: The PulseBlock instance to be saved
         """
         filename = '{0}.block'.format(block.name)
-        # try:
-        with open(os.path.join(self._assets_storage_dir, filename), 'wb') as file:
-            print(block)
-            pickle.dump(block, file)
-        # except:
-        #     self.log.error('Failed to serialize PulseBlock "{0}" to file.'.format(block.name))
+        try:
+            with open(os.path.join(self._assets_storage_dir, filename), 'wb') as file:
+                pickle.dump(block, file)
+        except:
+            self.log.error('Failed to serialize PulseBlock "{0}" to file.'.format(block.name))
         return
 
     def _save_blocks_to_file(self):

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -735,11 +735,12 @@ class SequenceGeneratorLogic(GenericLogic):
         @param PulseBlock block: The PulseBlock instance to be saved
         """
         filename = '{0}.block'.format(block.name)
-        try:
-            with open(os.path.join(self._assets_storage_dir, filename), 'wb') as file:
-                pickle.dump(block, file)
-        except:
-            self.log.error('Failed to serialize PulseBlock "{0}" to file.'.format(block.name))
+        # try:
+        with open(os.path.join(self._assets_storage_dir, filename), 'wb') as file:
+            print(block)
+            pickle.dump(block, file)
+        # except:
+        #     self.log.error('Failed to serialize PulseBlock "{0}" to file.'.format(block.name))
         return
 
     def _save_blocks_to_file(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In the sampling functions as well as in the predefined methods, the GUI elements are constructed from the data type of the default initialization of the specified parameters (see documentation). The available data types of these parameters were extended by Enum subclasses.

## Description
<!--- Describe your changes in detail -->
By creating your own Enum subclass you can now specify parameters, that have limited selection options. The GUI automatically creates a ComboBox for each parameter.

Also added the sample_rate to the parameters of PredefinedGeneratorBase.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As this is just an enhancement of the Pulsed 3.0 Pull Request, it does not need its own entry in the changelog.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with my own sampling functions and predefined methods on dummy (win7 64x) and on lap polarizer setup (win 8.1 64x)

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
