### PR TITLE
Spinbox unit prefix

### DIFF
--- a/config/example/default.cfg
+++ b/config/example/default.cfg
@@ -341,6 +341,7 @@ gui:
         image_x_padding: 0.02
         image_y_padding: 0.02
         image_z_padding: 0.02
+        default_meter_prefix: 'u'
 
     poimanager:
         module.Class: 'poimanager.poimangui.PoiManagerGui'

--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -485,16 +485,16 @@ class ConfocalGui(GUIBase):
         self._mw.z_max_InputWidget.setValue(self._scanning_logic.image_z_range[1])
 
         if self.default_meter_prefix:
-            self._mw.x_current_InputWidget.fixed_unit_prefix = self.default_meter_prefix
-            self._mw.y_current_InputWidget.fixed_unit_prefix = self.default_meter_prefix
-            self._mw.z_current_InputWidget.fixed_unit_prefix = self.default_meter_prefix
+            self._mw.x_current_InputWidget.assumed_unit_prefix = self.default_meter_prefix
+            self._mw.y_current_InputWidget.assumed_unit_prefix = self.default_meter_prefix
+            self._mw.z_current_InputWidget.assumed_unit_prefix = self.default_meter_prefix
 
-            self._mw.x_min_InputWidget.fixed_unit_prefix = self.default_meter_prefix
-            self._mw.x_max_InputWidget.fixed_unit_prefix = self.default_meter_prefix
-            self._mw.y_min_InputWidget.fixed_unit_prefix = self.default_meter_prefix
-            self._mw.y_max_InputWidget.fixed_unit_prefix = self.default_meter_prefix
-            self._mw.z_min_InputWidget.fixed_unit_prefix = self.default_meter_prefix
-            self._mw.z_max_InputWidget.fixed_unit_prefix = self.default_meter_prefix
+            self._mw.x_min_InputWidget.assumed_unit_prefix = self.default_meter_prefix
+            self._mw.x_max_InputWidget.assumed_unit_prefix = self.default_meter_prefix
+            self._mw.y_min_InputWidget.assumed_unit_prefix = self.default_meter_prefix
+            self._mw.y_max_InputWidget.assumed_unit_prefix = self.default_meter_prefix
+            self._mw.z_min_InputWidget.assumed_unit_prefix = self.default_meter_prefix
+            self._mw.z_max_InputWidget.assumed_unit_prefix = self.default_meter_prefix
 
         # Handle slider movements by user:
         self._mw.x_SliderWidget.sliderMoved.connect(self.update_from_slider_x)

--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -198,6 +198,8 @@ class ConfocalGui(GUIBase):
     image_y_padding = ConfigOption('image_y_padding', 0.02)
     image_z_padding = ConfigOption('image_z_padding', 0.02)
 
+    default_meter_prefix = ConfigOption('default_meter_prefix', None)  # assume the unit prefix of position spinbox
+
     # status var
     adjust_cursor_roi = StatusVar(default=True)
     slider_small_step = StatusVar(default=10e-9)    # initial value in meter
@@ -481,6 +483,18 @@ class ConfocalGui(GUIBase):
         self._mw.y_max_InputWidget.setValue(self._scanning_logic.image_y_range[1])
         self._mw.z_min_InputWidget.setValue(self._scanning_logic.image_z_range[0])
         self._mw.z_max_InputWidget.setValue(self._scanning_logic.image_z_range[1])
+
+        if self.default_meter_prefix:
+            self._mw.x_current_InputWidget.fixed_unit_prefix = self.default_meter_prefix
+            self._mw.y_current_InputWidget.fixed_unit_prefix = self.default_meter_prefix
+            self._mw.z_current_InputWidget.fixed_unit_prefix = self.default_meter_prefix
+
+            self._mw.x_min_InputWidget.fixed_unit_prefix = self.default_meter_prefix
+            self._mw.x_max_InputWidget.fixed_unit_prefix = self.default_meter_prefix
+            self._mw.y_min_InputWidget.fixed_unit_prefix = self.default_meter_prefix
+            self._mw.y_max_InputWidget.fixed_unit_prefix = self.default_meter_prefix
+            self._mw.z_min_InputWidget.fixed_unit_prefix = self.default_meter_prefix
+            self._mw.z_max_InputWidget.fixed_unit_prefix = self.default_meter_prefix
 
         # Handle slider movements by user:
         self._mw.x_SliderWidget.sliderMoved.connect(self.update_from_slider_x)

