### PR TITLE
Bugfix and improvement regarding axis labels and units

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -4,7 +4,8 @@
 
 Changes/New features:
 
-* Improved scientific SpinBox validators to allow for more intuitive keyboard input
+* Added the keyword "labels" to the "measurement_information" dict container in predefined methods.
+This can be used to specify the axis labels for the measurement (excluding units)
 * All modules use new connector style where feasible.
 * Bug fix for POI manager was losing active POI when moving crosshair in confocal
 * Added a how-to-get-started guide to the documentation

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -815,10 +815,14 @@ class PulsedMeasurementGui(GUIBase):
         """
         Initialize the settings dialog for 'Analysis' Tab.
         """
-        self._as.ana_param_x_axis_name_LineEdit.setText(self._ana_param_x_axis_name_text)
-        self._as.ana_param_x_axis_unit_LineEdit.setText(self._ana_param_x_axis_unit_text)
-        self._as.ana_param_y_axis_name_LineEdit.setText(self._ana_param_y_axis_name_text)
-        self._as.ana_param_y_axis_unit_LineEdit.setText(self._ana_param_y_axis_unit_text)
+        self._as.ana_param_x_axis_name_LineEdit.setText(
+            self.pulsedmasterlogic().measurement_settings['labels'][0])
+        self._as.ana_param_x_axis_unit_LineEdit.setText(
+            self.pulsedmasterlogic().measurement_settings['units'][0])
+        self._as.ana_param_y_axis_name_LineEdit.setText(
+            self.pulsedmasterlogic().measurement_settings['labels'][1])
+        self._as.ana_param_y_axis_unit_LineEdit.setText(
+            self.pulsedmasterlogic().measurement_settings['units'][1])
         self._as.ana_param_second_plot_x_axis_name_LineEdit.setText(self._ana_param_second_plot_x_axis_name_text)
         self._as.ana_param_second_plot_x_axis_unit_LineEdit.setText(self._ana_param_second_plot_x_axis_unit_text)
         self._as.ana_param_second_plot_y_axis_name_LineEdit.setText(self._ana_param_second_plot_y_axis_name_text)
@@ -835,24 +839,18 @@ class PulsedMeasurementGui(GUIBase):
 
     def update_analysis_settings(self):
         """ Apply the new settings """
-        self._ana_param_x_axis_name_text = self._as.ana_param_x_axis_name_LineEdit.text()
-        self._ana_param_x_axis_unit_text = self._as.ana_param_x_axis_unit_LineEdit.text()
-        self._ana_param_y_axis_name_text = self._as.ana_param_y_axis_name_LineEdit.text()
-        self._ana_param_y_axis_unit_text = self._as.ana_param_y_axis_unit_LineEdit.text()
+        axis_labels = (self._as.ana_param_x_axis_name_LineEdit.text(),
+                       self._as.ana_param_y_axis_name_LineEdit.text())
+        axis_units = (self._as.ana_param_x_axis_unit_LineEdit.text(),
+                      self._as.ana_param_y_axis_unit_LineEdit.text())
 
         self._ana_param_second_plot_x_axis_name_text = self._as.ana_param_second_plot_x_axis_name_LineEdit.text()
         self._ana_param_second_plot_x_axis_unit_text = self._as.ana_param_second_plot_x_axis_unit_LineEdit.text()
         self._ana_param_second_plot_y_axis_name_text = self._as.ana_param_second_plot_y_axis_name_LineEdit.text()
         self._ana_param_second_plot_y_axis_unit_text = self._as.ana_param_second_plot_y_axis_unit_LineEdit.text()
 
