### PR TITLE
PulseSequence object improvement

### DIFF
--- a/gui/pulsed/pulse_editors.py
+++ b/gui/pulsed/pulse_editors.py
@@ -985,8 +985,8 @@ class SequenceEditorTableModel(QtCore.QAbstractTableModel):
 
         # Remove ensembles from list that are not there anymore
         rows_to_remove = list()
-        for row, (ensemble_name, params) in enumerate(self._pulse_sequence):
-            if ensemble_name not in ensembles:
+        for row, seq_step in enumerate(self._pulse_sequence):
+            if seq_step.ensemble not in ensembles:
                 rows_to_remove.append(row)
         for row in reversed(rows_to_remove):
             self.removeRows(row, 1)
@@ -1024,21 +1024,21 @@ class SequenceEditorTableModel(QtCore.QAbstractTableModel):
             return None
 
         if role == self.repetitionsRole:
-            return self._pulse_sequence[index.row()][1].get('repetitions')
+            return self._pulse_sequence[index.row()].repetitions
         elif role == self.ensembleNameRole:
-            return self._pulse_sequence[index.row()][0]
+            return self._pulse_sequence[index.row()].ensemble
         elif role == self.goToRole:
-            return self._pulse_sequence[index.row()][1].get('go_to')
+            return self._pulse_sequence[index.row()].go_to
         elif role == self.eventJumpToRole:
-            return self._pulse_sequence[index.row()][1].get('event_jump_to')
+            return self._pulse_sequence[index.row()].event_jump_to
         elif role == self.eventTriggerRole:
-            return self._pulse_sequence[index.row()][1].get('event_trigger')
+            return self._pulse_sequence[index.row()].event_trigger
         elif role == self.waitForRole:
-            return self._pulse_sequence[index.row()][1].get('wait_for')
+            return self._pulse_sequence[index.row()].wait_for
         elif role == self.flagTriggerRole:
-            return self._pulse_sequence[index.row()][1].get('flag_trigger')
+            return self._pulse_sequence[index.row()].flag_trigger
         elif role == self.flagHighRole:
-            return self._pulse_sequence[index.row()][1].get('flag_high')
+            return self._pulse_sequence[index.row()].flag_high
         else:
             return None
 
@@ -1046,25 +1046,24 @@ class SequenceEditorTableModel(QtCore.QAbstractTableModel):
         """
         """
         if role == self.ensembleNameRole and isinstance(data, str):
-            params = self._pulse_sequence[index.row()][1]
-            self._pulse_sequence[index.row()] = (data, params)
+            self._pulse_sequence[index.row()].ensemble = data
         elif role == self.repetitionsRole and isinstance(data, int):
-            self._pulse_sequence[index.row()][1]['repetitions'] = data
+            self._pulse_sequence[index.row()].repetitions = data
         elif role == self.goToRole and isinstance(data, int):
-            self._pulse_sequence[index.row()][1]['go_to'] = data
+            self._pulse_sequence[index.row()].go_to = data
         elif role == self.eventJumpToRole and isinstance(data, int):
-            self._pulse_sequence[index.row()][1]['event_jump_to'] = data
+            self._pulse_sequence[index.row()].event_jump_to = data
         elif role == self.eventTriggerRole and isinstance(data, str):
-            self._pulse_sequence[index.row()][1]['event_trigger'] = data
+            self._pulse_sequence[index.row()].event_trigger = data
         elif role == self.waitForRole and isinstance(data, str):
-            self._pulse_sequence[index.row()][1]['wait_for'] = data
+            self._pulse_sequence[index.row()].wait_for = data
         elif role == self.flagTriggerRole and isinstance(data, str):
-            self._pulse_sequence[index.row()][1]['flag_trigger'] = data
+            self._pulse_sequence[index.row()].flag_trigger = data
         elif role == self.flagHighRole and isinstance(data, str):
-            self._pulse_sequence[index.row()][1]['flag_high'] = data
+            self._pulse_sequence[index.row()].flag_high = data
         elif role == self.sequenceRole and isinstance(data, PulseSequence):
-            self._pulse_sequence = copy.deepcopy(data)
-            self._pulse_sequence.name = 'EDITOR CONTAINER'
+            self._pulse_sequence = PulseSequence('EDITOR CONTAINER')
+            self._pulse_sequence.extend(data.ensemble_list)
         return
 
     def headerData(self, section, orientation, role):

--- a/gui/pulsed/pulse_editors.py
+++ b/gui/pulsed/pulse_editors.py
@@ -1163,13 +1163,16 @@ class SequenceEditor(QtWidgets.QTableView):
                                                               self.model().ensembleNameRole,
                                                               QtCore.QSize(100, 50)))
         # Set item delegate (SpinBoxes) for repetition column
