### PR TITLE
Improvement for loading assets into pulser

### DIFF
--- a/logic/pulsed/pulsed_master_logic.py
+++ b/logic/pulsed/pulsed_master_logic.py
@@ -647,6 +647,10 @@ class PulsedMasterLogic(GenericLogic):
         if still_busy:
             self.log.error('Can not clear pulse generator. Sampling/Loading still in progress.')
         else:
+            if self.status_dict['pulser_running']:
+                self.log.warning('Can not clear pulse generator while it is still running. '
+                                 'Turned off.')
+                self.pulsedmeasurementlogic().pulse_generator_off()
             self.sigClearPulseGenerator.emit()
         return
 
@@ -711,6 +715,10 @@ class PulsedMasterLogic(GenericLogic):
                            'PulseBlockEnsemble "{0}" not loaded!'.format(ensemble_name))
         else:
             self.status_dict['loading_busy'] = True
+            if self.status_dict['pulser_running']:
+                self.log.warning('Can not load new asset into pulse generator while it is still '
+                                 'running. Turned off.')
+                self.pulsedmeasurementlogic().pulse_generator_off()
             self.sigLoadBlockEnsemble.emit(ensemble_name)
         return
 
@@ -721,6 +729,10 @@ class PulsedMasterLogic(GenericLogic):
                            'PulseSequence "{0}" not loaded!'.format(sequence_name))
         else:
             self.status_dict['loading_busy'] = True
+            if self.status_dict['pulser_running']:
+                self.log.warning('Can not load new asset into pulse generator while it is still '
+                                 'running. Turned off.')
+                self.pulsedmeasurementlogic().pulse_generator_off()
             self.sigLoadSequence.emit(sequence_name)
         return
 

--- a/logic/pulsed/pulsed_master_logic.py
+++ b/logic/pulsed/pulsed_master_logic.py
@@ -646,6 +646,8 @@ class PulsedMasterLogic(GenericLogic):
                                    'sampload_busy']
         if still_busy:
             self.log.error('Can not clear pulse generator. Sampling/Loading still in progress.')
+        elif self.status_dict['measurement_running']:
+            self.log.error('Can not clear pulse generator. Measurement is still running.')
         else:
             if self.status_dict['pulser_running']:
                 self.log.warning('Can not clear pulse generator while it is still running. '
@@ -713,6 +715,11 @@ class PulsedMasterLogic(GenericLogic):
         if self.status_dict['loading_busy']:
             self.log.error('Loading of a different asset already in progress.\n'
                            'PulseBlockEnsemble "{0}" not loaded!'.format(ensemble_name))
+            self.loaded_asset_updated(*self.loaded_asset)
+        elif self.status_dict['measurement_running']:
+            self.log.error('Loading of ensemble not possible while measurement is running.\n'
+                           'PulseBlockEnsemble "{0}" not loaded!'.format(ensemble_name))
+            self.loaded_asset_updated(*self.loaded_asset)
         else:
             self.status_dict['loading_busy'] = True
             if self.status_dict['pulser_running']:
@@ -727,6 +734,11 @@ class PulsedMasterLogic(GenericLogic):
         if self.status_dict['loading_busy']:
             self.log.error('Loading of a different asset already in progress.\n'
                            'PulseSequence "{0}" not loaded!'.format(sequence_name))
+            self.loaded_asset_updated(*self.loaded_asset)
+        elif self.status_dict['measurement_running']:
+            self.log.error('Loading of sequence not possible while measurement is running.\n'
+                           'PulseSequence "{0}" not loaded!'.format(sequence_name))
+            self.loaded_asset_updated(*self.loaded_asset)
         else:
             self.status_dict['loading_busy'] = True
             if self.status_dict['pulser_running']:


### PR DESCRIPTION
## Description
Clearing the pulse generator or loading a new asset while the output is still active will now stop the pulser and issue a warning.

## Motivation and Context
It has been inconvenient that you were not able to load a new asset into a running pulse generator without an error. Now you will only receive a warning and the pulser will be stopped.

## How Has This Been Tested?
On dummy Win 8.1 x64

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