-        self._pa.pulse_analysis_PlotWidget.setLabel(
-            axis='bottom',
-            text=self._ana_param_x_axis_name_text,
-            units=self._ana_param_x_axis_unit_text)
-        self._pa.pulse_analysis_PlotWidget.setLabel(
-            axis='left',
-            text=self._ana_param_y_axis_name_text,
-            units=self._ana_param_y_axis_unit_text)
+        self.pulsedmasterlogic().set_measurement_settings(units=axis_units, labels=axis_labels)
+
         self._pa.pulse_analysis_second_PlotWidget.setLabel(
             axis='bottom',
             text=self._ana_param_second_plot_x_axis_name_text,
@@ -861,22 +859,18 @@ class PulsedMeasurementGui(GUIBase):
             axis='left',
             text=self._ana_param_second_plot_y_axis_name_text,
             units=self._ana_param_second_plot_y_axis_unit_text)
-        self._pe.measuring_error_PlotWidget.setLabel(
-            axis='bottom',
-            text=self._ana_param_x_axis_name_text,
-            units=self._ana_param_x_axis_unit_text)
-
-        # FIXME: Not very elegant
-        self.pulsedmasterlogic().fit_container.set_units(
-            [self._ana_param_x_axis_unit_text, self._ana_param_y_axis_unit_text])
         return
 
     def keep_former_analysis_settings(self):
         """ Keep the old settings """
-        self._as.ana_param_x_axis_name_LineEdit.setText(self._ana_param_x_axis_name_text)
-        self._as.ana_param_x_axis_unit_LineEdit.setText(self._ana_param_x_axis_unit_text)
-        self._as.ana_param_y_axis_name_LineEdit.setText(self._ana_param_y_axis_name_text)
-        self._as.ana_param_y_axis_unit_LineEdit.setText(self._ana_param_y_axis_unit_text)
+        self._as.ana_param_x_axis_name_LineEdit.setText(
+            self.pulsedmasterlogic().measurement_settings['labels'][0])
+        self._as.ana_param_x_axis_unit_LineEdit.setText(
+            self.pulsedmasterlogic().measurement_settings['units'][0])
+        self._as.ana_param_y_axis_name_LineEdit.setText(
+            self.pulsedmasterlogic().measurement_settings['labels'][1])
+        self._as.ana_param_y_axis_unit_LineEdit.setText(
+            self.pulsedmasterlogic().measurement_settings['units'][1])
         self._as.ana_param_second_plot_x_axis_name_LineEdit.setText(
             self._ana_param_second_plot_x_axis_name_text)
         self._as.ana_param_second_plot_x_axis_unit_LineEdit.setText(
@@ -2507,6 +2501,10 @@ class PulsedMeasurementGui(GUIBase):
         self._pa.ana_param_x_axis_inc_ScienDSpinBox.blockSignals(True)
         self._pa.ana_param_invoke_settings_CheckBox.blockSignals(True)
         self._pe.laserpulses_ComboBox.blockSignals(True)
+        self._as.ana_param_x_axis_name_LineEdit.blockSignals(True)
+        self._as.ana_param_x_axis_unit_LineEdit.blockSignals(True)
+        self._as.ana_param_y_axis_name_LineEdit.blockSignals(True)
+        self._as.ana_param_y_axis_unit_LineEdit.blockSignals(True)
 
         # set widgets
         if 'number_of_lasers' in settings_dict:
@@ -2538,8 +2536,29 @@ class PulsedMeasurementGui(GUIBase):
         if 'invoke_settings' in settings_dict:
             self._pa.ana_param_invoke_settings_CheckBox.setChecked(settings_dict['invoke_settings'])
             self.toggle_measurement_settings_editor(settings_dict['invoke_settings'])
+        if 'units' in settings_dict and 'labels' in settings_dict:
+            self._as.ana_param_x_axis_name_LineEdit.setText(settings_dict['labels'][0])
+            self._as.ana_param_x_axis_unit_LineEdit.setText(settings_dict['units'][0])
+            self._as.ana_param_y_axis_name_LineEdit.setText(settings_dict['labels'][1])
+            self._as.ana_param_y_axis_unit_LineEdit.setText(settings_dict['units'][1])
+            self._pa.pulse_analysis_PlotWidget.setLabel(
+                axis='bottom',
+                text=settings_dict['labels'][0],
+                units=settings_dict['units'][0])
+            self._pa.pulse_analysis_PlotWidget.setLabel(
+                axis='left',
+                text=settings_dict['labels'][1],
+                units=settings_dict['units'][1])
+            self._pe.measuring_error_PlotWidget.setLabel(
+                axis='bottom',
+                text=settings_dict['labels'][0],
+                units=settings_dict['units'][0])
 
         # unblock signals
+        self._as.ana_param_x_axis_name_LineEdit.blockSignals(False)
+        self._as.ana_param_x_axis_unit_LineEdit.blockSignals(False)
+        self._as.ana_param_y_axis_name_LineEdit.blockSignals(False)
+        self._as.ana_param_y_axis_unit_LineEdit.blockSignals(False)
         self._pa.ana_param_ignore_first_CheckBox.blockSignals(False)
         self._pa.ana_param_ignore_last_CheckBox.blockSignals(False)
         self._pa.ana_param_alternating_CheckBox.blockSignals(False)

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -823,10 +823,12 @@ class PulsedMeasurementGui(GUIBase):
             self.pulsedmasterlogic().measurement_settings['labels'][1])
         self._as.ana_param_y_axis_unit_LineEdit.setText(
             self.pulsedmasterlogic().measurement_settings['units'][1])
