### PR TITLE
Live odmr

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -24,6 +24,7 @@ This can be used to specify the axis labels for the measurement (excluding units
 * Microwave interface passes trigger timing to microwave source, needs hardware module adjustments for not-in-tree modules
 * Bug fixes and support for SMD12 laser controller
 * For SMIQs added config options to additionally limit frequency and power. Added constraint for SMQ06B model.
+* Added live OMDR functionality to only calculate the average signal over a limited amount of scanned lines
 * New hardware file for Microwave source - Anritsu MG3691C has been added.
 * New hardware file for Microwave source - WindFreak Technologies SynthHDPro 54MHz-13GHz source
 * New hardware file for AWG - Keysight M3202A 1GS/s 4-channel PXIe AWG

--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -272,7 +272,8 @@ class ODMRGui(GUIBase):
         self.sigClockFreqChanged.connect(self._odmr_logic.set_clock_frequency,
                                          QtCore.Qt.QueuedConnection)
         self.sigSaveMeasurement.connect(self._odmr_logic.save_odmr_data, QtCore.Qt.QueuedConnection)
-        self.sigAverageLinesChanged.connect(self._odmr_logic.set_average_length, QtCore.Qt.QueuedConnection)
+        self.sigAverageLinesChanged.connect(self._odmr_logic.set_average_length,
+                                            QtCore.Qt.QueuedConnection)
 
         # Update signals coming from logic:
         self._odmr_logic.sigParameterUpdated.connect(self.update_parameter,
@@ -688,6 +689,12 @@ class ODMRGui(GUIBase):
             self._mw.cw_power_DoubleSpinBox.blockSignals(True)
             self._mw.cw_power_DoubleSpinBox.setValue(param)
             self._mw.cw_power_DoubleSpinBox.blockSignals(False)
+
+        param = param_dict.get('average_length')
+        if param is not None:
+            self._mw.average_level_SpinBox.blockSignals(True)
+            self._mw.average_level_SpinBox.setValue(param)
+            self._mw.average_level_SpinBox.blockSignals(False)
         return
 
     ############################################################################

--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -90,6 +90,7 @@ class ODMRGui(GUIBase):
     sigRuntimeChanged = QtCore.Signal(float)
     sigDoFit = QtCore.Signal(str, object, object, int)
     sigSaveMeasurement = QtCore.Signal(str, list, list)
+    sigAverageLinesChanged = QtCore.Signal(int)
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -239,6 +240,7 @@ class ODMRGui(GUIBase):
         self._mw.odmr_cb_min_DoubleSpinBox.valueChanged.connect(self.colorscale_changed)
         self._mw.odmr_cb_high_percentile_DoubleSpinBox.valueChanged.connect(self.colorscale_changed)
         self._mw.odmr_cb_low_percentile_DoubleSpinBox.valueChanged.connect(self.colorscale_changed)
+        self._mw.average_level_SpinBox.valueChanged.connect(self.average_level_changed)
         # Internal trigger signals
         self._mw.odmr_cb_manual_RadioButton.clicked.connect(self.colorscale_changed)
         self._mw.odmr_cb_centiles_RadioButton.clicked.connect(self.colorscale_changed)
@@ -269,6 +271,7 @@ class ODMRGui(GUIBase):
         self.sigClockFreqChanged.connect(self._odmr_logic.set_clock_frequency,
                                          QtCore.Qt.QueuedConnection)
         self.sigSaveMeasurement.connect(self._odmr_logic.save_odmr_data, QtCore.Qt.QueuedConnection)
+        self.sigAverageLinesChanged.connect(self._odmr_logic.set_average_length, QtCore.Qt.QueuedConnection)
 
         # Update signals coming from logic:
         self._odmr_logic.sigParameterUpdated.connect(self.update_parameter,
@@ -319,6 +322,7 @@ class ODMRGui(GUIBase):
         self.sigNumberOfLinesChanged.disconnect()
         self.sigClockFreqChanged.disconnect()
         self.sigSaveMeasurement.disconnect()
+        self.sigAverageLinesChanged.disconnect()
         self._mw.odmr_cb_manual_RadioButton.clicked.disconnect()
         self._mw.odmr_cb_centiles_RadioButton.clicked.disconnect()
         self._mw.clear_odmr_PushButton.clicked.disconnect()
@@ -339,6 +343,7 @@ class ODMRGui(GUIBase):
         self._mw.odmr_cb_min_DoubleSpinBox.valueChanged.disconnect()
         self._mw.odmr_cb_high_percentile_DoubleSpinBox.valueChanged.disconnect()
         self._mw.odmr_cb_low_percentile_DoubleSpinBox.valueChanged.disconnect()
+        self._mw.average_level_SpinBox.valueChanged.disconnect()
         self._fsd.sigFitsUpdated.disconnect()
         self._mw.action_FitSettings.triggered.disconnect()
         self._mw.close()
@@ -510,6 +515,13 @@ class ODMRGui(GUIBase):
             self._odmr_logic.odmr_plot_x,
             self._odmr_logic.odmr_plot_y,
             self._odmr_logic.odmr_plot_xy)
+
+    def average_level_changed(self):
+        """
+        Sends to lines to average to the logic
+        """
+        self.sigAverageLinesChanged.emit(self._mw.average_level_SpinBox.value())
+        return
 
     def colorscale_changed(self):
         """

--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -215,6 +215,7 @@ class ODMRGui(GUIBase):
         self._mw.runtime_DoubleSpinBox.setValue(self._odmr_logic.run_time)
         self._mw.elapsed_time_DisplayWidget.display(int(np.rint(self._odmr_logic.elapsed_time)))
         self._mw.elapsed_sweeps_DisplayWidget.display(self._odmr_logic.elapsed_sweeps)
+        self._mw.average_level_SpinBox.setValue(self._odmr_logic.lines_to_average)
 
         self._sd.matrix_lines_SpinBox.setValue(self._odmr_logic.number_of_lines)
         self._sd.clock_frequency_DoubleSpinBox.setValue(self._odmr_logic.clock_frequency)

--- a/gui/odmr/ui_odmrgui.ui
+++ b/gui/odmr/ui_odmrgui.ui
@@ -241,7 +241,6 @@
    <addaction name="menu_View"/>
    <addaction name="menu_Options"/>
   </widget>
-  <widget class="QStatusBar" name="statusbar"/>
   <widget class="QToolBar" name="toolBar">
    <property name="windowTitle">
     <string>toolBar</string>
@@ -604,6 +603,29 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item row="0" column="5">
+      <widget class="QLabel" name="average_label">
+       <property name="text">
+        <string>Lines to average</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="6">
+      <widget class="QSpinBox" name="average_level_SpinBox">
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>1000</number>
+       </property>
+       <property name="singleStep">
+        <number>1</number>
+       </property>
+       <property name="value">
+        <number>0</number>
+       </property>
+      </widget>
      </item>
     </layout>
    </widget>

--- a/gui/odmr/ui_odmrgui.ui
+++ b/gui/odmr/ui_odmrgui.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>934</width>
+    <width>936</width>
     <height>545</height>
    </rect>
   </property>
@@ -213,7 +213,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>934</width>
+     <width>936</width>
      <height>18</height>
     </rect>
    </property>
@@ -441,25 +441,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1" colspan="4">
-      <widget class="Line" name="line_2">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="lineWidth">
-        <number>1</number>
-       </property>
-       <property name="midLineWidth">
-        <number>0</number>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
      <item row="5" column="1">
       <widget class="QLabel" name="label_2">
        <property name="sizePolicy">
@@ -624,6 +605,25 @@
        </property>
        <property name="value">
         <number>0</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1" colspan="6">
+      <widget class="Line" name="line_2">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="lineWidth">
+        <number>1</number>
+       </property>
+       <property name="midLineWidth">
+        <number>0</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
       </widget>
      </item>

--- a/gui/odmr/ui_odmrgui.ui
+++ b/gui/odmr/ui_odmrgui.ui
@@ -214,7 +214,7 @@
      <x>0</x>
      <y>0</y>
      <width>934</width>
-     <height>21</height>
+     <height>18</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -348,7 +348,7 @@
      <item row="2" column="6">
       <widget class="QLCDNumber" name="elapsed_sweeps_DisplayWidget"/>
      </item>
-     <item row="3" column="1" colspan="6">
+     <item row="4" column="1" colspan="6">
       <widget class="Line" name="line">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -419,7 +419,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="2">
+     <item row="5" column="2">
       <widget class="ScienDSpinBox" name="sweep_power_DoubleSpinBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -460,7 +460,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="5" column="1">
       <widget class="QLabel" name="label_2">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -486,7 +486,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="6" column="1">
       <widget class="QLabel" name="label_3">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -499,7 +499,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="2">
+     <item row="6" column="2">
       <widget class="ScienDSpinBox" name="start_freq_DoubleSpinBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -518,7 +518,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="3">
+     <item row="6" column="3">
       <widget class="QLabel" name="label_4">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -531,7 +531,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="4">
+     <item row="6" column="4">
       <widget class="ScienDSpinBox" name="step_freq_DoubleSpinBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -556,7 +556,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="5">
+     <item row="6" column="5">
       <widget class="QLabel" name="label_5">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -569,7 +569,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="6">
+     <item row="6" column="6">
       <widget class="ScienDSpinBox" name="stop_freq_DoubleSpinBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -591,7 +591,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0" rowspan="6">
+     <item row="0" column="0" rowspan="7">
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -604,14 +604,14 @@
        </property>
       </spacer>
      </item>
-     <item row="0" column="5">
+     <item row="3" column="1">
       <widget class="QLabel" name="average_label">
        <property name="text">
         <string>Lines to average</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="6">
+     <item row="3" column="2">
       <widget class="QSpinBox" name="average_level_SpinBox">
        <property name="minimum">
         <number>0</number>

--- a/logic/interfuse/odmr_counter_microwave_interfuse.py
+++ b/logic/interfuse/odmr_counter_microwave_interfuse.py
@@ -266,14 +266,15 @@ class ODMRCounterMicrowaveInterfuse(GenericLogic, ODMRCounterInterface,
         """
         return self._mw_device.reset_sweeppos()
 
-    def set_ext_trigger(self, pol=TriggerEdge.RISING):
+    def set_ext_trigger(self, pol, timing):
         """ Set the external trigger for this device with proper polarization.
 
         @param TriggerEdge pol: polarisation of the trigger (basically rising edge or falling edge)
+        @param timing: estimated time between triggers
 
         @return object: current trigger polarity [TriggerEdge.RISING, TriggerEdge.FALLING]
         """
-        return self._mw_device.set_ext_trigger(pol=pol)
+        return self._mw_device.set_ext_trigger(pol=pol, timing=timing)
 
     def get_limits(self):
         """ Return the device-specific limits in a nested dictionary.

--- a/logic/odmr_logic.py
+++ b/logic/odmr_logic.py
@@ -238,7 +238,7 @@ class ODMRLogic(GenericLogic):
         """
         self.lines_to_average = int(lines_to_average)
 
-        if self.lines_to_average == 0:
+        if self.lines_to_average <= 0:
             self.odmr_plot_y = np.mean(
                 self.odmr_raw_data[:max(1, self.elapsed_sweeps), :, :],
                 axis=0,
@@ -668,7 +668,7 @@ class ODMRLogic(GenericLogic):
             if self._clearOdmrData:
                 self.odmr_plot_y[:, :] = 0
 
-            if self.lines_to_average == 0:
+            if self.lines_to_average <= 0:
                 self.odmr_plot_y = np.mean(
                     self.odmr_raw_data[:max(1, self.elapsed_sweeps), :, :],
                     axis=0,

--- a/logic/odmr_logic.py
+++ b/logic/odmr_logic.py
@@ -252,6 +252,7 @@ class ODMRLogic(GenericLogic):
             )
 
         self.sigOdmrPlotsUpdated.emit(self.odmr_plot_x, self.odmr_plot_y, self.odmr_plot_xy)
+        self.sigParameterUpdated.emit({'average_length': self.lines_to_average})
         return self.lines_to_average
 
     def set_clock_frequency(self, clock_frequency):

--- a/logic/odmr_logic.py
+++ b/logic/odmr_logic.py
@@ -65,6 +65,7 @@ class ODMRLogic(GenericLogic):
     run_time = StatusVar('run_time', 60)
     number_of_lines = StatusVar('number_of_lines', 50)
     fc = StatusVar('fits', None)
+    lines_to_average = StatusVar('lines_to_average', 0)
 
     # Internal signals
     sigNextLine = QtCore.Signal()
@@ -226,6 +227,32 @@ class ODMRLogic(GenericLogic):
         update_dict = {'trigger_pol': self.mw_trigger_pol}
         self.sigParameterUpdated.emit(update_dict)
         return self.mw_trigger_pol
+
+    def set_average_length(self, lines_to_average):
+        """
+        Sets the number of lines to average for the sum of the data
+
+        @param int lines_to_average: desired number of lines to average (0 means all)
+
+        @return int: actually set lines to average
+        """
+        self.lines_to_average = int(lines_to_average)
+
+        if self.lines_to_average == 0:
+            self.odmr_plot_y = np.mean(
+                self.odmr_raw_data[:max(1, self.elapsed_sweeps), :, :],
+                axis=0,
+                dtype=np.float64
+            )
+        else:
+            self.odmr_plot_y = np.mean(
+                self.odmr_raw_data[:max(1, min(self.lines_to_average, self.elapsed_sweeps)), :, :],
+                axis=0,
+                dtype=np.float64
+            )
+
+        self.sigOdmrPlotsUpdated.emit(self.odmr_plot_x, self.odmr_plot_y, self.odmr_plot_xy)
+        return self.lines_to_average
 
     def set_clock_frequency(self, clock_frequency):
         """
@@ -617,12 +644,6 @@ class ODMRLogic(GenericLogic):
                 self.sigNextLine.emit()
                 return
 
-            # Add new count data to mean signal
-            if self._clearOdmrData:
-                self.odmr_plot_y[:, :] = 0
-            self.odmr_plot_y = (self.elapsed_sweeps * self.odmr_plot_y + new_counts) / (
-                self.elapsed_sweeps + 1)
-
             # Add new count data to raw_data array and append if array is too small
             if self._clearOdmrData:
                 self.odmr_raw_data[:, :, :] = 0
@@ -642,6 +663,23 @@ class ODMRLogic(GenericLogic):
             self.odmr_raw_data = np.roll(self.odmr_raw_data, 1, axis=0)
 
             self.odmr_raw_data[0] = new_counts
+
+            # Add new count data to mean signal
+            if self._clearOdmrData:
+                self.odmr_plot_y[:, :] = 0
+
+            if self.lines_to_average == 0:
+                self.odmr_plot_y = np.mean(
+                    self.odmr_raw_data[:max(1, self.elapsed_sweeps), :, :],
+                    axis=0,
+                    dtype=np.float64
+                )
+            else:
+                self.odmr_plot_y = np.mean(
+                    self.odmr_raw_data[:max(1, min(self.lines_to_average, self.elapsed_sweeps)), :, :],
+                    axis=0,
+                    dtype=np.float64
+                )
 
             # Set plot slice of matrix
             self.odmr_plot_xy = self.odmr_raw_data[:self.number_of_lines, :, :]


### PR DESCRIPTION
In the ODMR you can now select of how many lines the average should be taken.

## Description
<!--- Describe your changes in detail -->
This feature is quite useful if you want to do magnetic field alignment on a live running ODMR. If you want to still average over all the line (this is the default) just put the number of lines to 0.
You can also change the number of line, when ODMR is not running.
The data saved will also be the one displayed in the GUI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on Setup Quantentunnel with Win10 1803. Tested on Lab Polarizer Win8.1

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
