### PR TITLE
Copy-paste config example in the docstring of the hardware modules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,7 @@
 - [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
+- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
 - [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
 - [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
 - [ ] All changed Jupyter notebooks have been stripped of their output cells.

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -32,6 +32,8 @@ This can be used to specify the axis labels for the measurement (excluding units
 * Correct the low level implementation for the PulseBlasterESR-PRO.
 * Implement the pulser interface for PulseBlasterESR-PRO devices.
 * Implement the switch interface for PulseBlasterESR-PRO devices.
+* Add possibility to set instruction delays in the config for PulseBlasterESR-PRO sequence generation.
+* Add a copy-paste config option to the docstrings of all current qudi hardware modules.
 * **Pulsed 3.0:**\
     _A truckload of changes regarding all pulsed measurement related modules_
     * Bug fix for waveform generation larger than ~2 GSamples

--- a/hardware/CTC100_temperature.py
+++ b/hardware/CTC100_temperature.py
@@ -42,7 +42,7 @@ class CTC100(Base):
     _modtype = 'hardware'
 
     # config options
-    _interface = ConfigOption('interface', default='ASRL1::INSTR', missing='error')
+    _interface = ConfigOption('interface', missing='error')
 
     def on_activate(self):
         """ Activate modeule

--- a/hardware/CTC100_temperature.py
+++ b/hardware/CTC100_temperature.py
@@ -24,16 +24,25 @@ from core.module import Base, ConfigOption
 import visa
 
 class CTC100(Base):
-    """
-    This module implements communication with CTC100 temperature controllers or clones/licensed devices.
+    """ This module implements communication with CTC100 temperature controllers
+    or clones/licensed devices.
 
-    This module is untested and very likely broken.
+    ATTENTION: This module is untested and very likely broken.
+
+    Example config for copy-paste:
+
+    tempcontroller_ctc100:
+        module.Class: 'CTC100_temperature.CTC100'
+        interface: 'ASRL1::INSTR'
+        fitlogic: 'fitlogic' # name of the fitlogic module, see default config
+
     """
+
     _modclass = 'ctc100'
     _modtype = 'hardware'
 
     # config options
-    _interface = ConfigOption('interface', missing='error')
+    _interface = ConfigOption('interface', default='ASRL1::INSTR', missing='error')
 
     def on_activate(self):
         """ Activate modeule

--- a/hardware/awg/keysight_M3202A.py
+++ b/hardware/awg/keysight_M3202A.py
@@ -46,6 +46,12 @@ from interface.pulser_interface import PulserInterface, PulserConstraints
 class M3202A(Base, PulserInterface):
     """ Qudi module for the Keysight M3202A PXIe AWG card (1GHz sampling frequency)
 
+    Example config for copy-paste:
+
+    keysight_m3202a:
+        module.Class: 'awg.keysight_M3202A.M3202A'
+        awg_serial: 0000000000 # here the serial number of current AWG
+
     """
     _modclass = 'M3202A'
     _modtype = 'hardware'

--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -36,22 +36,36 @@ from interface.pulser_interface import PulserInterface, PulserConstraints
 
 
 class AWG70K(Base, PulserInterface):
-    """
+    """ A hardware module for the Tektronix AWG70000 series for generating
+        waveforms and sequences thereof.
+
+    Example config for copy-paste:
+
+    pulser_awg70000:
+        module.Class: 'awg.tektronix_awg70k.AWG70k'
+        awg_visa_address: 'TCPIP::10.42.0.211::INSTR'
+        awg_ip_address: '10.42.0.211'
+        timeout: 60
+        # tmp_work_dir: 'C:\\Software\\qudi_pulsed_files' # optional
+        # ftp_root_dir: 'C:\\inetpub\\ftproot' # optional, root directory on AWG device
+        # ftp_login: 'anonymous' # optional, the username for ftp login
+        # ftp_passwd: 'anonymous@' # optional, the password for ftp login
 
     """
     _modclass = 'awg70k'
     _modtype = 'hardware'
 
     # config options
+    _visa_address = ConfigOption(name='awg_visa_address', missing='error')
+    _ip_address = ConfigOption(name='awg_ip_address', missing='error')
+    _visa_timeout = ConfigOption(name='timeout', default=30, missing='nothing')
     _tmp_work_dir = ConfigOption(name='tmp_work_dir',
                                  default=os.path.join(get_home_dir(), 'pulsed_files'),
                                  missing='warn')
-    _visa_address = ConfigOption(name='awg_visa_address', missing='error')
-    _ip_address = ConfigOption(name='awg_ip_address', missing='error')
     _ftp_dir = ConfigOption(name='ftp_root_dir', default='C:\\inetpub\\ftproot', missing='warn')
     _username = ConfigOption(name='ftp_login', default='anonymous', missing='warn')
     _password = ConfigOption(name='ftp_passwd', default='anonymous@', missing='warn')
-    _visa_timeout = ConfigOption(name='timeout', default=30, missing='nothing')
+
 
     # translation dict from qudi trigger descriptor to device command
     __event_triggers = {'OFF': 'OFF', 'A': 'ATR', 'B': 'BTR', 'INT': 'INT'}

--- a/hardware/awg/tektronix_awg7k.py
+++ b/hardware/awg/tektronix_awg7k.py
@@ -34,8 +34,21 @@ from interface.pulser_interface import PulserInterface, PulserConstraints
 
 
 class AWG7k(Base, PulserInterface):
-    """ A hardware module for the Tektronix AWG7000 series for generating waveforms and
-        sequences thereof.
+    """ A hardware module for the Tektronix AWG7000 series for generating
+        waveforms and sequences thereof.
+
+    Example config for copy-paste:
+
+    pulser_awg7000:
+        module.Class: 'awg.tektronix_awg7k.AWG7k'
+        awg_visa_address: 'TCPIP::10.42.0.211::INSTR'
+        awg_ip_address: '10.42.0.211'
+        timeout: 60
+        # tmp_work_dir: 'C:\\Software\\qudi_pulsed_files' # optional
+        # ftp_root_dir: 'C:\\inetpub\\ftproot' # optional, root directory on AWG device
+        # ftp_login: 'anonymous' # optional, the username for ftp login
+        # ftp_passwd: 'anonymous@' # optional, the password for ftp login
+
     """
 
     _modclass = 'awg7k'
@@ -50,7 +63,6 @@ class AWG7k(Base, PulserInterface):
     _ftp_dir = ConfigOption(name='ftp_root_dir', default='C:\\inetpub\\ftproot', missing='warn')
     _username = ConfigOption(name='ftp_login', default='anonymous', missing='warn')
     _password = ConfigOption(name='ftp_passwd', default='anonymous@', missing='warn')
-    _default_sample_rate = ConfigOption(name='default_sample_rate', default=None, missing='warn')
     _visa_timeout = ConfigOption(name='timeout', default=30, missing='nothing')
 
     def __init__(self, config, **kwargs):

--- a/hardware/camera/andor/iXon897_ultra.py
+++ b/hardware/camera/andor/iXon897_ultra.py
@@ -98,21 +98,32 @@ ERROR_DICT = {
 }
 
 class IxonUltra(Base, CameraInterface):
-    """
-    Hardware class for Andors Ixon Ultra 897
+    """ Hardware class for Andors Ixon Ultra 897
+
+    Example config for copy-paste:
+
+    andor_ultra_camera:
+        module.Class: 'camera.andor.iXon897_ultra.IxonUltra'
+        dll_location: 'C:\\camera\\andor.dll' # path to library file
+        default_exposure: 1.0
+        default_read_mode: 'IMAGE'
+        default_temperature: -70
+        default_cooler_on: True
+        default_acquisition_mode: 'SINGLE_SCAN'
+        default_trigger_mode: 'INTERNAL'
+
     """
 
     _modtype = 'camera'
     _modclass = 'hardware'
 
+    _dll_location = ConfigOption('dll_location', missing='error')
     _default_exposure = ConfigOption('default_exposure', 1.0)
     _default_read_mode = ConfigOption('default_read_mode', 'IMAGE')
     _default_temperature = ConfigOption('default_temperature', -70)
     _default_cooler_on = ConfigOption('default_cooler_on', True)
     _default_acquisition_mode = ConfigOption('default_acquisition_mode', 'SINGLE_SCAN')
     _default_trigger_mode = ConfigOption('default_trigger_mode', 'INTERNAL')
-    _dll_location = ConfigOption('dll_location', missing='error')
-
 
     _exposure = _default_exposure
     _temperature = _default_temperature

--- a/hardware/camera/camera_dummy.py
+++ b/hardware/camera/camera_dummy.py
@@ -28,6 +28,16 @@ from interface.camera_interface import CameraInterface
 
 class CameraDummy(Base, CameraInterface):
     """ Dummy hardware for camera interface
+
+    Example config for copy-paste:
+
+    camera_dummy:
+        module.Class: 'camera.camera_dummy.CameraDummy'
+        support_live: True
+        camera_name: 'Dummy camera'
+        resolution: (1280, 720)
+        exposure: 0.1
+        gain: 1.0
     """
 
     _modtype = 'DummyCamera'

--- a/hardware/camera/thorlabs/thorlabs_DCx.py
+++ b/hardware/camera/thorlabs/thorlabs_DCx.py
@@ -36,15 +36,23 @@ from .uc480_h import *
 
 
 class CameraThorlabs(Base, CameraInterface):
-    """
-    Main class of the module
+    """ Main class of the module
+
+    Example config for copy-paste:
+
+    thorlabs_camera:
+        module.Class: 'camera.thorlabs.thorlabs_DCx.CameraThorlabs'
+        default_exposure: 0.1
+        default_gain: 1.0
+        id_camera: 0 # if more tha one camera is present
+
     """
 
     _modtype = 'camera'
     _modclass = 'hardware'
 
     _default_exposure = ConfigOption('default_exposure', 0.1)
-    _default_gain = ConfigOption('_default_gain', 1.0)
+    _default_gain = ConfigOption('default_gain', 1.0)
     _id_camera = ConfigOption('id_camera', 0)  # if more than one camera is present
 
     _dll = None

--- a/hardware/confocal_scanner_dummy.py
+++ b/hardware/confocal_scanner_dummy.py
@@ -27,10 +27,17 @@ from interface.confocal_scanner_interface import ConfocalScannerInterface
 
 
 class ConfocalScannerDummy(Base, ConfocalScannerInterface):
+    """ Dummy confocal scanner. Produces a picture with several gaussian spots.
 
-    """ Dummy confocal scanner.
-        Produces a picture with several gaussian spots.
+    Example config for copy-paste:
+
+    confocal_scanner_dummy:
+        module.Class: 'confocal_scanner_dummy.ConfocalScannerDummy'
+        clock_frequency: 100 # in Hz
+        fitlogic: 'fitlogic' # name of the fitlogic module, see default config
+
     """
+
     _modclass = 'ConfocalScannerDummy'
     _modtype = 'hardware'
 

--- a/hardware/dtg/dtg5334.py
+++ b/hardware/dtg/dtg5334.py
@@ -32,8 +32,14 @@ from core.module import Base, ConfigOption
 
 
 class DTG5334(Base, PulserInterface):
-    """
-        Tektronix DTG 5334
+    """ Tektronix DTG 5334
+
+    Example config for copy-paste:
+
+    pulser_dtg:
+        module.Class: 'dtg.dtg5334.DTG5334'
+        visa_address: 'GPIB0::12::INSTR'
+
     """
     _modclass = 'dtg5334'
     _modtype = 'hardware'

--- a/hardware/edwards_vacuum_controller.py
+++ b/hardware/edwards_vacuum_controller.py
@@ -42,7 +42,7 @@ class EdwardsVacuumController(Base):
     _modtype = 'hardware'
 
     # config options
-    _interface = ConfigOption('interface', default='ASRL1::INSTR', missing='error')
+    _interface = ConfigOption('interface', missing='error')
 
     # IDs for communication
     PRIORITY = {

--- a/hardware/edwards_vacuum_controller.py
+++ b/hardware/edwards_vacuum_controller.py
@@ -25,18 +25,24 @@ from core.module import Base, ConfigOption
 import visa
 
 class EdwardsVacuumController(Base):
-    """
-    This module implements communication with Edwards turbopump and
-    vacuum PIC.
+    """ This module implements communication with Edwards turbopump and vacuum
+    PIC.
 
+    ATTENTION: This module is not complete or functional.
 
-    This module is not complete or functional.
+    Example config for copy-paste:
+
+    vacuum_control_edwards:
+        module.Class: 'edwards_vacuum_controller.EdwardsVacuumController'
+        interface: 'ASRL1::INSTR'
+
     """
+
     _modclass = 'edwards_pump'
     _modtype = 'hardware'
 
     # config options
-    _interface = ConfigOption('interface', missing='error')
+    _interface = ConfigOption('interface', default='ASRL1::INSTR', missing='error')
 
     # IDs for communication
     PRIORITY = {

--- a/hardware/fast_counter_dummy.py
+++ b/hardware/fast_counter_dummy.py
@@ -30,8 +30,15 @@ from interface.fast_counter_interface import FastCounterInterface
 
 
 class FastCounterDummy(Base, FastCounterInterface):
-    """This is the Interface class to define the controls for the simple
-    microwave hardware.
+    """ Implementation of the FastCounter interface methods for a dummy usage.
+
+    Example config for copy-paste:
+
+    fastcounter_dummy:
+        module.Class: 'fast_counter_dummy.FastCounterDummy'
+        gated: False
+        #load_trace: None # path to the saved dummy trace
+
     """
     _modclass = 'fastcounterinterface'
     _modtype = 'hardware'

--- a/hardware/fastcomtec/fastcomtecmcs6.py
+++ b/hardware/fastcomtec/fastcomtecmcs6.py
@@ -160,11 +160,21 @@ class BOARDSETTING(ctypes.Structure):
                 ('timepreset',  ctypes.c_double), ]
 
 class FastComtec(Base, FastCounterInterface):
-    """
+    """ Hardware Class for the FastComtec Card.
+
     stable: Jochen Scheuer, Simon Schmitt
 
-    Hardware Class for the FastComtec Card.
+    Example config for copy-paste:
+
+    fastcomtec_mcs6:
+        module.Class: 'fastcomtec.fastcomtecmcs6.FastComtec'
+        gated: False
+        trigger_safety: 400e-9
+        aom_delay: 390e-9
+        minimal_binwidth: 0.2e-9
+
     """
+
     _modclass = 'FastComtec'
     _modtype = 'hardware'
     gated = ConfigOption('gated', False, missing='warn')

--- a/hardware/fastcomtec/fastcomtecp7887.py
+++ b/hardware/fastcomtec/fastcomtecp7887.py
@@ -147,11 +147,21 @@ class ACQDATA(ctypes.Structure):
 
 
 class FastComtec(Base, FastCounterInterface):
-    """
+    """ Hardware Class for the FastComtec Card.
+
     unstable: Jochen Scheuer, Simon Schmitt
 
-    Hardware Class for the FastComtec Card.
+    Example config for copy-paste:
+
+    fastcomtec_p7887:
+        module.Class: 'fastcomtec.fastcomtecp7887.FastComtec'
+        gated: False
+        trigger_safety: 200e-9
+        aom_delay: 400e-9
+        minimal_binwidth: 0.25e-9
+
     """
+
     _modclass = 'FastComtec'
     _modtype = 'hardware'
     gated = ConfigOption('gated', False, missing='warn')

--- a/hardware/fpga_fastcounter/fast_counter_fpga_pi3.py
+++ b/hardware/fpga_fastcounter/fast_counter_fpga_pi3.py
@@ -29,6 +29,20 @@ from interface.fast_counter_interface import FastCounterInterface
 
 
 class FastCounterFGAPiP3(Base, FastCounterInterface):
+    """ Qudi module for the an FPGA based FastCounter.
+
+    Example config for copy-paste:
+
+    fpga_pi3:
+        module.Class: 'fpga_fastcounter.fast_counter_fpga_pi3.FastCounterFGAPiP3'
+        fpgacounter_serial: '143400058N'
+        fpgacounter_channel_apd_0: 1
+        fpgacounter_channel_apd_1: 3
+        fpgacounter_channel_detect: 2
+        fpgacounter_channel_sequence: 6
+
+    """
+
     _modclass = 'FastCounterFGAPiP3'
     _modtype = 'hardware'
 

--- a/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
+++ b/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
@@ -45,7 +45,24 @@ class FastCounterFPGAQO(Base, FastCounterInterface):
         (SWIG) to access the dll library. Be aware that the wrapper is specified
         for a specific version of python (here python 3.4), and it is not
         guaranteed to be working with other versions.
+
+    Example config for copy-paste:
+
+    fpga_qo:
+        module.Class: 'fpga_fastcounter.fast_counter_fpga_qo.FastCounterFPGAQO'
+        fpgacounter_serial: '143400058N'
+        fpga_type: 'XEM6310_LX150'
+        #threshV_ch1: 0.5   # optional, threshold voltage for detection
+        #threshV_ch2: 0.5   # optional, threshold voltage for detection
+        #threshV_ch3: 0.5   # optional, threshold voltage for detection
+        #threshV_ch4: 0.5   # optional, threshold voltage for detection
+        #threshV_ch5: 0.5   # optional, threshold voltage for detection
+        #threshV_ch6: 0.5   # optional, threshold voltage for detection
+        #threshV_ch7: 0.5   # optional, threshold voltage for detection
+        #threshV_ch8: 0.5   # optional, threshold voltage for detection
+
     """
+
     _modclass = 'FastCounterFPGAQO'
     _modtype = 'hardware'
 

--- a/hardware/fpga_pulser/ok_fpga_pulser.py
+++ b/hardware/fpga_pulser/ok_fpga_pulser.py
@@ -30,7 +30,7 @@ from collections import OrderedDict
 
 
 class OkFpgaPulser(Base, PulserInterface):
-    """Methods to control Pulse Generator running on OK FPGA.
+    """ Methods to control Pulse Generator running on OK FPGA.
 
     Chan   PIN
     ----------
@@ -42,7 +42,16 @@ class OkFpgaPulser(Base, PulserInterface):
     Ch6    B8
     Ch7    D9
     Ch8    C9
+
+    Example config for copy-paste:
+
+    fpga_pulser_ok:
+        module.Class: 'fpga_fastcounter.fast_pulser_qo.OkFpgaPulser'
+        fpga_serial: '143400058N'
+        fpga_type: 'XEM6310_LX150'
+
     """
+
     _modclass = 'pulserinterface'
     _modtype = 'hardware'
 

--- a/hardware/gated_ni_card.py
+++ b/hardware/gated_ni_card.py
@@ -36,26 +36,67 @@ from .national_instruments_x_series import NationalInstrumentsXSeries
 
 class SlowGatedNICard(NationalInstrumentsXSeries):
     """ Enable the usage of the gated counter in the slow counter interface.
-    Overwrite in this new class therefore the appropriate methods. """
+    Overwrite in this new class therefore the appropriate methods.
+
+    Example config for copy-paste:
+
+    slowgated_ni:
+        module.Class: 'gated_ni_card.SlowGatedNICard'
+        photon_sources:
+            - '/Dev1/PFI8'
+        #    - '/Dev1/PFI9'
+        clock_channel: '/Dev1/Ctr0'
+        default_clock_frequency: 100 # optional, in Hz
+        counter_channels:
+            - '/Dev1/Ctr1'
+        counter_ai_channels:
+            - '/Dev1/AI0'
+        default_scanner_clock_frequency: 100 # optional, in Hz
+        scanner_clock_channel: '/Dev1/Ctr2'
+        pixel_clock_channel: '/Dev1/PFI6'
+        scanner_ao_channels:
+            - '/Dev1/AO0'
+            - '/Dev1/AO1'
+            - '/Dev1/AO2'
+            - '/Dev1/AO3'
+        scanner_ai_channels:
+            - '/Dev1/AI1'
+        scanner_counter_channels:
+            - '/Dev1/Ctr3'
+        scanner_voltage_ranges:
+            - [-10, 10]
+            - [-10, 10]
+            - [-10, 10]
+            - [-10, 10]
+        scanner_position_ranges:
+            - [0e-6, 200e-6]
+            - [0e-6, 200e-6]
+            - [-100e-6, 100e-6]
+            - [-10, 10]
+
+        odmr_trigger_channel: '/Dev1/PFI7'
+
+        gate_in_channel: '/Dev1/PFI9'
+        default_samples_number: 50
+        max_counts: 3e7
+        read_write_timeout: 10
+        counting_edge_rising: True
+
+    """
 
     _modtype = 'SlowGatedNICard'
     _modclass = 'hardware'
+
+    _photon_sources = ConfigOption('photon_sources', default=['/Dev1/PFI8'], missing='error')
 
     def on_activate(self):
         """ Starts up the NI Card at activation.
         """
         self._gated_counter_daq_task = None
         self._counter_channels = []
-        self._counter_channel = '/NIDAQ/Ctr0'
+        self._counter_channel = '/Dev1/Ctr0'
 
-        config = self.getConfiguration()
-
-        if 'photon_source' in config.keys():
-            self._photon_source = config['photon_source']
-        else:
-            self.log.error(
-                'No parameter "photon_source" configured.\n'
-                'Assign to that parameter an appropriated channel from your NI Card!')
+        self._ph_source = self._photon_sources[0]
 
     def get_constraints(self):
         """ Get hardware limits of NI device.

--- a/hardware/gated_ni_card.py
+++ b/hardware/gated_ni_card.py
@@ -87,7 +87,7 @@ class SlowGatedNICard(NationalInstrumentsXSeries):
     _modtype = 'SlowGatedNICard'
     _modclass = 'hardware'
 
-    _photon_sources = ConfigOption('photon_sources', default=['/Dev1/PFI8'], missing='error')
+    _photon_sources = ConfigOption('photon_sources', missing='error')
 
     def on_activate(self):
         """ Starts up the NI Card at activation.

--- a/hardware/high_finesse_wavemeter.py
+++ b/hardware/high_finesse_wavemeter.py
@@ -76,12 +76,21 @@ class HardwarePull(QtCore.QObject):
 
 
 class HighFinesseWavemeter(Base,WavemeterInterface):
+    """ Hardware class to controls a High Finesse Wavemeter.
+
+    Example config for copy-paste:
+
+    high_finesse_wavemeter:
+        module.Class: 'high_finesse_wavemeter.HighFinesseWavemeter'
+        measurement_timing: 10.0 # in seconds
+
+    """
 
     _modclass = 'HighFinesseWavemeter'
     _modtype = 'hardware'
 
     # config options
-    _measurement_timing = ConfigOption('measurement_timing', 10.)
+    _measurement_timing = ConfigOption('measurement_timing', default=10.)
 
     # signals
     sig_handle_timer = QtCore.Signal(bool)

--- a/hardware/influx_data_client.py
+++ b/hardware/influx_data_client.py
@@ -27,6 +27,20 @@ from interface.process_interface import ProcessInterface
 
 class InfluxDataClient(Base, ProcessInterface):
     """ Retrieve live data from InfluxDB as if the measurement device was connected directly.
+
+    Example config for copy-paste:
+
+    influx_data_client:
+        module.Class: 'influx_data_client.InfluxDataClient'
+        user: 'client_user'
+        password: 'client_password'
+        dbname: 'db_name'
+        host: 'localhost'
+        port: 8086
+        dataseries: 'data_series_name'
+        field: 'field_name'
+        criterion: 'criterion_name'
+
     """
 
     _modclass = 'InfluxDataClient'
@@ -36,7 +50,7 @@ class InfluxDataClient(Base, ProcessInterface):
     pw = ConfigOption('password', missing='error')
     dbname = ConfigOption('dbname', missing='error')
     host = ConfigOption('host', missing='error')
-    port = ConfigOption('port', 8086)
+    port = ConfigOption('port', default=8086)
     series = ConfigOption('dataseries', missing='error')
     field = ConfigOption('field', missing='error')
     cr = ConfigOption('criterion', missing='error')

--- a/hardware/influx_data_logger.py
+++ b/hardware/influx_data_logger.py
@@ -26,7 +26,22 @@ from influxdb import InfluxDBClient
 
 class InfluxLogger(Base, DataLoggerInterface):
     """ Log instrument values to InfluxDB.
+
+    Example config for copy-paste:
+
+    influx_data_logger:
+        module.Class: 'influx_data_logger.InfluxLogger'
+        user: 'client_user'
+        password: 'client_password'
+        dbname: 'db_name'
+        host: 'localhost'
+        port: 8086
+        dataseries: 'data_series_name'
+        field: 'field_name'
+        criterion: 'criterion_name'
+
     """
+
     _modclass = 'InfluxLogger'
     _modtype = 'hardware'
 

--- a/hardware/laser/coherent_obis_laser.py
+++ b/hardware/laser/coherent_obis_laser.py
@@ -31,12 +31,12 @@ class OBISLaser(Base, SimpleLaserInterface):
 
     """ Implements the Coherent OBIS laser.
 
-    Example configuration:
-    ```
-    # obis:
-    #     module.Class: 'SimpleLaserInterface.OBISLaser'
-    #     com_port: 'COM3'
-    ```
+    Example config for copy-paste:
+
+    obis_laser:
+        module.Class: 'laser.coherent_obis_laser.OBISLaser'
+        com_port: 'COM3'
+
     """
 
     _modclass = 'laser'

--- a/hardware/laser/laserquantum_laser.py
+++ b/hardware/laser/laserquantum_laser.py
@@ -39,9 +39,16 @@ class PSUTypes(Enum):
 
 
 class LaserQuantumLaser(Base, SimpleLaserInterface):
-    """
-    This module implements communication with the Edwards turbopump and
-    vacuum equipment.
+    """ Qudi module to communicate with the Edwards turbopump and vacuum equipment.
+
+    Example config for copy-paste:
+
+    laserquantum_laser:
+        module.Class: 'laser.laserquantum_laser.LaserQuantumLaser'
+        interface: 'ASRL1::INSTR'
+        maxpower: 0.250 # in Watt
+        psu: 'SMD6000'
+
     """
     _modclass = 'lqlaser'
     _modtype = 'hardware'

--- a/hardware/laser/millennia_ev_laser.py
+++ b/hardware/laser/millennia_ev_laser.py
@@ -35,8 +35,15 @@ class Models(Enum):
 
 
 class MillenniaeVLaser(Base, SimpleLaserInterface):
-    """
-    Spectra Physics Millennia diode pumped solid state laser
+    """ Spectra Physics Millennia diode pumped solid state laser.
+
+    Example config for copy-paste:
+
+    millennia_laser:
+        module.Class: 'laser.millennia_ev_laser.MillenniaeVLaser'
+        interface: 'ASRL1::INSTR'
+        maxpower: 25 # in Watt
+
     """
     _modclass = 'millenniaevlaser'
     _modtype = 'hardware'

--- a/hardware/laser/simple_laser_dummy.py
+++ b/hardware/laser/simple_laser_dummy.py
@@ -29,9 +29,15 @@ import random
 import time
 
 class SimpleLaserDummy(Base, SimpleLaserInterface):
+    """ Lazor dummy
+
+    Example config for copy-paste:
+
+    laser_dummy:
+        module.Class: 'laser.simple_laser_dummy.SimpleLaserDummy'
+
     """
-    Lazor dummy
-    """
+
     _modclass = 'laserdummy'
     _modtype = 'hardware'
 

--- a/hardware/magnet/magnet_dummy.py
+++ b/hardware/magnet/magnet_dummy.py
@@ -35,8 +35,14 @@ class MagnetAxisDummy:
 
 
 class MagnetDummy(Base, MagnetInterface):
-    """This is the Interface class to define the controls for the simple
-    magnet hardware.
+    """ This is the Interface class to define the controls for the simple
+        magnet hardware.
+
+    Example config for copy-paste:
+
+    magnet_dummy:
+        module.Class: 'magnet.magnet_dummy.MagnetDummy'
+
     """
 
     _modtype = 'MagnetDummy'

--- a/hardware/microwave/mw_source_agilent.py
+++ b/hardware/microwave/mw_source_agilent.py
@@ -36,9 +36,17 @@ from interface.microwave_interface import TriggerEdge
 
 
 class MicrowaveAgilent(Base, MicrowaveInterface):
-    """ This is the Interface class to define the controls for the simple
-        microwave hardware.
-        The hardware file was tested using the model N9310A.
+    """ Hardware control file for Agilent Devices.
+
+    The hardware file was tested using the model N9310A.
+
+    Example config for copy-paste:
+
+    mw_source_agilent:
+        module.Class: 'microwave.mw_source_agilent.MicrowaveAgilent'
+        usb_address: USB0::10::INSTR
+        usb_timeout: 100 # in seconds
+
     """
 
     _modclass = 'MicrowaveAgilent'

--- a/hardware/microwave/mw_source_anritsu.py
+++ b/hardware/microwave/mw_source_anritsu.py
@@ -35,9 +35,17 @@ from interface.microwave_interface import TriggerEdge
 
 
 class MicrowaveAnritsu(Base, MicrowaveInterface):
-    """
-    Hardware control file for Anritsu Devices.
+    """ Hardware control file for Anritsu Devices.
+
     Tested for the model MG37022A with Option 4.
+
+    Example config for copy-paste:
+
+    mw_source_anritsu:
+        module.Class: 'microwave.mw_source_anritsu.MicrowaveAnritsu'
+        gpib_address: 'GPIB0::12::INSTR'
+        gpib_timeout: 10 # in seconds
+
     """
 
     _modclass = 'MicrowaveAnritsu'

--- a/hardware/microwave/mw_source_anritsu70GHz.py
+++ b/hardware/microwave/mw_source_anritsu70GHz.py
@@ -36,6 +36,14 @@ from interface.microwave_interface import TriggerEdge
 class MicrowaveAnritsu70GHz(Base, MicrowaveInterface):
     """ Hardware control file for Anritsu 70GHz Devices.
         Tested for the model MG3696B.
+
+    Example config for copy-paste:
+
+    mw_source_anritsu70ghz:
+        module.Class: 'microwave.mw_source_anritsu70GHz.MicrowaveAnritsu70GHz'
+        gpib_address: 'GPIB0::12::INSTR'
+        gpib_timeout: 10 # in seconds
+
     """
     _modclass = 'MicrowaveAanritsu70GHz'
     _modtype = 'hardware'

--- a/hardware/microwave/mw_source_anritsu_mg3691c.py
+++ b/hardware/microwave/mw_source_anritsu_mg3691c.py
@@ -35,12 +35,20 @@ from interface.microwave_interface import TriggerEdge
 
 
 class MicrowaveAnritsu(Base, MicrowaveInterface):
-    """
-    Hardware control file for Anritsu Devices.
+    """ Hardware control file for Anritsu Devices.
+
     Tested for the model MG3691C with OPTION 2.
     cw and list modes are tested.
     Important: Trigger for frequency sweep is totally independent with most trigger syntax.
             In addition, it has to be Aux I/O pin connection.
+
+    Example config for copy-paste:
+
+    mw_source_anritsu_mg3691c:
+        module.Class: 'microwave.mw_source_anritsu_mg3691.MicrowaveAnritsu'
+        gpib_address: 'GPIB0::12::INSTR'
+        gpib_timeout: 10 # in seconds
+
     """
 
     _modclass = 'MicrowaveAnritsu'

--- a/hardware/microwave/mw_source_dummy.py
+++ b/hardware/microwave/mw_source_dummy.py
@@ -31,8 +31,13 @@ import time
 
 
 class MicrowaveDummy(Base, MicrowaveInterface):
-    """This is the Interface class to define the controls for the simple
-    microwave hardware.
+    """ A dummy class to emulate a microwave source.
+
+    Example config for copy-paste:
+
+    mw_source_dummy:
+        module.Class: 'microwave.mw_source_dummy.MicrowaveDummy'
+
     """
     _modclass = 'MicrowaveDummy'
     _modtype = 'mwsource'

--- a/hardware/microwave/mw_source_gigatronics.py
+++ b/hardware/microwave/mw_source_gigatronics.py
@@ -35,7 +35,16 @@ from interface.microwave_interface import TriggerEdge
 
 
 class MicrowaveGigatronics(Base, MicrowaveInterface):
-    """ Hardware file for Gigatronics. Tested for the model 2400/2500. """
+    """ Hardware file for Gigatronics. Tested for the model 2400/2500.
+
+    Example config for copy-paste:
+
+    mw_source_gigatronics:
+        module.Class: 'microwave.mw_source_gigatronics.MicrowaveGigatronics'
+        gpib_address: 'GPIB0::12::INSTR'
+        gpib_timeout: 10
+
+    """
 
     _modclass = 'MicrowaveInterface'
     _modtype = 'hardware'

--- a/hardware/microwave/mw_source_smbv.py
+++ b/hardware/microwave/mw_source_smbv.py
@@ -35,8 +35,16 @@ from interface.microwave_interface import TriggerEdge
 
 
 class MicrowaveSmbv(Base, MicrowaveInterface):
-    """ This is the Interface class to define the controls for the simple
-        microwave hardware.
+    """ Hardware file to control a R&S SMBV100A microwave device.
+
+    Example config for copy-paste:
+
+    mw_source_smbv:
+        module.Class: 'microwave.mw_source_smbv.MicrowaveSmbv'
+        gpib_address: 'GPIB0::12::INSTR'
+        gpib_address: 'GPIB0::12::INSTR'
+        gpib_timeout: 10
+
     """
 
     _modclass = 'MicrowaveSmbv'

--- a/hardware/microwave/mw_source_smiq.py
+++ b/hardware/microwave/mw_source_smiq.py
@@ -38,14 +38,14 @@ class MicrowaveSmiq(Base, MicrowaveInterface):
     """ This is the Interface class to define the controls for the simple
         microwave hardware.
 
-    Example configuration:
-    ```
-    smiq:
+    Example config for copy-paste:
+
+    mw_source_smiq:
         module.Class: 'microwave.mw_source_smiq.MicrowaveSmiq'
         gpib_address: 'GPIB0::28::INSTR'
-        gpib_timeout: 20
-        gpib_baud_rate: 460800  # optional
-    ```
+        gpib_timeout: 10
+        #gpib_baud_rate: 460800  # optional
+
     """
 
     _modclass = 'MicrowaveSmiq'

--- a/hardware/microwave/mw_source_smr.py
+++ b/hardware/microwave/mw_source_smr.py
@@ -41,6 +41,14 @@ class MicrowaveSMR(Base, MicrowaveInterface):
     GPIB connection through visa, please have a look at:
 
     http://cdn.rohde-schwarz.com/pws/dl_downloads/dl_common_library/dl_manuals/gb_1/s/smr_1/smr_20-40.pdf
+
+    Example config for copy-paste:
+
+    mw_source_smr:
+        module.Class: 'microwave.mw_source_smr.MicrowaveSMR'
+        gpib_address: 'GPIB0::28::INSTR'
+        gpib_timeout: 10
+
     """
 
     _modclass = 'MicrowaveSMR'

--- a/hardware/microwave/mw_source_srssg.py
+++ b/hardware/microwave/mw_source_srssg.py
@@ -31,7 +31,16 @@ from interface.microwave_interface import MicrowaveMode
 from interface.microwave_interface import TriggerEdge
 
 class MicrowaveSRSSG(Base, MicrowaveInterface):
-    """ Hardware control class to controls SRS SG390 devices.  """
+    """ Hardware control class to controls SRS SG390 devices.
+
+    Example config for copy-paste:
+
+    mw_source_srssg:
+        module.Class: 'microwave.mw_source_srssg.MicrowaveSRSSG'
+        gpib_address: 'GPIB0::12::INSTR'
+        gpib_timeout: 10
+
+    """
 
     _modclass = 'MicrowaveSRSSG'
     _modtype = 'hardware'

--- a/hardware/microwave/mw_source_windfreak_synthhdpro.py
+++ b/hardware/microwave/mw_source_windfreak_synthhdpro.py
@@ -30,8 +30,16 @@ import time
 
 
 class MicrowaveSynthHDPro(Base, MicrowaveInterface):
-    """This is the Interface class to define the controls for the simple
-    microwave hardware.
+    """ Hardware control class to controls a SynthHD Pro.
+
+    Example config for copy-paste:
+
+    mw_source_synthhd:
+        module.Class: 'microwave.mw_source_windfreak_synthhdpro.MicrowaveSynthHDPro'
+        serial_port: 'COM3'
+        serial_timeout: 10 # in seconds
+        output_channel: 0 # either 0 or 1
+
     """
     _modclass = 'MicrowaveSynthHDPro'
     _modtype = 'mwsource'

--- a/hardware/microwave/mw_source_windfreak_synthhdpro.py
+++ b/hardware/microwave/mw_source_windfreak_synthhdpro.py
@@ -30,7 +30,7 @@ import time
 
 
 class MicrowaveSynthHDPro(Base, MicrowaveInterface):
-    """ Hardware control class to controls a SynthHD Pro.
+    """ Hardware class to controls a SynthHD Pro.
 
     Example config for copy-paste:
 

--- a/hardware/motor/aptmotor.py
+++ b/hardware/motor/aptmotor.py
@@ -793,59 +793,57 @@ class APTStage(Base, MotorInterface):
 
     For example, a config file entry for a single-axis rotating half-wave-plate stage would look like:
 
-    ```
-    # hwp_motor:
-    #     module.Class: 'motor.aptmotor.APTStage'
-    #     dll_path:\ 'C:\Program Files\Thorlabs\'
-    #     axis_labels:
-    #         - phi
-    #     phi:
-    #         hw_type:'TDC001'
-    #         serial_num:27500136
-    #         pitch:  17.87
-    #         unit:'degree'
-    #         constraints:
-    #             pos_.min: -360
-    #             pos_max: 720
-    #             vel_min: 1.0
-    #             vel_max: 10.0
-    #             acc_min:4.0
-    #             acc_max:10.0
-    ```
+    hwp_motor:
+        module.Class: 'motor.aptmotor.APTStage'
+        dll_path:\ 'C:\Program Files\Thorlabs\'
+        axis_labels:
+            - phi
+        phi:
+            hw_type: 'TDC001'
+            serial_num: 27500136
+            pitch: 17.87
+            unit: 'degree'
+            constraints:
+                pos_min: -360
+                pos_max: 720
+                vel_min: 1.0
+                vel_max: 10.0
+                acc_min: 4.0
+                acc_max: 10.0
+
     A config file entry for a linear xy-axis stage would look like:
 
-    ```
-    # hwp_motor:
-    #     module.Class: 'motor.aptmotor.APTStage'
-    #     dll_path:\ 'C:\Program Files\Thorlabs\'
-    #     axis_labels:
-    #         - x
-    #         - y
-    #     x:
-    #         hw_type:'TDC001'
-    #         serial_num:00000000
-    #         pitch:  1
-    #         unit:'m'
-    #         constraints:
-    #             pos_.min: 0
-    #             pos_max: 2
-    #             vel_min: 1.0
-    #             vel_max: 10.0
-    #             acc_min:4.0
-    #             acc_max:10.0
-    #     y:
-    #         hw_type:'TDC001'
-    #         serial_num:00000001
-    #         pitch:  1
-    #         unit:'m'
-    #         constraints:
-    #             pos_.min: -1
-    #             pos_max: 1
-    #             vel_min: 1.0
-    #             vel_max: 10.0
-    #             acc_min:4.0
-    #             acc_max:10.0
-    ```
+    hwp_motor:
+        module.Class: 'motor.aptmotor.APTStage'
+        dll_path: 'C:\\Program Files\\Thorlabs\\'
+        axis_labels:
+            - x
+            - y
+        x:
+            hw_type: 'TDC001'
+            serial_num: 00000000
+            pitch:  1
+            unit: 'm'
+            constraints:
+                pos_min: 0
+                pos_max: 2
+                vel_min: 1.0
+                vel_max: 10.0
+                acc_min: 4.0
+                acc_max: 10.0
+        y:
+            hw_type: 'TDC001'
+            serial_num: 00000001
+            pitch: 1
+            unit: 'm'
+            constraints:
+                pos_min: -1
+                pos_max: 1
+                vel_min: 1.0
+                vel_max: 10.0
+                acc_min: 4.0
+                acc_max: 10.0
+
     """
 
     def on_activate(self):

--- a/hardware/motor/motor_dummy.py
+++ b/hardware/motor/motor_dummy.py
@@ -33,7 +33,14 @@ class MotorAxisDummy:
 
 
 class MotorDummy(Base, MotorInterface):
-    """ This is the dummy class to simulate a motorized stage. """
+    """ This is the dummy class to simulate a motorized stage.
+
+    Example config for copy-paste:
+
+    motor_dummy:
+        module.Class: 'motor.motor_dummy.MotorDummy'
+
+    """
 
     _modclass = 'MotorDummy'
     _modtype = 'hardware'

--- a/hardware/motor/motor_stage_micos.py
+++ b/hardware/motor/motor_stage_micos.py
@@ -29,8 +29,61 @@ from core.module import Base, ConfigOption
 from interface.motor_interface import MotorInterface
 
 class MotorStageMicos(Base, MotorInterface):
-    """unstable: Jochen Scheuer.
-    Hardware class to define the controls for the Micos stage of PI.
+    """ Hardware class to define the controls for the Micos stage of PI.
+
+    unstable: Jochen Scheuer.
+
+    Example config for copy-paste:
+
+    motorstage_micos:
+        module.Class: 'motor.motor_stage_micos.MotorStageMicos'
+        com_port_xy: 'COM4'
+        baud_rate_xy: 57600
+        timeout_xy: 1000
+        term_char_xy: '\n'
+        com_port_zphi: 'COM2'
+        baud_rate_zphi: 57600
+        timeout_zphi: 1000
+        term_char_zphi: '\n'
+
+        first_axis_label: 'x'
+        second_axis_label: 'y'
+        third_axis_label: 'z'
+        fourth_axis_label: 'phi'
+        first_axis_ID: '0'
+        second_axis_ID: '1'
+        third_axis_ID: '0'
+        fourth_axis_ID: '1'
+
+        first_min: -0.1 # in m
+        first_max: 0.1 # in m
+        second_min: -0.1 # in m
+        second_max: 0.1 # in m
+        third_min: -0.1 # in m
+        third_max: 0.1 # in m
+        fourth_min: -0.1 # in m
+        fourth_max: 0.1 # in m
+
+        first_axis_step: 1e-7 # in m
+        second_axis_step: 1e-7 # in m
+        third_axis_step: 1e-7 # in m
+        fourth_axis_step: 1e-7 # in m
+
+        vel_first_min: 1e-5 # in m/s
+        vel_first_max: 5e-2 # in m/s
+        vel_second_min: 1e-5 # in m/s
+        vel_second_max: 5e-2 # in m/s
+        vel_third_min: 1e-5 # in m/s
+        vel_third_max: 5e-2 # in m/s
+        vel_fourth_min: 1e-5 # in m/s
+        vel_fourth_max: 5e-2 # in m/s
+
+        vel_first_axis_step: 1e-5 # in m/s
+        vel_second_axis_step: 1e-5 # in m/s
+        vel_third_axis_step: 1e-5 # in m/s
+        vel_fourth_axis_step: 1e-5 # in m/s
+
+
     """
     _modclass = 'MotorStageMicos'
     _modtype = 'hardware'

--- a/hardware/motor/motor_stage_pi.py
+++ b/hardware/motor/motor_stage_pi.py
@@ -32,6 +32,44 @@ class MotorStagePI(Base, MotorInterface):
     """unstable: Christoph Müller, Simon Schmitt
     This is the Interface class to define the controls for the simple
     microwave hardware.
+
+    Example config for copy-paste:
+
+    motorstage_pi:
+        module.Class: 'motor.motor_stage_pi.MotorStagePI'
+        com_port_pi_xyz: 'ASRL1::INSTR'
+        pi_xyz_baud_rate: 9600
+        pi_xyz_timeout: 1000
+        pi_xyz_term_char: '\n'
+        pi_first_axis_label: 'x'
+        pi_second_axis_label: 'y'
+        pi_third_axis_label: 'z'
+        pi_first_axis_ID: '1'
+        pi_second_axis_ID: '2'
+        pi_third_axis_ID: '3'
+
+        pi_first_min: -0.1 # in m
+        pi_first_max: 0.1 # in m
+        pi_second_min: -0.1 # in m
+        pi_second_max: 0.1 # in m
+        pi_third_min: -0.1 # in m
+        pi_third_max: 0.1 # in m
+
+        pi_first_axis_step: 1e-7 # in m
+        pi_second_axis_step: 1e-7 # in m
+        pi_third_axis_step: 1e-7 # in m
+
+        vel_first_min: 1e-5 # in m/s
+        vel_first_max: 5e-2 # in m/s
+        vel_second_min: 1e-5 # in m/s
+        vel_second_max: 5e-2 # in m/s
+        vel_third_min: 1e-5 # in m/s
+        vel_third_max: 5e-2 # in m/s
+
+        vel_first_axis_step: 1e-5 # in m/s
+        vel_second_axis_step: 1e-5 # in m/s
+        vel_third_axis_step: 1e-5 # in m/s
+
     """
     _modclass = 'MotorStagePI'
     _modtype = 'hardware'

--- a/hardware/motor/zaber_motor_rotation_stage.py
+++ b/hardware/motor/zaber_motor_rotation_stage.py
@@ -31,6 +31,28 @@ class MotorRotationZaber(Base, MotorInterface):
     """unstable: Christoph Müller, Simon Schmitt
     This is the Interface class to define the controls for the simple
     microwave hardware.
+
+    Example config for copy-paste:
+
+    motorstage_zaber:
+        module.Class: 'motor.zaber_motor_rotation_stage.MotorRotationZaber'
+        com_port_zaber: 'ASRL1::INSTR'
+        zaber_baud_rate: 9600
+        zaber_timeout: 1000
+        zaber_term_char: '\n'
+
+        zaber_axis_label: 'phi'
+        zaber_angle_min: -1e5 # in degrees
+        zaber_angle_max: 1e5 # in degrees
+        zaber_angle_step: 1e-5 # in degrees
+
+        zaber_velocity_min: 1e-3 # in degrees/s
+        zaber_velocity_max: 10 # in degrees/s
+        zaber_velocity_step: -1e-3 # in degrees/s
+
+        zaber_micro_step_size: 234.375e-6
+        zaber_speed_conversion: 9.375
+
     """
     _modclass = 'MotorRotation'
     _modtype = 'hardware'

--- a/hardware/national_instruments_pulser.py
+++ b/hardware/national_instruments_pulser.py
@@ -34,12 +34,20 @@ from collections import OrderedDict
 
 class NationalInstrumentsPulser(Base, PulserInterface):
     """ Pulse generator using NI-DAQmx
+
+    Example config for copy-paste:
+
+    ni_pulser:
+        module.Class: 'national_instruments_pulser.NationalInstrumentsPulser'
+        device: 'Dev0'
+        #pulsed_file_dir: 'C:\\Software\\qudi_pulsed_files' # optional, path
+
     """
 
     _modtype = 'PulserInterface'
     _modclass = 'hardware'
 
-    self.device = ConfigOption('device', 'Dev0', missing='warn')
+    device = ConfigOption('device', default='Dev0', missing='warn')
 
     def on_activate(self):
         """ Activate module

--- a/hardware/national_instruments_x_series.py
+++ b/hardware/national_instruments_x_series.py
@@ -34,14 +34,59 @@ from interface.confocal_scanner_interface import ConfocalScannerInterface
 
 
 class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInterface, ODMRCounterInterface):
-    """ stable: Kay Jahnke, Alexander Stark
-
-    A National Instruments device that can count and control microvave generators.
+    """ A National Instruments device that can count and control microvave generators.
 
     !!!!!! NI USB 63XX, NI PCIe 63XX and NI PXIe 63XX DEVICES ONLY !!!!!!
 
     See [National Instruments X Series Documentation](@ref nidaq-x-series) for details.
-  """
+
+    stable: Kay Jahnke, Alexander Stark
+
+    Example config for copy-paste:
+
+    nicard_6343:
+        module.Class: 'national_instruments_x_series.NationalInstrumentsXSeries'
+        photon_sources:
+            - '/Dev1/PFI8'
+        #    - '/Dev1/PFI9'
+        clock_channel: '/Dev1/Ctr0'
+        default_clock_frequency: 100 # optional, in Hz
+        counter_channels:
+            - '/Dev1/Ctr1'
+        counter_ai_channels:
+            - '/Dev1/AI0'
+        default_scanner_clock_frequency: 100 # optional, in Hz
+        scanner_clock_channel: '/Dev1/Ctr2'
+        pixel_clock_channel: '/Dev1/PFI6'
+        scanner_ao_channels:
+            - '/Dev1/AO0'
+            - '/Dev1/AO1'
+            - '/Dev1/AO2'
+            - '/Dev1/AO3'
+        scanner_ai_channels:
+            - '/Dev1/AI1'
+        scanner_counter_channels:
+            - '/Dev1/Ctr3'
+        scanner_voltage_ranges:
+            - [-10, 10]
+            - [-10, 10]
+            - [-10, 10]
+            - [-10, 10]
+        scanner_position_ranges:
+            - [0e-6, 200e-6]
+            - [0e-6, 200e-6]
+            - [-100e-6, 100e-6]
+            - [-10, 10]
+
+        odmr_trigger_channel: '/Dev1/PFI7'
+
+        gate_in_channel: '/Dev1/PFI9'
+        default_samples_number: 50
+        max_counts: 3e7
+        read_write_timeout: 10
+        counting_edge_rising: True
+
+    """
 
     _modtype = 'NICard'
     _modclass = 'hardware'
@@ -73,10 +118,10 @@ class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInte
     # number of readout samples, mainly used for gated counter
     _default_samples_number = ConfigOption('default_samples_number', 50, missing='info')
     # used as a default for expected maximum counts
-    _max_counts = ConfigOption('max_counts', 3e7)
+    _max_counts = ConfigOption('max_counts', default=3e7)
     # timeout for the Read or/and write process in s
-    _RWTimeout = ConfigOption('read_write_timeout', 10)
-    _counting_edge_rising = ConfigOption('counting_edge_rising', True)
+    _RWTimeout = ConfigOption('read_write_timeout', default=10)
+    _counting_edge_rising = ConfigOption('counting_edge_rising', default=True)
 
     def on_activate(self):
         """ Starts up the NI Card at activation.

--- a/hardware/odmr_counter_dummy.py
+++ b/hardware/odmr_counter_dummy.py
@@ -26,7 +26,7 @@ from core.module import Base, Connector, ConfigOption
 from interface.odmr_counter_interface import ODMRCounterInterface
 
 class ODMRCounterDummy(Base, ODMRCounterInterface):
-    """This is the Dummy hardware class that simulates the controls for a simple ODMR.
+    """ Dummy hardware class to simulate the controls for a simple ODMR.
 
     Example config for copy-paste:
 

--- a/hardware/odmr_counter_dummy.py
+++ b/hardware/odmr_counter_dummy.py
@@ -27,7 +27,17 @@ from interface.odmr_counter_interface import ODMRCounterInterface
 
 class ODMRCounterDummy(Base, ODMRCounterInterface):
     """This is the Dummy hardware class that simulates the controls for a simple ODMR.
+
+    Example config for copy-paste:
+
+    odmr_counter_dummy:
+        module.Class: 'odmr_counter_dummy.ODMRCounterDummy'
+        clock_frequency: 100 # in Hz
+        number_of_channels: 2
+        fitlogic: 'fitlogic' # name of the fitlogic module, see default config
+
     """
+
     _modclass = 'ODMRCounterDummy'
     _modtype = 'hardware'
 

--- a/hardware/pi_pwm.py
+++ b/hardware/pi_pwm.py
@@ -29,6 +29,14 @@ import RPi.GPIO as GPIO
 
 class PiPWM(Base, ProcessControlInterface):
     """ Hardware module for Raspberry Pi-based PWM controller.
+
+    Example config for copy-paste:
+
+    pi_pwm:
+        module.Class: 'pi_pwm.PiPWM'
+        channel: 0
+        frequency: 100 # in Hz
+
     """
 
     _modclass = 'ProcessControlInterface'

--- a/hardware/picoquant/picoharp300.py
+++ b/hardware/picoquant/picoharp300.py
@@ -87,7 +87,7 @@ correspond to standard C/C++ data types as follows:
 
 
 class PicoHarp300(Base, SlowCounterInterface, FastCounterInterface):
-    """Hardware class to control the Picoharp 300 from PicoQuant.
+    """ Hardware class to control the Picoharp 300 from PicoQuant.
 
     This class is written according to the Programming Library Version 3.0
     Tested Version: Alex S.

--- a/hardware/picoquant/picoharp300.py
+++ b/hardware/picoquant/picoharp300.py
@@ -90,12 +90,20 @@ class PicoHarp300(Base, SlowCounterInterface, FastCounterInterface):
     """Hardware class to control the Picoharp 300 from PicoQuant.
 
     This class is written according to the Programming Library Version 3.0
-    STABLE AND TESTED VERSION: Alex S.
+    Tested Version: Alex S.
+
+    Example config for copy-paste:
+
+    fastcounter_picoharp300:
+        module.Class: 'picoquant.picoharp300.PicoHarp300'
+        deviceID: 0 # a device index from 0 to 7.
+        mode: 0 # 0: histogram mode, 2: T2 mode, 3: T3 mode
+        
     """
     _modclass = 'PicoHarp300'
     _modtype = 'hardware'
 
-    _deviceID = ConfigOption('deviceID', 0, missing='warn')
+    _deviceID = ConfigOption('deviceID', 0, missing='warn') # a device index from 0 to 7.
     _mode = ConfigOption('mode', 0, missing='warn')
 
     sigReadoutPicoharp = QtCore.Signal()
@@ -186,8 +194,8 @@ class PicoHarp300(Base, SlowCounterInterface, FastCounterInterface):
         return errorcode
 
     def _set_constants(self):
-        """Set the constants (max and min values) for the Picoharp300 device.
-        These setting are taken from phdefin.h"""
+        """ Set the constants (max and min values) for the Picoharp300 device.
+        These setting are taken from phdefin.h """
 
         self.MODE_HIST = 0
         self.MODE_T2 = 2
@@ -225,7 +233,7 @@ class PicoHarp300(Base, SlowCounterInterface, FastCounterInterface):
     def check(self, func_val):
         """ Check routine for the received error codes.
 
-        @param func_val int: return error code of the called function.
+        @param int func_val: return error code of the called function.
 
         @return int: pass the error code further so that other functions have
                      the possibility to use it.
@@ -312,7 +320,7 @@ class PicoHarp300(Base, SlowCounterInterface, FastCounterInterface):
     def close_connection(self):
         """Close the connection to the device.
 
-        @param int deviceID: a divice index from 0 to 7.
+        @param int deviceID: a device index from 0 to 7.
         """
         self.connected_to_device = False
         self.check(self._dll.PH_CloseDevice(self._deviceID))

--- a/hardware/process_dummy.py
+++ b/hardware/process_dummy.py
@@ -27,7 +27,14 @@ import numpy as np
 
 class ProcessDummy(Base, ProcessInterface, ProcessControlInterface):
     """ Methods to control slow laser switching devices.
+
+    Example config for copy-paste:
+
+    process_dummy:
+        module.Class: 'process_dummy.ProcessDummy'
+
     """
+
     _modclass = 'Process'
     _modtype = 'hardware'
 

--- a/hardware/pulser_dummy.py
+++ b/hardware/pulser_dummy.py
@@ -33,6 +33,12 @@ class PulserDummy(Base, PulserInterface):
     Be careful in adjusting the method names in that class, since some of them
     are also connected to the mwsourceinterface (to give the AWG the possibility
     to act like a microwave source).
+
+    Example config for copy-paste:
+
+    pulser_dummy:
+        module.Class: 'pulser_dummy.PulserDummy'
+
     """
     _modclass = 'PulserDummy'
     _modtype = 'hardware'

--- a/hardware/sc_magnet/magnet.py
+++ b/hardware/sc_magnet/magnet.py
@@ -30,12 +30,28 @@ import re
 
 
 class Magnet(Base, MagnetInterface):
-    """Magnet positioning software for superconducting magnet.
+    """ Magnet positioning software for superconducting magnet.
+
     Enables precise positioning of the magnetic field in spherical coordinates
     with the angle theta, phi and the radius rho.
     The superconducting magnet has three coils, one in x, y and z direction respectively.
     The current through these coils is used to compute theta, phi and rho.
     The alignment can be done manually as well as automatically via fluorescence alignment.
+
+    Example config for copy-paste:
+
+    sc_magnet:
+        module.Class: 'sc_magnet.magnet.Magnet'
+        magnet_port: 3000
+        magnet_IP_address_x: 192.168.0.12
+        magnet_IP_address_y: 192.168.0.13
+        magnet_IP_address_z: 192.168.0.14
+        magnet_waitingtime: 0.01 # in seconds
+        magnet_x_constr: 1.0
+        magnet_y_constr: 2.0
+        magnet_z_constr: 3.0
+        magnet_rho_constr: 1.2
+
     """
 
     _modtype = 'Magnet'

--- a/hardware/simple_data_acq.py
+++ b/hardware/simple_data_acq.py
@@ -27,7 +27,16 @@ from interface.simple_data_interface import SimpleDataInterface
 
 class SimpleAcq(Base, SimpleDataInterface):
     """ Read human readable numbers from serial port.
+
+    Example config for copy-paste:
+
+    simple_data_acq:
+        module.Class: 'simple_data_acq.SimpleAcq'
+        interface: 'ASRL1::INSTR'
+        baudrate: 115200
+
     """
+
     _modclass = 'simple'
     _modtype = 'hardware'
 

--- a/hardware/simple_data_dummy.py
+++ b/hardware/simple_data_dummy.py
@@ -27,8 +27,15 @@ from interface.simple_data_interface import SimpleDataInterface
 
 
 class SimpleDummy(Base, SimpleDataInterface):
+    """ A simple Data generator dummy.
+
+    Example config for copy-paste:
+
+    simple_data_dummy:
+        module.Class: 'simple_data_dummy.SimpleDummy'
+
     """
-    """
+
     _modclass = 'simple'
     _modtype = 'hardware'
 

--- a/hardware/slow_counter_dummy.py
+++ b/hardware/slow_counter_dummy.py
@@ -31,10 +31,21 @@ from interface.slow_counter_interface import CountingMode
 
 
 class SlowCounterDummy(Base, SlowCounterInterface):
+    """ Dummy hardware class to emulate a slow counter with various distributions.
 
-    """This is the Interface class to define the controls for the simple
-    microwave hardware.
+    Example config for copy-paste:
+
+    slow_counter_dummy:
+        module.Class: 'slow_counter_dummy.SlowCounterDummy'
+        clock_frequency: 100 # in Hz
+        samples_number: 10
+        source_channels: 2
+        count_distribution: 'dark_bright_gaussian' # other options are:
+            # 'uniform, 'exponential', 'single_poisson', 'dark_bright_poisson'
+            #  and 'single_gaussian'.
+
     """
+
     _modclass = 'SlowCounterDummy'
     _modtype = 'hardware'
 

--- a/hardware/spectrometer/lightfield_spectrometer.py
+++ b/hardware/spectrometer/lightfield_spectrometer.py
@@ -48,8 +48,14 @@ class LFImageMode(Enum):
 class Lightfield(Base, SpectrometerInterface):
     """ Control Princeton Instruments Lightfield from Qudi.
 
-        This hardware module needs a brave soul fluent in C# and Python,
-        as it can only do one thing right now: crash Lightfield.
+    This hardware module needs a brave soul fluent in C# and Python,
+    as it can only do one thing right now: crash Lightfield.
+
+    Example config for copy-paste:
+
+    lightfield_spectrometer:
+        module.Class: 'spectrometer.lightfield_spectrometer.Lightfield'
+
     """
 
     def on_activate(self):
@@ -110,29 +116,23 @@ class Lightfield(Base, SpectrometerInterface):
         self.lastframe = list()
 
     def on_deactivate(self):
-        """ Deactivate module.
+        """ Deactivate module. """
 
-            @param e object: fysom state transition information
-
-            This method needs to get rid of all the stuff fron the activation.
-        """
         if hasattr(self, 'au'):
             del self.au
 
 # Callbacks
     def settingChangedCallback(self, sender, args):
-        """ Lightfieldsettings changed.
-        """
+        """ Lightfieldsettings changed. """
         pass
 
     def exitHandler(self, sender, args):
-        """ Something went wrong, clean up.
-        """
+        """ Something went wrong, clean up. """
         del self.au
 
     def frameCallback(self, sender, args):
-        """ A frame/spectrum was recorded.
-        """
+        """ A frame/spectrum was recorded. """
+
         print(sender)
         print(args)
         dataSet = args.ImageDataSet
@@ -147,8 +147,7 @@ class Lightfield(Base, SpectrometerInterface):
         self.lastframe = list(arr)
 
     def setAcquisitionComplete(self, sender, args):
-        """ A frame/spectrum was recorded
-        """
+        """ A frame/spectrum was recorded. """
         pass
 
 # other stuff

--- a/hardware/spectrometer/spectrometer_dummy.py
+++ b/hardware/spectrometer/spectrometer_dummy.py
@@ -31,7 +31,14 @@ import numpy as np
 class SpectrometerInterfaceDummy(Base,SpectrometerInterface):
     """ Dummy spectrometer module.
 
-        Shows a silicon vacancy spectrum at liquid helium temperatures.
+    Shows a silicon vacancy spectrum at liquid helium temperatures.
+
+    Example config for copy-paste:
+
+    spectrometer_dummy:
+        module.Class: 'spectrometer.spectrometer_dummy.SpectrometerInterfaceDummy'
+        fitlogic: 'fitlogic' # name of the fitlogic module, see default config
+
     """
 
     fitlogic = Connector(interface='FitLogic')

--- a/hardware/spectrometer/winspec_spectrometer.py
+++ b/hardware/spectrometer/winspec_spectrometer.py
@@ -41,6 +41,12 @@ import comtypes.gen.WINX32Lib as WinSpecLib
 
 class WinSpec32(Base, SpectrometerInterface):
     """ Hardware module for reading spectra from the WinSpec32 spectrometer software.
+
+    Example config for copy-paste:
+
+    spectrometer_dummy:
+        module.Class: 'spectrometer.winspec_spectrometer.WinSpec32'
+
     """
 
     def on_activate(self):

--- a/hardware/swabian_instruments/pulse_streamer.py
+++ b/hardware/swabian_instruments/pulse_streamer.py
@@ -36,7 +36,16 @@ import hardware.swabian_instruments.pulse_streamer_pb2 as pulse_streamer_pb2
 import dill
 
 class PulseStreamer(Base, PulserInterface):
-    """Methods to control PulseStreamer.
+    """ Methods to control PulseStreamer.
+
+    Example config for copy-paste:
+
+    pulse_streamer:
+        module.Class: 'swabian_instruments.pulse_streamer.PulseStreamer'
+        pulsestreamer_ip: '192.168.1.100'
+        laser_channel: 0
+        uw_x_channel: 2
+
     """
     _modclass = 'pulserinterface'
     _modtype = 'hardware'

--- a/hardware/swabian_instruments/timetagger_fast_counter.py
+++ b/hardware/swabian_instruments/timetagger_fast_counter.py
@@ -33,9 +33,11 @@ class TimeTaggerFastCounter(Base, FastCounterInterface):
 
     fastcounter_timetagger:
         module.Class: 'swabian_instruments.timetagger_fast_counter.TimeTaggerFastCounter'
-        pulsestreamer_ip: '192.168.1.100'
-        laser_channel: 0
-        uw_x_channel: 2
+        timetagger_channel_apd_0: 0
+        timetagger_channel_apd_1: 1
+        timetagger_channel_detect: 2
+        timetagger_channel_sequence: 3
+        timetagger_sum_channels: 4
 
     """
     _modclass = 'TimeTaggerFastCounter'

--- a/hardware/swabian_instruments/timetagger_fast_counter.py
+++ b/hardware/swabian_instruments/timetagger_fast_counter.py
@@ -27,6 +27,17 @@ import os
 
 
 class TimeTaggerFastCounter(Base, FastCounterInterface):
+    """ Hardware class to controls a Time Tagger from Swabian Instruments.
+
+    Example config for copy-paste:
+
+    fastcounter_timetagger:
+        module.Class: 'swabian_instruments.timetagger_fast_counter.TimeTaggerFastCounter'
+        pulsestreamer_ip: '192.168.1.100'
+        laser_channel: 0
+        uw_x_channel: 2
+
+    """
     _modclass = 'TimeTaggerFastCounter'
     _modtype = 'hardware'
 

--- a/hardware/switches/flipmirror.py
+++ b/hardware/switches/flipmirror.py
@@ -29,6 +29,13 @@ from interface.switch_interface import SwitchInterface
 class FlipMirror(Base, SwitchInterface):
     """ This class is implements communication with the Radiant Dyes flip mirror driver
         through pyVISA.
+
+    Example config for copy-paste:
+
+    flipmirror_switch:
+        module.Class: 'switches.flipmirror.FlipMirror'
+        interface: 'ASRL1::INSTR'
+
     """
     _modclass = 'switchinterface'
     _modtype = 'hardware'

--- a/hardware/switches/hbridge.py
+++ b/hardware/switches/hbridge.py
@@ -28,6 +28,13 @@ from interface.switch_interface import SwitchInterface
 
 class HBridge(Base, SwitchInterface):
     """ Methods to control slow laser switching devices.
+
+    Example config for copy-paste:
+
+    flipmirror_switch:
+        module.Class: 'switches.hbridge.HBridge'
+        interface: 'ASRL1::INSTR'
+
     """
     _modclass = 'switchinterface'
     _modtype = 'hardware'

--- a/hardware/switches/ok_fpga/ok_fpga_switch.py
+++ b/hardware/switches/ok_fpga/ok_fpga_switch.py
@@ -29,8 +29,13 @@ from interface.switch_interface import SwitchInterface
 
 
 class OkFpgaTtlSwitch(Base, SwitchInterface):
+    """ Methods to control TTL switch running on OK FPGA.
 
-    """Methods to control TTL switch running on OK FPGA.
+    Example config for copy-paste:
+
+    fpga_ok_switch:
+        module.Class: 'switches.ok_fpga.ok_fpga_switch.OkFpgaTtlSwitch'
+
     """
     _modclass = 'switchinterface'
     _modtype = 'hardware'

--- a/hardware/switches/ok_fpga/ok_s6_switch.py
+++ b/hardware/switches/ok_fpga/ok_s6_switch.py
@@ -38,6 +38,13 @@ class HardwareSwitchFpga(Base, SwitchInterface):
     The Frontpanel is basically a C++ interface, where a wrapper was used (SWIG) to access the
     dll library. Be aware that the wrapper is specified for a specific version of python
     (here python 3.4), and it is not guaranteed to be working with other versions.
+
+    Example config for copy-paste:
+
+    fpga_oks6_switch:
+        module.Class: 'switches.ok_fpga.ok_s6_switch.HardwareSwitchFpga'
+        fpga_serial: '143400058N'
+
     """
     _modclass = 'HardwareSwitchFpga'
     _modtype = 'hardware'

--- a/hardware/switches/switch_dummy.py
+++ b/hardware/switches/switch_dummy.py
@@ -26,7 +26,14 @@ import time
 
 class SwitchDummy(Base, SwitchInterface):
     """ Methods to control slow laser switching devices.
+
+    Example config for copy-paste:
+
+    switch_dummy:
+        module.Class: 'switches.switch_dummy.SwitchDummy'
+
     """
+
     _modclass = 'switchinterfacedummy'
     _modtype = 'hardware'
 

--- a/hardware/timetagger_counter.py
+++ b/hardware/timetagger_counter.py
@@ -30,8 +30,17 @@ from interface.slow_counter_interface import SlowCounterConstraints
 from interface.slow_counter_interface import CountingMode
 
 class TimeTaggerCounter(Base, SlowCounterInterface):
+    """ Using the TimeTagger as a slow counter.
 
-    """ Using the TimeTagger as a counter."""
+    Example config for copy-paste:
+
+    timetagger_slowcounter:
+        module.Class: 'timetagger_counter.TimeTaggerCounter'
+        timetagger_channel_apd_0: 0
+        timetagger_channel_apd_1: 1
+        timetagger_sum_channels: 2
+
+    """
 
     _modtype = 'TTCounter'
     _modclass = 'hardware'

--- a/hardware/tsys01_spi.py
+++ b/hardware/tsys01_spi.py
@@ -31,13 +31,22 @@ import time
 
 class TSYS01SPI(Base, ProcessInterface):
     """ Measurement Systems TSYS01 temperature sensor.
+
+    Example config for copy-paste:
+
+    temp_tsys:
+        module.Class: 'tsys01_spi.TSYS01SPI'
+        bus: 0
+        device: 0
+
     """
+
     _modclass = 'TSYS01'
     _modtype = 'hardware'
 
     # config opts
-    bus = ConfigOption('bus', 0, missing='warn')
-    device = ConfigOption('device', 0, missing='warn')
+    bus = ConfigOption('bus', default=0, missing='warn')
+    device = ConfigOption('device', default=0, missing='warn')
 
     # commands to chip (constants)
     READ_ADC  = 0x00

--- a/hardware/wavemeter_dummy.py
+++ b/hardware/wavemeter_dummy.py
@@ -30,8 +30,7 @@ from core.util.mutex import Mutex
 
 
 class HardwarePull(QtCore.QObject):
-
-    """Helper class for running the hardware communication in a separate
+    """ Helper class for running the hardware communication in a separate
     thread.
     """
 
@@ -45,7 +44,7 @@ class HardwarePull(QtCore.QObject):
         """ Threaded method that can be called by a signal from outside to start
             the timer.
 
-        @param bool state: (True) starts timer, (False) stops it.
+        @param bool state_change: (True) starts timer, (False) stops it.
         """
 
         if state_change:
@@ -57,8 +56,7 @@ class HardwarePull(QtCore.QObject):
                 self.timer.stop()
 
     def _measure_thread(self):
-        """ The threaded method querying the data from the wavemeter.
-        """
+        """ The threaded method querying the data from the wavemeter. """
 
         range_step = 0.1
 
@@ -70,7 +68,15 @@ class HardwarePull(QtCore.QObject):
 
 
 class WavemeterDummy(Base, WavemeterInterface):
+    """ Dummy hardware class to simulate the controls for a wavemeter.
 
+    Example config for copy-paste:
+
+    temp_tsys:
+        module.Class: 'wavemeter_dummy.WavemeterDummy'
+        measurement_timing: 10.0
+
+    """
     _modclass = 'WavemeterDummy'
     _modtype = 'hardware'
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add a config example to each hardware module which can be copy-pasted.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, the config options do not specify a data type, hence, it is very hard to understand the config option if no examples or descriptions are present. (I believe that an attempt in this direction was pursued by @latchr.)
For qudi users, it might be just tedious to find out the correct type of the config option, because the simple 'shape' (datatype) is not always obvious and it forces you to go through the implemented methods, to extract this information (=> time consuming).
For new qudi users, it increases significantly the barrier to start with an implemented module.

Therefore, I propose to insert (at least in every hardware) qudi module an example configuration, which can be just copy-pasted into the config file. The biggest advantage is that the config pattern is already given, and the present options have just to be adapted.

This pull request contains mainly docstring additions, therefore the changes should be non-breaking. Only the [AWG5002C](https://github.com/Ulm-IQO/qudi/blob/0a8868e502b93965b9bc606b29c1d0425e61bdfd/hardware/awg/tektronix_awg5002c.py) file was adapted to have the same pattern for the pulsed_file_dir option as in [tektronix_awg70k.py](https://github.com/Ulm-IQO/qudi/compare/configexample_in_hardware?expand=1#diff-85a9070b02c419b3e73d1f4fc89f0680) and [tektronix_awg7k.py](https://github.com/Ulm-IQO/qudi/compare/configexample_in_hardware?expand=1#diff-72e8335b98fce72631bc45b20a3421bf).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Improve docstrings (non-breaking changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