+
         self._as.ana_param_second_plot_x_axis_name_LineEdit.setText(self._ana_param_second_plot_x_axis_name_text)
         self._as.ana_param_second_plot_x_axis_unit_LineEdit.setText(self._ana_param_second_plot_x_axis_unit_text)
         self._as.ana_param_second_plot_y_axis_name_LineEdit.setText(self._ana_param_second_plot_y_axis_name_text)
         self._as.ana_param_second_plot_y_axis_unit_LineEdit.setText(self._ana_param_second_plot_y_axis_unit_text)
+
         self.update_analysis_settings()
         return
 
@@ -844,27 +846,12 @@ class PulsedMeasurementGui(GUIBase):
         axis_units = (self._as.ana_param_x_axis_unit_LineEdit.text(),
                       self._as.ana_param_y_axis_unit_LineEdit.text())
 
-        if self.pulsedmasterlogic().alternative_data_type == 'Delta':
-            self._ana_param_second_plot_x_axis_name_text = self._as.ana_param_x_axis_name_LineEdit.text()
-            self._ana_param_second_plot_x_axis_unit_text = self._as.ana_param_x_axis_unit_LineEdit.text()
-            self._ana_param_second_plot_y_axis_name_text = self._as.ana_param_y_axis_name_LineEdit.text()
-            self._ana_param_second_plot_y_axis_unit_text = self._as.ana_param_y_axis_unit_LineEdit.text()
-        else:
-            self._ana_param_second_plot_x_axis_name_text = self._as.ana_param_second_plot_x_axis_name_LineEdit.text()
-            self._ana_param_second_plot_x_axis_unit_text = self._as.ana_param_second_plot_x_axis_unit_LineEdit.text()
-            self._ana_param_second_plot_y_axis_name_text = self._as.ana_param_second_plot_y_axis_name_LineEdit.text()
-            self._ana_param_second_plot_y_axis_unit_text = self._as.ana_param_second_plot_y_axis_unit_LineEdit.text()
+        self._ana_param_second_plot_x_axis_name_text = self._as.ana_param_second_plot_x_axis_name_LineEdit.text()
+        self._ana_param_second_plot_x_axis_unit_text = self._as.ana_param_second_plot_x_axis_unit_LineEdit.text()
+        self._ana_param_second_plot_y_axis_name_text = self._as.ana_param_second_plot_y_axis_name_LineEdit.text()
+        self._ana_param_second_plot_y_axis_unit_text = self._as.ana_param_second_plot_y_axis_unit_LineEdit.text()
 
         self.pulsedmasterlogic().set_measurement_settings(units=axis_units, labels=axis_labels)