--- a/qtwidgets/scientific_spinbox.py
+++ b/qtwidgets/scientific_spinbox.py
@@ -230,6 +230,7 @@ class ScienDSpinBox(QtWidgets.QAbstractSpinBox):
         self.__cached_value = None  # a temporary variable for restore functionality
         self._dynamic_stepping = True
         self._dynamic_precision = True
+        self._fixed_unit_prefix = None # To use only one unit prefix for the view and assume it at input
         self._is_valid = True  # A flag property to check if the current value is valid.
         self.validator = FloatValidator()
         self.lineEdit().textEdited.connect(self.update_value)
@@ -276,6 +277,25 @@ class ScienDSpinBox(QtWidgets.QAbstractSpinBox):
         """
         use_dynamic_precision = bool(use_dynamic_precision)
         self._dynamic_precision = use_dynamic_precision
+
+    @property
+    def fixed_unit_prefix(self):
+        """
+        This property can fix a default unit prefix that is used for GUI and assumed at text input.
+
+        @return: None or prefix string
+        """
+        return self._fixed_unit_prefix
+
+    @fixed_unit_prefix.setter
+    def fixed_unit_prefix(self, unit_prefix):
+        """
+        This property can fix a default unit prefix that is used for GUI and assumed at text input.
+
+        @param unit_prefix: None or unit prefix in the dictionary
+        """
+        if unit_prefix is None or unit_prefix in self._unit_prefix_dict:
+            self._fixed_unit_prefix = unit_prefix
 
     @property
     def is_valid(self):
@@ -761,6 +781,8 @@ class ScienDSpinBox(QtWidgets.QAbstractSpinBox):
         si_prefix = group_dict['si']
         if si_prefix is None:
             si_prefix = ''
+        if si_prefix == '' and self.fixed_unit_prefix is not None:
+            si_prefix = self.fixed_unit_prefix
         si_scale = self._unit_prefix_dict[si_prefix.replace('u', 'µ')]
 
         if group_dict['sign'] is not None:

--- a/qtwidgets/scientific_spinbox.py
+++ b/qtwidgets/scientific_spinbox.py
@@ -296,6 +296,8 @@ class ScienDSpinBox(QtWidgets.QAbstractSpinBox):
         """
         if unit_prefix is None or unit_prefix in self._unit_prefix_dict:
             self._fixed_unit_prefix = unit_prefix
+        if unit_prefix == 'u':  # in case of encoding problems
+            self._fixed_unit_prefix = 'µ'
 
     @property
     def is_valid(self):

--- a/qtwidgets/scientific_spinbox.py
+++ b/qtwidgets/scientific_spinbox.py
@@ -230,7 +230,7 @@ class ScienDSpinBox(QtWidgets.QAbstractSpinBox):
         self.__cached_value = None  # a temporary variable for restore functionality
         self._dynamic_stepping = True
         self._dynamic_precision = True
-        self._assumed_unit_prefix = None # To assume one prefix at unit
+        self._assumed_unit_prefix = None  # To assume one prefix. This is only used if no prefix would be out of range
         self._is_valid = True  # A flag property to check if the current value is valid.
         self.validator = FloatValidator()
         self.lineEdit().textEdited.connect(self.update_value)
@@ -329,7 +329,10 @@ class ScienDSpinBox(QtWidgets.QAbstractSpinBox):
         if value is False:
             return
         value, in_range = self.check_range(value)
-
+        # if the value is out of range, then only use assumed unit prefix
+        if not in_range and self._assumed_unit_prefix is not None:
+            value = self.valueFromText(text, use_assumed_unit_prefix=True)
+            value, in_range = self.check_range(value)
         # save old value to be able to restore it later on
         if self.__cached_value is None:
             self.__cached_value = self.__value
