### PR TITLE
AWG70k bugfix

### DIFF
--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -846,16 +846,16 @@ class AWG70K(Base, PulserInterface):
                     offset[chnl] = constraints.a_ch_offset.max
 
         if amplitude is not None:
-            for a_ch in amplitude:
+            for chnl, amp in amplitude.items():
                 ch_num = int(chnl.rsplit('_ch', 1)[1])
-                self.write('SOUR{0:d}:VOLT:AMPL {1}'.format(ch_num, amplitude[a_ch]))
+                self.write('SOUR{0:d}:VOLT:AMPL {1}'.format(ch_num, amp))
                 while int(self.query('*OPC?')) != 1:
                     time.sleep(0.25)
 
         if offset is not None:
-            for a_ch in offset:
+            for chnl, off in offset.items():
                 ch_num = int(chnl.rsplit('_ch', 1)[1])
-                self.write('SOUR{0:d}:VOLT:OFFSET {1}'.format(ch_num, offset[a_ch]))
+                self.write('SOUR{0:d}:VOLT:OFFSET {1}'.format(ch_num, off))
                 while int(self.query('*OPC?')) != 1:
                     time.sleep(0.25)
         return self.get_analog_level()

--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -765,7 +765,7 @@ class AWG70K(Base, PulserInterface):
             for chnl in offset:
                 if chnl in chnl_list:
                     ch_num = int(chnl.rsplit('_ch', 1)[1])
-                    off[chnl] = 0.0
+                    off[chnl] = float(self.query('SOUR{0:d}:VOLT:OFFS?'.format(ch_num)))
                 else:
                     self.log.warning('Get analog offset from AWG70k channel "{0}" failed. '
                                      'Channel non-existent.'.format(chnl))


### PR DESCRIPTION
## Description
Fixed a bug when setting the analog level (pp-amplitude and offset) for AWG70k series.

## Motivation and Context
Setting the pp-voltage and/or offset for analog channels in the AWG70k module was not working because of a variable naming bug.

## How Has This Been Tested?
On setup 9 with AWG70002A

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