-
-        self._pa.pulse_analysis_second_PlotWidget.setLabel(
-            axis='bottom',
-            text=self._ana_param_second_plot_x_axis_name_text,
-            units=self._ana_param_second_plot_x_axis_unit_text)
-        self._pa.pulse_analysis_second_PlotWidget.setLabel(
-            axis='left',
-            text=self._ana_param_second_plot_y_axis_name_text,
-            units=self._ana_param_second_plot_y_axis_unit_text)
         return
 
     def keep_former_analysis_settings(self):
@@ -2573,6 +2560,8 @@ class PulsedMeasurementGui(GUIBase):
         self._pa.ana_param_x_axis_inc_ScienDSpinBox.blockSignals(False)
         self._pa.ana_param_invoke_settings_CheckBox.blockSignals(False)
         self._pe.laserpulses_ComboBox.blockSignals(False)
+
+        self.second_plot_changed(self.pulsedmasterlogic().alternative_data_type)
         return
 
     def set_plot_dimensions(self):
@@ -2663,7 +2652,26 @@ class PulsedMeasurementGui(GUIBase):
         if second_plot != self.pulsedmasterlogic().alternative_data_type:
             self.pulsedmasterlogic().set_alternative_data_type(second_plot)
 
-        self.update_analysis_settings()
+        if self.pulsedmasterlogic().alternative_data_type == 'Delta':
+            self._ana_param_second_plot_x_axis_name_text = self._as.ana_param_x_axis_name_LineEdit.text()
+            self._ana_param_second_plot_x_axis_unit_text = self._as.ana_param_x_axis_unit_LineEdit.text()
+            self._ana_param_second_plot_y_axis_name_text = self._as.ana_param_y_axis_name_LineEdit.text()
+            self._ana_param_second_plot_y_axis_unit_text = self._as.ana_param_y_axis_unit_LineEdit.text()
+        else:
+            self._ana_param_second_plot_x_axis_name_text = self._as.ana_param_second_plot_x_axis_name_LineEdit.text()
+            self._ana_param_second_plot_x_axis_unit_text = self._as.ana_param_second_plot_x_axis_unit_LineEdit.text()
+            self._ana_param_second_plot_y_axis_name_text = self._as.ana_param_second_plot_y_axis_name_LineEdit.text()
+            self._ana_param_second_plot_y_axis_unit_text = self._as.ana_param_second_plot_y_axis_unit_LineEdit.text()
+
+        self._pa.pulse_analysis_second_PlotWidget.setLabel(
+            axis='bottom',
+            text=self._ana_param_second_plot_x_axis_name_text,
+            units=self._ana_param_second_plot_x_axis_unit_text)
+        self._pa.pulse_analysis_second_PlotWidget.setLabel(
+            axis='left',
+            text=self._ana_param_second_plot_y_axis_name_text,
+            units=self._ana_param_second_plot_y_axis_unit_text)
+
         return
 
     ###########################################################################

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -844,10 +844,16 @@ class PulsedMeasurementGui(GUIBase):
         axis_units = (self._as.ana_param_x_axis_unit_LineEdit.text(),
                       self._as.ana_param_y_axis_unit_LineEdit.text())
 