@@ -754,7 +757,7 @@ class ScienDSpinBox(QtWidgets.QAbstractSpinBox):
         """
         return self.validator.fixup(text)
 
-    def valueFromText(self, text):
+    def valueFromText(self, text, use_assumed_unit_prefix=False):
         """
         This method is responsible for converting a string displayed in the SpinBox into a Decimal.
 
@@ -783,7 +786,7 @@ class ScienDSpinBox(QtWidgets.QAbstractSpinBox):
         si_prefix = group_dict['si']
         if si_prefix is None:
             si_prefix = ''
-        if si_prefix == '' and self._assumed_unit_prefix is not None:
+        if si_prefix == '' and use_assumed_unit_prefix and self._assumed_unit_prefix is not None:
             si_prefix = self._assumed_unit_prefix
         si_scale = self._unit_prefix_dict[si_prefix.replace('u', 'µ')]
 

--- a/qtwidgets/scientific_spinbox.py
+++ b/qtwidgets/scientific_spinbox.py
@@ -230,7 +230,7 @@ class ScienDSpinBox(QtWidgets.QAbstractSpinBox):
         self.__cached_value = None  # a temporary variable for restore functionality
         self._dynamic_stepping = True
         self._dynamic_precision = True
-        self._fixed_unit_prefix = None # To use only one unit prefix for the view and assume it at input
+        self._assumed_unit_prefix = None # To assume one prefix at unit
         self._is_valid = True  # A flag property to check if the current value is valid.
         self.validator = FloatValidator()
         self.lineEdit().textEdited.connect(self.update_value)
@@ -279,25 +279,25 @@ class ScienDSpinBox(QtWidgets.QAbstractSpinBox):
         self._dynamic_precision = use_dynamic_precision
 
     @property
-    def fixed_unit_prefix(self):
+    def assumed_unit_prefix(self):
         """
-        This property can fix a default unit prefix that is used for GUI and assumed at text input.
+        This property can fix a default unit prefix that is used for text input.
 
         @return: None or prefix string
         """
-        return self._fixed_unit_prefix
+        return self._assumed_unit_prefix
 
-    @fixed_unit_prefix.setter
-    def fixed_unit_prefix(self, unit_prefix):
+    @assumed_unit_prefix.setter
+    def assumed_unit_prefix(self, unit_prefix):
         """
-        This property can fix a default unit prefix that is used for GUI and assumed at text input.
+        This property can fix a default unit prefix that is used for text input.
 
         @param unit_prefix: None or unit prefix in the dictionary
         """
         if unit_prefix is None or unit_prefix in self._unit_prefix_dict:
-            self._fixed_unit_prefix = unit_prefix
+            self._assumed_unit_prefix = unit_prefix
         if unit_prefix == 'u':  # in case of encoding problems
-            self._fixed_unit_prefix = 'µ'
+            self._assumed_unit_prefix = 'µ'
 
     @property
     def is_valid(self):
@@ -783,8 +783,8 @@ class ScienDSpinBox(QtWidgets.QAbstractSpinBox):
         si_prefix = group_dict['si']
         if si_prefix is None:
             si_prefix = ''
-        if si_prefix == '' and self.fixed_unit_prefix is not None:
-            si_prefix = self.fixed_unit_prefix
+        if si_prefix == '' and self._assumed_unit_prefix is not None:
+            si_prefix = self._assumed_unit_prefix
         si_scale = self._unit_prefix_dict[si_prefix.replace('u', 'µ')]
 
         if group_dict['sign'] is not None:


### PR DESCRIPTION
I've added a feature to the scientific spinbox to have a default prefix.

## Description
The GUI module can set the _assumed_unit_prefix of a spinbox so that a prefix is assumed if none is provided.

## Motivation and Context
For some module, like confocal scan, unit is almost the same. This let the user use the config file to change a spinbox's behavior if this is supported by the GUI module.

## How Has This Been Tested?
I've checked that this does what it's supposed to on a real setup.


## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
