### PR TITLE
save_logic now expands environment variables in data path

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -4,7 +4,7 @@
 
 Changes/New features:
 
-* Save_logic now expands environment variables in the configured data path
+* Save_logic now expands environment variables in the configured data path (e.g. $HOME under Unix or $HOMEPATH under Windows)
 * Added command line argument --logdir to specify the path to the logging directory
 * Added the keyword "labels" to the "measurement_information" dict container in predefined methods.
 This can be used to specify the axis labels for the measurement (excluding units)

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -4,6 +4,7 @@
 
 Changes/New features:
 
+* Save_logic now expands environment variables in the configured data path
 * Added command line argument --logdir to specify the path to the logging directory
 * Added the keyword "labels" to the "measurement_information" dict container in predefined methods.
 This can be used to specify the axis labels for the measurement (excluding units)

--- a/logic/save_logic.py
+++ b/logic/save_logic.py
@@ -178,6 +178,9 @@ class SaveLogic(GenericLogic):
         else:
             raise Exception('Identify the operating system.')
 
+        # Expand environment variables in the data_dir path (e.g. $HOME)
+        self.data_dir = os.path.expandvars(self.data_dir)
+
         # start logging into daily directory?
         if not isinstance(self.log_into_daily_directory, bool):
                 self.log.warning(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In the configuration section for the save_logic module, there are two options for setting the directory in which qudi saves all data files:
- win_data_directory (for Windows)
- unix_data_directory (for Unix)
In the current implementation, the path is just a string. It is very common, especially under linux os, to use environment variables when specifying a path (e.g. $HOME).

This PR adds a simple fix to this issue by expanding environment variables in the data path for both windows and unix using the python library function [os.path.expandvars](https://docs.python.org/3/library/os.path.html#os.path.expandvars).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested using the following value for unix_data_directory in the config file: '$HOME/Data'.
Data was written in the correct directory under the current user home.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