-        self._ana_param_second_plot_x_axis_name_text = self._as.ana_param_second_plot_x_axis_name_LineEdit.text()
-        self._ana_param_second_plot_x_axis_unit_text = self._as.ana_param_second_plot_x_axis_unit_LineEdit.text()
-        self._ana_param_second_plot_y_axis_name_text = self._as.ana_param_second_plot_y_axis_name_LineEdit.text()
-        self._ana_param_second_plot_y_axis_unit_text = self._as.ana_param_second_plot_y_axis_unit_LineEdit.text()
+        if self.pulsedmasterlogic().alternative_data_type == 'Delta':
+            self._ana_param_second_plot_x_axis_name_text = self._as.ana_param_x_axis_name_LineEdit.text()
+            self._ana_param_second_plot_x_axis_unit_text = self._as.ana_param_x_axis_unit_LineEdit.text()
+            self._ana_param_second_plot_y_axis_name_text = self._as.ana_param_y_axis_name_LineEdit.text()
+            self._ana_param_second_plot_y_axis_unit_text = self._as.ana_param_y_axis_unit_LineEdit.text()
+        else:
+            self._ana_param_second_plot_x_axis_name_text = self._as.ana_param_second_plot_x_axis_name_LineEdit.text()
+            self._ana_param_second_plot_x_axis_unit_text = self._as.ana_param_second_plot_x_axis_unit_LineEdit.text()
+            self._ana_param_second_plot_y_axis_name_text = self._as.ana_param_second_plot_y_axis_name_LineEdit.text()
+            self._ana_param_second_plot_y_axis_unit_text = self._as.ana_param_second_plot_y_axis_unit_LineEdit.text()
 
         self.pulsedmasterlogic().set_measurement_settings(units=axis_units, labels=axis_labels)
 
@@ -2656,6 +2662,8 @@ class PulsedMeasurementGui(GUIBase):
 
         if second_plot != self.pulsedmasterlogic().alternative_data_type:
             self.pulsedmasterlogic().set_alternative_data_type(second_plot)
+
+        self.update_analysis_settings()
         return
 
     ###########################################################################

--- a/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
+++ b/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
@@ -168,6 +168,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         block_ensemble.measurement_information['laser_ignore_list'] = list()
         block_ensemble.measurement_information['controlled_variable'] = tau_array
         block_ensemble.measurement_information['units'] = ('s', '')
+        block_ensemble.measurement_information['labels'] = ('Tau', 'Signal')
         block_ensemble.measurement_information['number_of_lasers'] = num_of_points
         block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
@@ -225,6 +226,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         block_ensemble.measurement_information['laser_ignore_list'] = list()
         block_ensemble.measurement_information['controlled_variable'] = freq_array
         block_ensemble.measurement_information['units'] = ('Hz', '')
+        block_ensemble.measurement_information['labels'] = ('Frequency', 'Signal')
         block_ensemble.measurement_information['number_of_lasers'] = num_of_points
         block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
@@ -305,6 +307,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         block_ensemble.measurement_information['laser_ignore_list'] = list()
         block_ensemble.measurement_information['controlled_variable'] = tau_array
         block_ensemble.measurement_information['units'] = ('s', '')
+        block_ensemble.measurement_information['labels'] = ('Tau', 'Signal')
         block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
         block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
@@ -389,6 +392,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         block_ensemble.measurement_information['laser_ignore_list'] = list()
         block_ensemble.measurement_information['controlled_variable'] = tau_array
         block_ensemble.measurement_information['units'] = ('s', '')
+        block_ensemble.measurement_information['labels'] = ('Tau', 'Signal')
         block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
         block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
@@ -477,6 +481,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         block_ensemble.measurement_information['laser_ignore_list'] = list()
         block_ensemble.measurement_information['controlled_variable'] = tau_array
         block_ensemble.measurement_information['units'] = ('s', '')
+        block_ensemble.measurement_information['labels'] = ('Tau', 'Signal')
         block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
         block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
@@ -571,6 +576,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         block_ensemble.measurement_information['laser_ignore_list'] = list()
         block_ensemble.measurement_information['controlled_variable'] = tau_array
         block_ensemble.measurement_information['units'] = ('s', '')
+        block_ensemble.measurement_information['labels'] = ('Tau', 'Signal')
         block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
         block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
