### PR TITLE
Add command line argument --logdir to configure the path for qudi logfiles

### DIFF
--- a/core/__main__.py
+++ b/core/__main__.py
@@ -48,12 +48,13 @@ parser.add_argument('-m', '--manhole', action='store_true',
 parser.add_argument('-g', '--no-gui', action='store_true',
         help='does not load the manager gui module')
 parser.add_argument('-c', '--config', default='', help='configuration file')
+parser.add_argument('-l', '--logdir', default='', help='log directory')
 args = parser.parse_args()
 
 
 # install logging facility
 from .logger import initialize_logger
-initialize_logger()
+initialize_logger(args.logdir)
 import logging
 logger = logging.getLogger(__name__)
 logger.info('Loading Qudi...')

--- a/core/logger.py
+++ b/core/logger.py
@@ -27,6 +27,7 @@ Originally distributed under MIT/X11 license. See documentation/MITLicense.txt f
 
 import logging
 import logging.handlers
+import os
 import sys
 import traceback
 import functools
@@ -112,7 +113,7 @@ class QtLogHandler(QtCore.QObject, logging.Handler):
             self.sigLoggedMessage.emit(record)
 
 
-def initialize_logger():
+def initialize_logger(path=''):
     """sets up the logger including a console, file and qt handler
     """
     # initialize logger
@@ -130,8 +131,9 @@ def initialize_logger():
     logger.handlers[0].setLevel(logging.WARNING)
 
     # add file logger
+    logfile_path = os.path.join(path, 'qudi.log')
     rotating_file_handler = logging.handlers.RotatingFileHandler(
-        'qudi.log', maxBytes=10*1024*1024, backupCount=5)
+        logfile_path, maxBytes=10*1024*1024, backupCount=5)
     rotating_file_handler.setFormatter(logging.Formatter(
         '%(asctime)s %(levelname)s %(name)s %(message)s',
         datefmt="%Y-%m-%d %H:%M:%S"))

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -4,7 +4,7 @@
 
 Changes/New features:
 
-* Added command line argument --logfile to specify the path to the logging directory
+* Added command line argument --logdir to specify the path to the logging directory
 * Added the keyword "labels" to the "measurement_information" dict container in predefined methods.
 This can be used to specify the axis labels for the measurement (excluding units)
 * All modules use new connector style where feasible.

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -4,6 +4,7 @@
 
 Changes/New features:
 
+* Added command line argument --logfile to specify the path to the logging directory
 * Added the keyword "labels" to the "measurement_information" dict container in predefined methods.
 This can be used to specify the axis labels for the measurement (excluding units)
 * All modules use new connector style where feasible.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Qudi writes logfiles to the current working directory, which is usually the qudi base directory. In this PR, I added the command line argument --logdir to make this path configurable. The default location is still the current working directory, so the change won't break anything.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I made this change for two reasons:
- It is good practice to make such paths configurable
- In my setup, I install qudi in a system-wide location and want to write logfiles in the current user's home directory

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Running qudi with and without the --logdir flag

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