-        self.setItemDelegateForColumn(1, SpinBoxItemDelegate(self, {'init_val': 1, 'min': -1},
+        self.setItemDelegateForColumn(1, SpinBoxItemDelegate(self, {'init_val': 1, 'min': -1,
+                                                                    'max': 2 ** 31 - 1},
                                                              self.model().repetitionsRole))
         # Set item delegate (SpinBoxes) for go_to column
-        self.setItemDelegateForColumn(2, SpinBoxItemDelegate(self, {'init_val': -1, 'min': -1},
+        self.setItemDelegateForColumn(2, SpinBoxItemDelegate(self, {'init_val': -1, 'min': -1,
+                                                                    'max': 2 ** 31 - 1},
                                                              self.model().goToRole))
         # Set item delegate (SpinBoxes) for event_jump_to column
-        self.setItemDelegateForColumn(3, SpinBoxItemDelegate(self, {'init_val': -1, 'min': -1},
+        self.setItemDelegateForColumn(3, SpinBoxItemDelegate(self, {'init_val': -1, 'min': -1,
+                                                                    'max': 2 ** 31 - 1},
                                                              self.model().eventJumpToRole))
         # Set item delegate (ComboBox) for event_trigger column
         self.setItemDelegateForColumn(4, ComboBoxItemDelegate(self, ['OFF'],
@@ -1317,9 +1320,7 @@ class SequenceEditor(QtWidgets.QTableView):
         @return: object, an instance of PulseSequence
         """
         data_container = self.model().data(QtCore.QModelIndex(), self.model().sequenceRole)
-        sequence_copy = copy.deepcopy(data_container)
-        sequence_copy.name = ''
-        sequence_copy.refresh_parameters()
+        sequence_copy = PulseSequence('', ensemble_list=data_container.ensemble_list)
         return sequence_copy
 
     def load_sequence(self, pulse_sequence):

--- a/gui/pulsed/pulsed_item_delegates.py
+++ b/gui/pulsed/pulsed_item_delegates.py
@@ -20,6 +20,7 @@ Copyright (c) the Qudi Developers. See the COPYRIGHT.txt file at the
 top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi/>
 """
 
+import numpy as np
 from qtpy import QtCore, QtGui, QtWidgets
 from gui.pulsed.pulsed_custom_widgets import DigitalChannelsWidget, AnalogParametersWidget
 from qtwidgets.scientific_spinbox import ScienDSpinBox
@@ -196,10 +197,10 @@ class SpinBoxItemDelegate(QtGui.QStyledItemDelegate):
         understood by the editor.
         """
         data = index.data(self._access_role)
-        if not isinstance(data, int):
+        if not isinstance(data, (np.integer, int)):
             data = self.item_dict['init_val']
         editor.blockSignals(True)
-        editor.setValue(data)
+        editor.setValue(int(data))
         editor.blockSignals(False)
         return
 

--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -1221,7 +1221,7 @@ class AWG70K(Base, PulserInterface):
                                                                           waveform_name))
         return 0
 
-    def sequence_set_repetitions(self, sequence_name, step, repeat=1):
+    def sequence_set_repetitions(self, sequence_name, step, repeat=0):
         """
         Set the repetition counter of sequence "sequence_name" at step "step" to "repeat".
         A repeat value of -1 denotes infinite repetitions; 0 means the step is played once.
@@ -1236,7 +1236,7 @@ class AWG70K(Base, PulserInterface):
             self.log.error('Direct sequence generation in AWG not possible. '
                            'Sequencer option not installed.')
             return -1
-        repeat = 'INF' if repeat < 0 else str(int(repeat))
+        repeat = 'INF' if repeat < 0 else str(int(repeat + 1))
         self.write('SLIS:SEQ:STEP{0:d}:RCO "{1}", {2}'.format(step, sequence_name, repeat))
         return 0
 

--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -346,7 +346,7 @@ class AWG70K(Base, PulserInterface):
                 mrk_bytes = digital_samples[mrk_ch_1].view('uint8')
             else:
                 mrk_bytes = None
-            print('Prepare digital channel data: {0}'.format(time.time()-start))
+            self.log.debug('Prepare digital channel data: {0}'.format(time.time()-start))
 
             # Create waveform name string
             wfm_name = '{0}_ch{1:d}'.format(name, a_ch_num)
@@ -363,12 +363,12 @@ class AWG70K(Base, PulserInterface):
                              is_first_chunk=is_first_chunk,
                              is_last_chunk=is_last_chunk,
                              total_number_of_samples=total_number_of_samples)
-            print('Write WFMX file: {0}'.format(time.time() - start))
+            self.log.debug('Write WFMX file: {0}'.format(time.time() - start))
 
             # transfer waveform to AWG and load into workspace
             start = time.time()
             self._send_file(filename=wfm_name + '.wfmx')
-            print('Send WFMX file: {0}'.format(time.time() - start))
+            self.log.debug('Send WFMX file: {0}'.format(time.time() - start))
 
             start = time.time()
             self.write('MMEM:OPEN "{0}"'.format(os.path.join(
@@ -379,7 +379,7 @@ class AWG70K(Base, PulserInterface):
             # Just to make sure
             while wfm_name not in self.get_waveform_names():
                 time.sleep(0.25)
-            print('Load WFMX file into workspace: {0}'.format(time.time() - start))
+            self.log.debug('Load WFMX file into workspace: {0}'.format(time.time() - start))
 
             # Append created waveform name to waveform list
             waveforms.append(wfm_name)

--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -95,6 +95,8 @@ class AWG70K(Base, PulserInterface):
             self.awg_model = self.query('*IDN?').split(',')[1]
         else:
             self.awg_model = ''
+
+        self.__min_waveform_length = int(self.query('WLIS:WAV:LMIN?'))
         return
 
     def on_deactivate(self):
@@ -164,7 +166,10 @@ class AWG70K(Base, PulserInterface):
         constraints.d_ch_high.step = 0.1
         constraints.d_ch_high.default = 1.0
 
-        constraints.waveform_length.min = 4800
+        if self.awg_model == 'AWG70002A':
+            constraints.waveform_length.min = 2400
+        elif self.awg_model == 'AWG70001A':
+            constraints.waveform_length.min = 4800
         constraints.waveform_length.max = 8000000000
         constraints.waveform_length.step = 1
         constraints.waveform_length.default = 1

--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -164,7 +164,7 @@ class AWG70K(Base, PulserInterface):
         constraints.d_ch_high.step = 0.1
         constraints.d_ch_high.default = 1.0
 
-        constraints.waveform_length.min = 1
+        constraints.waveform_length.min = 4800
         constraints.waveform_length.max = 8000000000
         constraints.waveform_length.step = 1
         constraints.waveform_length.default = 1

--- a/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
+++ b/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
@@ -1283,7 +1283,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         count_length = 0.0
         for k in k_array:
             t1_sequence.append(tau_ensemble.name)
-            t1_sequence[-1].repetitions = k
+            t1_sequence[-1].repetitions = int(k)
             count_length += k * self._get_ensemble_count_length(ensemble=tau_ensemble,
                                                                 created_blocks=created_blocks)
 
@@ -1291,6 +1291,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
             count_length += self._get_ensemble_count_length(ensemble=readout_ensemble,
                                                             created_blocks=created_blocks)
         if self.sync_channel:
+            print('AAAAAAAAAAAAA')
             t1_sequence.append(sync_ensemble.name)
             t1_sequence[-1].go_to = 1
             count_length += self._get_ensemble_count_length(ensemble=sync_ensemble,

--- a/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
+++ b/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
@@ -1283,7 +1283,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         count_length = 0.0
         for k in k_array:
             t1_sequence.append(tau_ensemble.name)
-            t1_sequence[-1].repetitions = int(k)
+            t1_sequence[-1].repetitions = int(k) - 1
             count_length += k * self._get_ensemble_count_length(ensemble=tau_ensemble,
                                                                 created_blocks=created_blocks)
 
@@ -1291,7 +1291,6 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
             count_length += self._get_ensemble_count_length(ensemble=readout_ensemble,
                                                             created_blocks=created_blocks)
         if self.sync_channel:
-            print('AAAAAAAAAAAAA')
             t1_sequence.append(sync_ensemble.name)
             t1_sequence[-1].go_to = 1
             count_length += self._get_ensemble_count_length(ensemble=sync_ensemble,

--- a/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
+++ b/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
@@ -21,7 +21,7 @@ top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi
 """
 
 import numpy as np
-from logic.pulsed.pulse_objects import PulseBlock, PulseBlockEnsemble
+from logic.pulsed.pulse_objects import PulseBlock, PulseBlockEnsemble, PulseSequence
 from logic.pulsed.pulse_objects import PredefinedGeneratorBase
 
 """
@@ -45,6 +45,9 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+    ################################################################################################
+    #                             Generation methods for waveforms                                 #
+    ################################################################################################
     def generate_laser_on(self, name='laser_on', length=3.0e-6):
         """ Generates Laser on.
 
@@ -1218,4 +1221,92 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
 
         # append ensemble to created ensembles
         created_ensembles.append(block_ensemble)
+        return created_blocks, created_ensembles, created_sequences
+
+    ################################################################################################
+    #                             Generation methods for sequences                                 #
+    ################################################################################################
+    def generate_t1_sequencing(self, name='t1_seq', tau_start=1.0e-6, tau_max=1.0e-3,
+                               num_of_points=10):
+        """
+
+        """
+        created_blocks = list()
+        created_ensembles = list()
+        created_sequences = list()
+
+        # Get logarithmically spaced steps in multiples of tau_start.
+        # Note that the number of points and the position of the last point can change here.
+        k_array = np.unique(
+            np.rint(np.logspace(0., np.log10(tau_max / tau_start), num_of_points)).astype(int))
+        # get tau array for measurement ticks
+        tau_array = k_array * tau_start
+
+        # Create the readout PulseBlockEnsemble
+        # Get necessary PulseBlockElements
+        laser_element = self._get_laser_gate_element(length=self.laser_length,  increment=0)
+        delay_element = self._get_delay_gate_element()
+        # Create PulseBlock and append PulseBlockElements
+        readout_block = PulseBlock(name='{0}_readout'.format(name))
+        readout_block.append(laser_element)
+        readout_block.append(delay_element)
+        created_blocks.append(readout_block)
+        # Create PulseBlockEnsemble and append block to it
+        readout_ensemble = PulseBlockEnsemble(name='{0}_readout'.format(name), rotating_frame=False)
+        readout_ensemble.append((readout_block.name, 0))
+        created_ensembles.append(readout_ensemble)
+
+        # Create the tau/waiting PulseBlockEnsemble
+        # Get tau PulseBlockElement
+        tau_element = self._get_idle_element(length=tau_start, increment=0)
+        # Create PulseBlock and append PulseBlockElements
+        tau_block = PulseBlock(name='{0}_tau'.format(name))
+        tau_block.append(tau_element)
+        created_blocks.append(tau_block)
+        # Create PulseBlockEnsemble and append block to it
+        tau_ensemble = PulseBlockEnsemble(name='{0}_tau'.format(name), rotating_frame=False)
+        tau_ensemble.append((tau_block.name, 0))
+        created_ensembles.append(tau_ensemble)
+
+        # Create the sync trigger PulseBlockEnsemble if needed
+        if self.sync_channel:
+            sync_block = PulseBlock(name='sync_trigger')
+            sync_block.append(self._get_sync_element())
+            created_blocks.append(sync_block)
+            sync_ensemble = PulseBlockEnsemble(name='sync_trigger', rotating_frame=False)
+            sync_ensemble.append((sync_block.name, 0))
+            created_ensembles.append(sync_ensemble)
+
+        # Create the PulseSequence and append the PulseBlockEnsemble names as sequence steps
+        # together with the necessary parameters.
+        t1_sequence = PulseSequence(name=name, rotating_frame=False)
+        count_length = 0.0
+        for k in k_array:
+            t1_sequence.append(tau_ensemble.name)
+            t1_sequence[-1].repetitions = k - 1
+            count_length += k * self._get_ensemble_count_length(ensemble=tau_ensemble,
+                                                                created_blocks=created_blocks)
+
+            t1_sequence.append(readout_ensemble.name)
+            count_length += self._get_ensemble_count_length(ensemble=readout_ensemble,
+                                                            created_blocks=created_blocks)
+        if self.sync_channel:
+            t1_sequence.append(sync_ensemble.name)
+            t1_sequence[-1].go_to = 1
+            count_length += self._get_ensemble_count_length(ensemble=sync_ensemble,
+                                                            created_blocks=created_blocks)
+
+        # Trigger the calculation of parameters in the PulseSequence instance
+        t1_sequence.refresh_parameters()
+
+        # add metadata to invoke settings later on
+        t1_sequence.measurement_information['alternating'] = False
+        t1_sequence.measurement_information['laser_ignore_list'] = list()
+        t1_sequence.measurement_information['controlled_variable'] = tau_array
+        t1_sequence.measurement_information['units'] = ('s', '')
+        t1_sequence.measurement_information['number_of_lasers'] = len(tau_array)
+        t1_sequence.measurement_information['counting_length'] = count_length
+
+        # Append PulseSequence to created_sequences list
+        created_sequences.append(t1_sequence)
         return created_blocks, created_ensembles, created_sequences

--- a/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
+++ b/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
@@ -1283,7 +1283,7 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         count_length = 0.0
         for k in k_array:
             t1_sequence.append(tau_ensemble.name)
-            t1_sequence[-1].repetitions = k - 1
+            t1_sequence[-1].repetitions = k
             count_length += k * self._get_ensemble_count_length(ensemble=tau_ensemble,
                                                                 created_blocks=created_blocks)
 

--- a/logic/pulsed/pulse_objects.py
+++ b/logic/pulsed/pulse_objects.py
@@ -603,7 +603,7 @@ class SequenceStep(dict):
         mystep.repetitions = 0
     """
 
-    __default_parameters = {'repetitions': 1,
+    __default_parameters = {'repetitions': 0,
                             'go_to': -1,
                             'event_jump_to': -1,
                             'event_trigger': 'OFF',
@@ -683,9 +683,9 @@ class PulseSequence(object):
                                           according parameter (as item).
                                           Available parameters are:
                                           'repetitions': The number of repetitions for that sequence
-                                                         step. (Default 1)
-                                                         1 meaning the step is played once.
-                                                         Set to -1 or 0 for infinite looping.
+                                                         step. (Default 0)
+                                                         0 meaning the step is played once.
+                                                         Set to -1 for infinite looping.
                                           'go_to':   The sequence step index to jump to after
                                                      having played all repetitions. (Default -1)
                                                      Indices starting at 1 for first step.

--- a/logic/pulsed/pulse_objects.py
+++ b/logic/pulsed/pulse_objects.py
@@ -710,7 +710,7 @@ class PulseSequence(object):
 
                                           If only 'repetitions' are in the dictionary, then the dict
                                           will look like:
-                                            seq_param = {'repetitions': 42}
+                                            seq_param = {'repetitions': 41}
                                           and so the respective sequence step will play 42 times.
         @param bool rotating_frame: indicates, whether the phase has to be preserved in all
                                     analog signals ACROSS different waveforms
@@ -741,7 +741,7 @@ class PulseSequence(object):
     def refresh_parameters(self):
         self.is_finite = True
         for sequence_step in self.ensemble_list:
-            if sequence_step.repetitions <= 0:
+            if sequence_step.repetitions < 0:
                 self.is_finite = False
                 break
         return
@@ -799,9 +799,9 @@ class PulseSequence(object):
                                 '\t- a dict containing the sequence parameters including the '
                                 'PulseBlockEnsemble name')
 
-            if value.repetitions <= 0:
+            if value.repetitions < 0:
                 self.is_finite = False
-            elif not self.is_finite and self[key].repetitions <= 0:
+            elif not self.is_finite and self[key].repetitions < 0:
                 stage_refresh = True
         elif isinstance(key, slice):
             if isinstance(value[0], (str, dict)):
@@ -824,7 +824,7 @@ class PulseSequence(object):
                                     '\t- a dict containing the sequence parameters including the '
                                     'PulseBlockEnsemble name')
 
-                if element.repetitions <= 0:
+                if element.repetitions < 0:
                     self.is_finite = False
                 elif not self.is_finite:
                     stage_refresh = True
@@ -841,11 +841,11 @@ class PulseSequence(object):
         if isinstance(key, slice):
             stage_refresh = False
             for element in self.ensemble_list[key]:
-                if element.repetitions <= 0:
+                if element.repetitions < 0:
                     stage_refresh = True
                     break
         elif isinstance(key, int):
-            stage_refresh = self.ensemble_list[key].repetitions <= 0
+            stage_refresh = self.ensemble_list[key].repetitions < 0
         else:
             raise TypeError('PulseSequence indices must be int or slice, not {0}'.format(type(key)))
         del self.ensemble_list[key]
@@ -875,7 +875,7 @@ class PulseSequence(object):
 
         self.sampling_information = dict()
         self.measurement_information = dict()
-        if self.ensemble_list[position].repetitions <= 0:
+        if self.ensemble_list[position].repetitions < 0:
             stage_refresh = True
         popped_element = self.ensemble_list.pop(position)
         if stage_refresh:
@@ -914,7 +914,7 @@ class PulseSequence(object):
             raise IndexError('PulseSequence ensemble list index out of range')
 
         self.ensemble_list.insert(position, element)
-        if element.repetitions <= 0:
+        if element.repetitions < 0:
             self.is_finite = False
         self.sampling_information = dict()
         self.measurement_information = dict()

--- a/logic/pulsed/pulse_objects.py
+++ b/logic/pulsed/pulse_objects.py
@@ -584,6 +584,73 @@ class PulseBlockEnsemble(object):
         return new_ens
 
 
+class SequenceStep(dict):
+    """
+    This is basically a dictionary where each key can be accessed like an attribute.
+    In addition it needs a mandatory key "ensemble" whose value must be a str containing the
+    PulseBlockEnsemble name associated with this sequence step.
+    You can initialize this the same way as a dict or pass the ensemble name as positional argument:
+        mystep = SequenceStep(ensemble='myPulseBlockEnsembleName', repetitions=10, go_to=-1)
+        mystep = SequenceStep(
+            [('ensemble', 'myPulseBlockEnsembleName'), ('repetitions', 10), ('go_to', -1)])
+        mystep = SequenceStep(
+            {'ensemble': 'myPulseBlockEnsembleName', 'repetitions': 10, 'go_to': -1})
+        mystep = SequenceStep('myPulseBlockEnsembleName', repetitions=10, go_to=-1)
+        mystep = SequenceStep('myPulseBlockEnsembleName', {'repetitions': 10, 'go_to': -1})
+    You have all the built-in dict methods, e.g. keys(), items() etc...
+    You can access the keys/values in a dict-like way or like an attribute:
+        mystep['repetitions'] = 0
+        mystep.repetitions = 0
+    """
+
+    __default_parameters = {'repetitions': 0,
+                            'go_to': -1,
+                            'event_jump_to': -1,
+                            'event_trigger': 'OFF',
+                            'wait_for': 'OFF',
+                            'flag_trigger': 'OFF',
+                            'flag_high': 'OFF'}
+
+    def __init__(self, *args, **kwargs):
+        if len(args) > 2:
+            raise TypeError('SequenceStep expected at most 2 arguments, got {0}'.format(len(args)))
+        # Allow the PulseBlockEnsemble name to be passed as positional argument
+        for i, pos_arg in enumerate(args):
+            if isinstance(pos_arg, str):
+                kwargs['ensemble'] = pos_arg
+                if len(args) == 2:
+                    args = (args[0],) if i == 1 else (args[1],)
+                else:
+                    args = tuple()
+                break
+
+        # Check for allowed keys in order to avoid overwriting built-in dict methods and the
+        # ensemble name.
+        # Also check presence of a valid mandatory "ensemble" entry
+        tmp = dict(*args, **kwargs)
+        if not isinstance(tmp.get('ensemble'), str):
+            raise KeyError('"ensemble" entry of type str must be present in SequenceStep. Either '
+                           'include it as dict item or pass it as positional argument in the '
+                           'constructor.')
+        for attribute in dir(dict):
+            if attribute in tmp:
+                raise KeyError('It is not allowed to overwrite built-in dict attributes. '
+                               'Please use another key than "{0}".'.format(attribute))
+
+        # Initialize the dict and merge namespaces
+        super().__init__(*args, **kwargs)
+        self.__dict__ = self
+
+        # Add missing default parameters
+        for key, default_value in self.__default_parameters.items():
+            if key not in self:
+                self[key] = default_value
+        return
+
+    def copy(self):
+        return SequenceStep(super().copy())
+
+
 class PulseSequence(object):
     """
     Higher order object for sequence capability.
@@ -591,13 +658,6 @@ class PulseSequence(object):
     Represents a playback procedure for a number of PulseBlockEnsembles. Unused for pulse
     generator hardware without sequencing functionality.
     """
-    __default_seq_params = {'repetitions': 0,
-                            'go_to': -1,
-                            'event_jump_to': -1,
-                            'event_trigger': 'OFF',
-                            'wait_for': 'OFF',
-                            'flag_trigger': 'OFF',
-                            'flag_high': 'OFF'}
 
     def __init__(self, name, ensemble_list=None, rotating_frame=False):
         """
@@ -669,8 +729,8 @@ class PulseSequence(object):
 
     def refresh_parameters(self):
         self.is_finite = True
-        for ensemble_name, params in self.ensemble_list:
-            if params['repetitions'] < 0:
+        for sequence_step in self.ensemble_list:
+            if sequence_step.repetitions < 0:
                 self.is_finite = False
                 break
         return
@@ -714,46 +774,52 @@ class PulseSequence(object):
     def __setitem__(self, key, value):
         stage_refresh = False
         if isinstance(key, int):
-            if isinstance(value, str):
-                value = (value, self.__default_seq_params.copy())
-            if not isinstance(value, (tuple, list)) or len(value) != 2:
-                raise TypeError('PulseSequence ensemble list entries must be a tuple or list of '
-                                'length 2')
-            elif not isinstance(value[0], str):
-                raise ValueError('PulseSequence element tuple index 0 must contain str, not {0}'
-                                 ''.format(type(value[0])))
-            elif not isinstance(value[1], dict):
-                raise ValueError('PulseSequence element tuple index 1 must contain dict, not {0}'
-                                 ''.format(type(value[1])))
+            if isinstance(value, (str, dict)):
+                value = SequenceStep(value)
+            elif isinstance(value, (tuple, list)) and len(value) == 2:
+                value = SequenceStep(*value)
 
-            if value[1]['repetitions'] < 0:
+            if not isinstance(value, SequenceStep):
+                raise TypeError('PulseSequence ensemble list entries must be either:\n'
+                                '\t- a tuple or list of length 2 with one entry being the '
+                                'PulseBlockEnsemble name and the other being a sequence parameter '
+                                'dictionary\n'
+                                '\t- a str containing the PulseBlockEnsemble name\n'
+                                '\t- a dict containing the sequence parameters including the '
+                                'PulseBlockEnsemble name')
+
+            if value.repetitions < 0:
                 self.is_finite = False
-            elif not self.is_finite and self[key][1]['repetitions'] < 0:
+            elif not self.is_finite and self[key].repetitions < 0:
                 stage_refresh = True
         elif isinstance(key, slice):
-            if isinstance(value[0], str):
+            if isinstance(value[0], (str, dict)):
                 tmp_value = list()
                 for element in value:
-                    tmp_value.append((element, self.__default_seq_params.copy()))
+                    tmp_value.append(SequenceStep(element))
+                value = tmp_value
+            elif isinstance(value[0], (tuple, list)) and len(value[0]) == 2:
+                tmp_value = list()
+                for element in value:
+                    tmp_value.append(SequenceStep(*element))
                 value = tmp_value
             for element in value:
-                if not isinstance(element, (tuple, list)) or len(value) != 2:
-                    raise TypeError('PulseSequence block list entries must be a tuple or list '
-                                    'of length 2')
-                elif not isinstance(element[0], str):
-                    raise ValueError('PulseSequence element tuple index 0 must contain str, not {0}'
-                                     ''.format(type(element[0])))
-                elif not isinstance(element[1], dict):
-                    raise ValueError('PulseSequence element tuple index 1 must contain dict, not '
-                                     '{0}'.format(type(element[1])))
+                if not isinstance(element, SequenceStep):
+                    raise TypeError('PulseSequence ensemble list entries must be either:\n'
+                                    '\t- a tuple or list of length 2 with one entry being the '
+                                    'PulseBlockEnsemble name and the other being a sequence parameter '
+                                    'dictionary\n'
+                                    '\t- a str containing the PulseBlockEnsemble name\n'
+                                    '\t- a dict containing the sequence parameters including the '
+                                    'PulseBlockEnsemble name')
 
-                if element[1]['repetitions'] < 0:
+                if element.repetitions < 0:
                     self.is_finite = False
                 elif not self.is_finite:
                     stage_refresh = True
         else:
             raise TypeError('PulseSequence indices must be int or slice, not {0}'.format(type(key)))
-        self.ensemble_list[key] = tuple(value)
+        self.ensemble_list[key] = value
         self.sampling_information = dict()
         self.measurement_information = dict()
         if stage_refresh:
@@ -764,11 +830,11 @@ class PulseSequence(object):
         if isinstance(key, slice):
             stage_refresh = False
             for element in self.ensemble_list[key]:
-                if element[1]['repetitions'] < 0:
+                if element.repetitions < 0:
                     stage_refresh = True
                     break
         elif isinstance(key, int):
-            stage_refresh = self.ensemble_list[key][1]['repetitions'] < 0
+            stage_refresh = self.ensemble_list[key].repetitions < 0
         else:
             raise TypeError('PulseSequence indices must be int or slice, not {0}'.format(type(key)))
         del self.ensemble_list[key]
@@ -779,6 +845,7 @@ class PulseSequence(object):
         return
 
     def pop(self, position=None):
+        stage_refresh = False
         if len(self.ensemble_list) == 0:
             raise IndexError('pop from empty PulseSequence')
 
@@ -797,38 +864,46 @@ class PulseSequence(object):
 
         self.sampling_information = dict()
         self.measurement_information = dict()
-        if self.ensemble_list[-1][1]['repetitions'] < 0:
-            popped_element = self.ensemble_list.pop(position)
+        if self.ensemble_list[position].repetitions < 0:
+            stage_refresh = True
+        popped_element = self.ensemble_list.pop(position)
+        if stage_refresh:
             self.refresh_parameters()
-            return popped_element
-        return self.ensemble_list.pop(position)
+        return popped_element
 
     def insert(self, position, element):
-        """ Insert a (PulseSequence.name, parameters) tuple at the given position. The old element
+        """
+        Insert a SequenceStep instance at the given position. The old element
         at this position and all consecutive elements after that will be shifted to higher indices.
 
         @param int position: position in the ensemble list
-        @param tuple|str element: PulseBlock name (str)[, seq_parameters (dict)]
+        @param tuple|list|str|dict|SequenceStep element:
+            PulseBlockEnsemble name (str) |
+            (PulseBlockEnsemble name, sequence parameters dict) (tuple|list) |
+            sequence parameters dict including PulseBlockEnsemble name (dict) |
+            SequenceStep instance (SequenceStep)
         """
-        if isinstance(element, str):
-            element = (element, self.__default_seq_params.copy())
+        if isinstance(element, (str, dict)):
+            element = SequenceStep(element)
+        elif isinstance(element, (tuple, list)) and len(element) == 2:
+            element = SequenceStep(*element)
 
-        if not isinstance(element, (tuple, list)) or len(element) != 2:
-            raise TypeError('PulseSequence ensemble list entries must be a tuple or list of '
-                            'length 2')
-        elif not isinstance(element[0], str):
-            raise ValueError('PulseSequence element tuple index 0 must contain str, '
-                             'not {0}'.format(type(element[0])))
-        elif not isinstance(element[1], dict):
-            raise ValueError('PulseSequence element tuple index 1 must contain dict')
+        if not isinstance(element, SequenceStep):
+            raise TypeError('PulseSequence ensemble list entries must be either:\n'
+                            '\t- a tuple or list of length 2 with one entry being the '
+                            'PulseBlockEnsemble name and the other being a sequence parameter '
+                            'dictionary\n'
+                            '\t- a str containing the PulseBlockEnsemble name\n'
+                            '\t- a dict containing the sequence parameters including the '
+                            'PulseBlockEnsemble name')
 
         if position < 0:
             position = len(self.ensemble_list) + position
         if len(self.ensemble_list) < position or position < 0:
             raise IndexError('PulseSequence ensemble list index out of range')
 
-        self.ensemble_list.insert(position, tuple(copy.deepcopy(element)))
-        if element[1]['repetitions'] < 0:
+        self.ensemble_list.insert(position, element)
+        if element.repetitions < 0:
             self.is_finite = False
         self.sampling_information = dict()
         self.measurement_information = dict()
@@ -837,7 +912,7 @@ class PulseSequence(object):
     def append(self, element):
         """
         """
-        self.insert(position=len(self), element=element)
+        self.insert(position=len(self.ensemble_list), element=element)
         return
 
     def extend(self, iterable):

--- a/logic/pulsed/pulse_objects.py
+++ b/logic/pulsed/pulse_objects.py
@@ -1158,7 +1158,8 @@ class PredefinedGeneratorBase:
         """
 
         """
-        return self._get_trigger_element(length=50e-9,
+        minimum_length = self.__sequencegeneratorlogic.pulse_generator_constraints.waveform_length.min/self.sample_rate
+        return self._get_trigger_element(length=max(50e-9, minimum_length),
                                          increment=0,
                                          channels=self.sync_channel)
 

--- a/logic/pulsed/pulse_objects.py
+++ b/logic/pulsed/pulse_objects.py
@@ -603,7 +603,7 @@ class SequenceStep(dict):
         mystep.repetitions = 0
     """
 
-    __default_parameters = {'repetitions': 0,
+    __default_parameters = {'repetitions': 1,
                             'go_to': -1,
                             'event_jump_to': -1,
                             'event_trigger': 'OFF',
@@ -683,9 +683,9 @@ class PulseSequence(object):
                                           according parameter (as item).
                                           Available parameters are:
                                           'repetitions': The number of repetitions for that sequence
-                                                         step. (Default 0)
-                                                         0 meaning the step is played once.
-                                                         Set to -1 for infinite looping.
+                                                         step. (Default 1)
+                                                         1 meaning the step is played once.
+                                                         Set to -1 or 0 for infinite looping.
                                           'go_to':   The sequence step index to jump to after
                                                      having played all repetitions. (Default -1)
                                                      Indices starting at 1 for first step.
@@ -710,7 +710,7 @@ class PulseSequence(object):
 
                                           If only 'repetitions' are in the dictionary, then the dict
                                           will look like:
-                                            seq_param = {'repetitions': 41}
+                                            seq_param = {'repetitions': 42}
                                           and so the respective sequence step will play 42 times.
         @param bool rotating_frame: indicates, whether the phase has to be preserved in all
                                     analog signals ACROSS different waveforms
@@ -741,7 +741,7 @@ class PulseSequence(object):
     def refresh_parameters(self):
         self.is_finite = True
         for sequence_step in self.ensemble_list:
-            if sequence_step.repetitions < 0:
+            if sequence_step.repetitions <= 0:
                 self.is_finite = False
                 break
         return
@@ -799,9 +799,9 @@ class PulseSequence(object):
                                 '\t- a dict containing the sequence parameters including the '
                                 'PulseBlockEnsemble name')
 
-            if value.repetitions < 0:
+            if value.repetitions <= 0:
                 self.is_finite = False
-            elif not self.is_finite and self[key].repetitions < 0:
+            elif not self.is_finite and self[key].repetitions <= 0:
                 stage_refresh = True
         elif isinstance(key, slice):
             if isinstance(value[0], (str, dict)):
@@ -824,7 +824,7 @@ class PulseSequence(object):
                                     '\t- a dict containing the sequence parameters including the '
                                     'PulseBlockEnsemble name')
 
-                if element.repetitions < 0:
+                if element.repetitions <= 0:
                     self.is_finite = False
                 elif not self.is_finite:
                     stage_refresh = True
@@ -841,11 +841,11 @@ class PulseSequence(object):
         if isinstance(key, slice):
             stage_refresh = False
             for element in self.ensemble_list[key]:
-                if element.repetitions < 0:
+                if element.repetitions <= 0:
                     stage_refresh = True
                     break
         elif isinstance(key, int):
-            stage_refresh = self.ensemble_list[key].repetitions < 0
+            stage_refresh = self.ensemble_list[key].repetitions <= 0
         else:
             raise TypeError('PulseSequence indices must be int or slice, not {0}'.format(type(key)))
         del self.ensemble_list[key]
@@ -875,7 +875,7 @@ class PulseSequence(object):
 
         self.sampling_information = dict()
         self.measurement_information = dict()
-        if self.ensemble_list[position].repetitions < 0:
+        if self.ensemble_list[position].repetitions <= 0:
             stage_refresh = True
         popped_element = self.ensemble_list.pop(position)
         if stage_refresh:
@@ -914,7 +914,7 @@ class PulseSequence(object):
             raise IndexError('PulseSequence ensemble list index out of range')
 
         self.ensemble_list.insert(position, element)
-        if element.repetitions < 0:
+        if element.repetitions <= 0:
             self.is_finite = False
         self.sampling_information = dict()
         self.measurement_information = dict()


### PR DESCRIPTION
## Description
Introduced a new class `SequenceStep` which is basically a `dict` where you can access key-value-pairs like attributes as well, e.g. `my_sequence_step.repetitions = 0` or `my_sequence_step['repetitions'] = 0`.
During initialization of a `SequenceStep` instance the underlying `dict` will be completed with missing mandatory default parameters (like repetitions, go_to etc.).
The only parameter that is mandatory for initialization is "ensemble". It is a string containing the `PulseBlockEnsemble` name used in that sequence step.

Also fixed the minimal waveform length constraint in the AWG70k hardware module as well as consequently fixing the use of the "repetitions" sequence parameter to start from 0 for single playback.

## Motivation and Context
The introduction of the new sequence step data type simplifies scripted `PulseSequence` generation by making access to the sequence step parameters more intuitive.
```python
# create empty PulseSequence
my_sequence = PulseSequence()  
# append SequenceStep with PulseBlockEnsemble name
my_sequence.append('my_pulse_block_ensemble_name')  
# make the last sequence step loop infinitely
my_sequence[-1].repetitions = -1  
```

## How Has This Been Tested?
On dummy win7 x64

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