@@ -634,6 +640,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         block_ensemble.measurement_information['laser_ignore_list'] = list()
         block_ensemble.measurement_information['controlled_variable'] = tau_array
         block_ensemble.measurement_information['units'] = ('s', '')
+        block_ensemble.measurement_information['labels'] = ('Tau', 'Signal')
         block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
         block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
@@ -701,6 +708,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         block_ensemble.measurement_information['laser_ignore_list'] = list()
         block_ensemble.measurement_information['controlled_variable'] = tau_array
         block_ensemble.measurement_information['units'] = ('s', '')
+        block_ensemble.measurement_information['labels'] = ('Tau', 'Signal')
         block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
         block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
@@ -782,6 +790,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         block_ensemble.measurement_information['laser_ignore_list'] = list()
         block_ensemble.measurement_information['controlled_variable'] = amp_array
         block_ensemble.measurement_information['units'] = ('V', '')
+        block_ensemble.measurement_information['labels'] = ('MW amplitude', 'Signal')
         block_ensemble.measurement_information['number_of_lasers'] = 2 * num_of_points
         block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
@@ -863,6 +872,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         block_ensemble.measurement_information['laser_ignore_list'] = list()
         block_ensemble.measurement_information['controlled_variable'] = tau_array
         block_ensemble.measurement_information['units'] = ('s', '')
+        block_ensemble.measurement_information['labels'] = ('Spinlock time', 'Signal')
         block_ensemble.measurement_information['number_of_lasers'] = 2 * num_of_points
         block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
@@ -948,6 +958,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         block_ensemble.measurement_information['laser_ignore_list'] = list()
         block_ensemble.measurement_information['controlled_variable'] = steps_array
         block_ensemble.measurement_information['units'] = ('#', '')
+        block_ensemble.measurement_information['labels'] = ('Polarization Steps', 'Signal')
         block_ensemble.measurement_information['number_of_lasers'] = 2 * polarization_steps
         block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
@@ -1077,6 +1088,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         block_ensemble.measurement_information['laser_ignore_list'] = list()
         block_ensemble.measurement_information['controlled_variable'] = tau_array
         block_ensemble.measurement_information['units'] = ('s', '')
+        block_ensemble.measurement_information['labels'] = ('Tau', 'Signal')
         block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
         block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)
@@ -1212,6 +1224,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         block_ensemble.measurement_information['laser_ignore_list'] = list()
         block_ensemble.measurement_information['controlled_variable'] = freq_array
         block_ensemble.measurement_information['units'] = ('Hz', '')
+        block_ensemble.measurement_information['labels'] = ('Frequency', 'Signal')
         block_ensemble.measurement_information['number_of_lasers'] = number_of_lasers
         block_ensemble.measurement_information['counting_length'] = self._get_ensemble_count_length(
             ensemble=block_ensemble, created_blocks=created_blocks)

--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -1373,7 +1373,7 @@ class PulsedMeasurementLogic(GenericLogic):
                 y_axis_ft_label = 'FT({0}) (arb. u.)'.format(self._data_labels[1])
                 ft_label = 'FT of data trace 1'
             else:
-                if self._data_units[1]:
+                if self._data_units[0]:
                     x_axis_ft_label = '{0} ({1})'.format(self._data_labels[0], self._data_units[0])
                 else:
                     x_axis_ft_label = '{0}'.format(self._data_labels[0])


### PR DESCRIPTION
## Description
The handling of axis units and labels in pulsed measurements has been a bit buggy. The "units" entry in the measurement_information dictionary (in predefined methods) has previously been ignored by the GUI.
Now it is not only properly handled but you can additionally set the axis label as well by using this dictionary container with the keyword "labels" (similar to the "units" keyword it requires a pair of strings as values).
Also removed the axis labels and units StatusVars from the GUI. This was redundant with the PulsedMeasurementLogic StatusVars.

## How Has This Been Tested?
Dummy on Win8.1 x64

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
