### PR TITLE
Pulsed delta analysis

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -116,6 +116,8 @@ This can be used to specify the axis labels for the measurement (excluding units
 	  the ungated trace. For fine-tuning additional delays (for example from AOMs) can be taken 
 	  into account. This method speeds up laser extractions from ungated timetraced by a lot.
 	* Improved pulsed measurement textfile and plot layout for saved data
+	* When an alternating measurement is running the CheckBox "show Delta" can be used to analyze 
+	  the absolute difference of the alternating data sets
     
 
 Config changes:

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -117,7 +117,7 @@ This can be used to specify the axis labels for the measurement (excluding units
 	  into account. This method speeds up laser extractions from ungated timetraced by a lot.
 	* Improved pulsed measurement textfile and plot layout for saved data
 	* When an alternating measurement is running the CheckBox "show Delta" can be used to analyze 
-	  the absolute difference of the alternating data sets
+	  the difference of the alternating data sets
     
 
 Config changes:

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -349,6 +349,7 @@ class PulsedMeasurementGui(GUIBase):
         self._pa.ana_param_fc_bins_ComboBox.currentIndexChanged.connect(self.fast_counter_settings_changed)
 
         self._pa.time_param_ana_periode_DoubleSpinBox.editingFinished.connect(self.measurement_timer_changed)
+        self._pa.ana_param_delta_CheckBox.toggled.connect(self.pulsedmasterlogic().sigUseDeltaForAlternatingChanged)
         self._pa.ana_param_errorbars_CheckBox.toggled.connect(self.toggle_error_bars)
         self._pa.second_plot_ComboBox.currentIndexChanged[str].connect(self.second_plot_changed)
         return
@@ -386,6 +387,7 @@ class PulsedMeasurementGui(GUIBase):
         self.pulsedmasterlogic().sigMeasurementSettingsUpdated.connect(self.measurement_settings_updated)
         self.pulsedmasterlogic().sigAnalysisSettingsUpdated.connect(self.analysis_settings_updated)
         self.pulsedmasterlogic().sigExtractionSettingsUpdated.connect(self.extraction_settings_updated)
+        self.pulsedmasterlogic().sigUseDeltaForAlternatingUpdated.connect(self.use_delta_for_alternating_updated)
 
         self.pulsedmasterlogic().sigBlockDictUpdated.connect(self.update_block_dict)
         self.pulsedmasterlogic().sigEnsembleDictUpdated.connect(self.update_ensemble_dict)
@@ -498,6 +500,7 @@ class PulsedMeasurementGui(GUIBase):
         self._pa.ana_param_fc_bins_ComboBox.currentIndexChanged.disconnect()
 
         self._pa.time_param_ana_periode_DoubleSpinBox.editingFinished.disconnect()
+        self._pa.ana_param_delta_CheckBox.toggled.disconnect()
         self._pa.ana_param_errorbars_CheckBox.toggled.disconnect()
         self._pa.second_plot_ComboBox.currentIndexChanged[str].disconnect()
         return
@@ -542,6 +545,7 @@ class PulsedMeasurementGui(GUIBase):
         self.pulsedmasterlogic().sigMeasurementSettingsUpdated.disconnect()
         self.pulsedmasterlogic().sigAnalysisSettingsUpdated.disconnect()
         self.pulsedmasterlogic().sigExtractionSettingsUpdated.disconnect()
+        self.pulsedmasterlogic().sigUseDeltaForAlternatingUpdated.disconnect()
 
         self.pulsedmasterlogic().sigBlockDictUpdated.disconnect()
         self.pulsedmasterlogic().sigEnsembleDictUpdated.disconnect()
@@ -2177,8 +2181,11 @@ class PulsedMeasurementGui(GUIBase):
         self._pa.ana_param_errorbars_CheckBox.blockSignals(True)
         self._pa.ana_param_errorbars_CheckBox.setChecked(self._ana_param_errorbars)
         self._pa.ana_param_errorbars_CheckBox.blockSignals(False)
+        self._pa.ana_param_delta_CheckBox.blockSignals(True)
+        self._pa.ana_param_delta_CheckBox.setChecked(
+            self.pulsedmasterlogic().use_delta_for_alternating)
+        self._pa.ana_param_delta_CheckBox.blockSignals(False)
         self.second_plot_changed(self.pulsedmasterlogic().alternative_data_type)
-        self._pa.ana_param_delta_CheckBox.setEnabled(False)  # FIXME: non-functional CheckBox
 
         # Update measurement, microwave and fast counter settings from logic
         self.measurement_settings_updated(self.pulsedmasterlogic().measurement_settings)
@@ -2222,6 +2229,14 @@ class PulsedMeasurementGui(GUIBase):
         self._pa.ext_control_mw_freq_DoubleSpinBox.blockSignals(False)
         self._pa.ext_control_mw_power_DoubleSpinBox.blockSignals(False)
         self._pa.ana_param_fc_bins_ComboBox.blockSignals(False)
+        return
+
+    @QtCore.Slot(bool)
+    def use_delta_for_alternating_updated(self, use_delta):
+        if isinstance(use_delta, bool):
+            self._pa.ana_param_delta_CheckBox.blockSignals(True)
+            self._pa.ana_param_delta_CheckBox.setChecked(use_delta)
+            self._pa.ana_param_delta_CheckBox.blockSignals(False)
         return
 
     @QtCore.Slot()

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -2233,6 +2233,12 @@ class PulsedMeasurementGui(GUIBase):
 
     @QtCore.Slot(bool)
     def use_delta_for_alternating_updated(self, use_delta):
+        """
+        Updates the "show Delta" CheckBox in the analysis tab upon a change of the corresponding
+        flag in logic.
+
+        @param bool use_delta: Set to "True" to evaluate alternating measurements as difference.
+        """
         if isinstance(use_delta, bool):
             self._pa.ana_param_delta_CheckBox.blockSignals(True)
             self._pa.ana_param_delta_CheckBox.setChecked(use_delta)

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -349,7 +349,7 @@ class PulsedMeasurementGui(GUIBase):
         self._pa.ana_param_fc_bins_ComboBox.currentIndexChanged.connect(self.fast_counter_settings_changed)
 
         self._pa.time_param_ana_periode_DoubleSpinBox.editingFinished.connect(self.measurement_timer_changed)
-        self._pa.ana_param_delta_CheckBox.toggled.connect(self.pulsedmasterlogic().sigUseDeltaForAlternatingChanged)
+        self._pa.ana_param_delta_CheckBox.toggled.connect(self.pulsedmasterlogic().set_use_delta_for_alternating)
         self._pa.ana_param_errorbars_CheckBox.toggled.connect(self.toggle_error_bars)
         self._pa.second_plot_ComboBox.currentIndexChanged[str].connect(self.second_plot_changed)
         return

--- a/logic/pulsed/pulsed_master_logic.py
+++ b/logic/pulsed/pulsed_master_logic.py
@@ -478,6 +478,17 @@ class PulsedMasterLogic(GenericLogic):
             self.sigAlternativeDataTypeChanged.emit(alt_data_type)
         return
 
+    @QtCore.Slot(bool)
+    def set_use_delta_for_alternating(self, use_delta):
+        """
+
+        @param use_delta:
+        @return:
+        """
+        if isinstance(use_delta, bool):
+            self.sigUseDeltaForAlternatingChanged.emit(use_delta)
+        return
+
     @QtCore.Slot()
     def manually_pull_data(self):
         """

--- a/logic/pulsed/pulsed_master_logic.py
+++ b/logic/pulsed/pulsed_master_logic.py
@@ -67,6 +67,7 @@ class PulsedMasterLogic(GenericLogic):
     sigTimerIntervalChanged = QtCore.Signal(float)
     sigAlternativeDataTypeChanged = QtCore.Signal(str)
     sigManuallyPullData = QtCore.Signal()
+    sigUseDeltaForAlternatingChanged = QtCore.Signal(bool)
 
     # signals for master module (i.e. GUI) coming from PulsedMeasurementLogic
     sigMeasurementDataUpdated = QtCore.Signal()
@@ -80,6 +81,7 @@ class PulsedMasterLogic(GenericLogic):
     sigMeasurementSettingsUpdated = QtCore.Signal(dict)
     sigAnalysisSettingsUpdated = QtCore.Signal(dict)
     sigExtractionSettingsUpdated = QtCore.Signal(dict)
+    sigUseDeltaForAlternatingUpdated = QtCore.Signal(bool)
 
     # SequenceGeneratorLogic control signals
     sigSavePulseBlock = QtCore.Signal(object)
@@ -163,6 +165,8 @@ class PulsedMasterLogic(GenericLogic):
             self.pulsedmeasurementlogic().set_alternative_data_type, QtCore.Qt.QueuedConnection)
         self.sigManuallyPullData.connect(
             self.pulsedmeasurementlogic().manually_pull_data, QtCore.Qt.QueuedConnection)
+        self.sigUseDeltaForAlternatingChanged.connect(
+            self.pulsedmeasurementlogic().set_use_delta_for_alternating, QtCore.Qt.QueuedConnection)
 
         # Connect signals coming from PulsedMeasurementLogic
         self.pulsedmeasurementlogic().sigMeasurementDataUpdated.connect(
@@ -187,6 +191,8 @@ class PulsedMasterLogic(GenericLogic):
             self.sigAnalysisSettingsUpdated, QtCore.Qt.QueuedConnection)
         self.pulsedmeasurementlogic().sigExtractionSettingsUpdated.connect(
             self.sigExtractionSettingsUpdated, QtCore.Qt.QueuedConnection)
+        self.pulsedmeasurementlogic().sigUseDeltaForAlternatingUpdated.connect(
+            self.sigUseDeltaForAlternatingUpdated, QtCore.Qt.QueuedConnection)
 
         # Connect signals controlling SequenceGeneratorLogic
         self.sigSavePulseBlock.connect(
@@ -263,6 +269,7 @@ class PulsedMasterLogic(GenericLogic):
         self.sigTimerIntervalChanged.disconnect()
         self.sigAlternativeDataTypeChanged.disconnect()
         self.sigManuallyPullData.disconnect()
+        self.sigUseDeltaForAlternatingChanged.disconnect()
         # Disconnect signals coming from PulsedMeasurementLogic
         self.pulsedmeasurementlogic().sigMeasurementDataUpdated.disconnect()
         self.pulsedmeasurementlogic().sigTimerUpdated.disconnect()
@@ -275,6 +282,7 @@ class PulsedMasterLogic(GenericLogic):
         self.pulsedmeasurementlogic().sigMeasurementSettingsUpdated.disconnect()
         self.pulsedmeasurementlogic().sigAnalysisSettingsUpdated.disconnect()
         self.pulsedmeasurementlogic().sigExtractionSettingsUpdated.disconnect()
+        self.pulsedmeasurementlogic().sigUseDeltaForAlternatingUpdated.disconnect()
 
         # Disconnect signals controlling SequenceGeneratorLogic
         self.sigSavePulseBlock.disconnect()
@@ -371,6 +379,10 @@ class PulsedMasterLogic(GenericLogic):
     @property
     def alternative_data_type(self):
         return self.pulsedmeasurementlogic().alternative_data_type
+
+    @property
+    def use_delta_for_alternating(self):
+        return self.pulsedmeasurementlogic().use_delta_for_alternating
 
     @property
     def fit_container(self):

--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -227,6 +227,15 @@ class PulsedMeasurementLogic(GenericLogic):
     ############################################################################
     @property
     def fast_counter_settings(self):
+        """
+        Property holding a dictionary containing all fast counter related parameters.
+        So far we have
+            - bin_width: The width in seconds for one timebin of the photon counter
+            - record_length: The record length of the counter in seconds.
+                             For gated counting devices this is the time for one gate.
+            - number_of_gates: The total number of gates configured. Unused for continuous counting.
+            - is_gated: A boolean flag indicating gated or continuous counting
+        """
         settings_dict = dict()
         settings_dict['bin_width'] = float(self.__fast_counter_binwidth)
         settings_dict['record_length'] = float(self.__fast_counter_record_length)
@@ -307,6 +316,7 @@ class PulsedMeasurementLogic(GenericLogic):
     @QtCore.Slot(bool)
     def toggle_fast_counter(self, switch_on):
         """
+        Helper method and Qt signal slot to toggle the fast counter on/off.
         """
         if not isinstance(switch_on, bool):
             return -1
@@ -318,14 +328,16 @@ class PulsedMeasurementLogic(GenericLogic):
         return err
 
     def fast_counter_pause(self):
-        """Switching off the fast counter
+        """
+        Switching off the fast counter
 
         @return int: error code (0:OK, -1:error)
         """
         return self.fastcounter().pause_measure()
 
     def fast_counter_continue(self):
-        """Switching off the fast counter
+        """
+        Switching off the fast counter
 
         @return int: error code (0:OK, -1:error)
         """
@@ -334,6 +346,7 @@ class PulsedMeasurementLogic(GenericLogic):
     @QtCore.Slot(bool)
     def fast_counter_pause_continue(self, continue_counter):
         """
+        Helper method and Qt signal slot to toggle fast counter pause/continue.
         """
         if not isinstance(continue_counter, bool):
             return -1
@@ -350,6 +363,14 @@ class PulsedMeasurementLogic(GenericLogic):
     ############################################################################
     @property
     def ext_microwave_settings(self):
+        """
+        Property holding a dictionary containing all external CW microwave related parameters.
+        (NOT direct waveform generation)
+        So far we have
+            - power: The CW microwave power to use (in dBm)
+            - frequency: The CW microwave frequency to use
+            - use_ext_microwave: Flag indicating if an external CW microwave source is being used.
+        """
         settings_dict = dict()
         settings_dict['power'] = float(self.__microwave_power)
         settings_dict['frequency'] = float(self.__microwave_freq)
@@ -484,8 +505,8 @@ class PulsedMeasurementLogic(GenericLogic):
         """
         Switch the pulse generator on or off.
 
-        :param switch_on: bool, turn the pulse generator on (True) or off (False)
-        :return int: error code (0: OK, -1: error)
+        @param switch_on: bool, turn the pulse generator on (True) or off (False)
+        @return int: error code (0: OK, -1: error)
         """
         if not isinstance(switch_on, bool):
             return -1
@@ -502,6 +523,20 @@ class PulsedMeasurementLogic(GenericLogic):
     ############################################################################
     @property
     def measurement_settings(self):
+        """
+        Property holding a dictionary containing all measurement related parameters.
+        So far we have
+            - invoke_settings: Flag indicating if the measurement settings should be invoked from
+                               the predefined pulse sequence loaded.
+            - controlled_variable: The x-axis values of the pulsed measurement data
+            - number_of_lasers: Total number of lasers expected in the timetrace
+                                (including laser pulses to ignore later on)
+            - laser_ignore_list: List containing the laser indices to ignore in the analysis
+            - alternating: Flag indicating if it is an alternating measurement so every odd/even
+                           data index belongs in a separate data row
+            - units: Tuple of length 2 containing the unit for x- and y-axis as str
+            - labels: Tuple of length 2 containing the label for x- and y-axis as str
+        """
         settings_dict = dict()
         settings_dict['invoke_settings'] = bool(self._invoke_settings_from_sequence)
         settings_dict['controlled_variable'] = np.array(self._controlled_variable,
@@ -546,6 +581,10 @@ class PulsedMeasurementLogic(GenericLogic):
 
     @property
     def sampling_information(self):
+        """
+        Property holding a dictionary containing all discretization/sampling details corresponding
+        to the currently loaded waveform/sequence.
+        """
         return self._sampling_information
 
     @sampling_information.setter
@@ -558,6 +597,9 @@ class PulsedMeasurementLogic(GenericLogic):
 
     @property
     def timer_interval(self):
+        """
+        Property representing the time interval in seconds for the measurement analysis loop
+        """
         return float(self.__timer_interval)
 
     @timer_interval.setter
@@ -568,6 +610,10 @@ class PulsedMeasurementLogic(GenericLogic):
 
     @property
     def use_delta_for_alternating(self):
+        """
+        Property representing a flag to indicate if an alternating measurement should be evaluated
+        as two separate data sets or as difference.
+        """
         return bool(self._use_delta_for_alternating)
 
     @use_delta_for_alternating.setter
@@ -579,6 +625,10 @@ class PulsedMeasurementLogic(GenericLogic):
 
     @property
     def alternative_data_type(self):
+        """
+        Property representing the optional alternative data plot type. Can be disabled by value
+        None.
+        """
         return str(self._alternative_data_type)
 
     @alternative_data_type.setter
@@ -618,9 +668,9 @@ class PulsedMeasurementLogic(GenericLogic):
     @QtCore.Slot(bool)
     def set_use_delta_for_alternating(self, use_delta):
         """
+        Qt slot for setting the use_delta_for_alternating property.
 
-        @param use_delta:
-        @return:
+        @param bool use_delta: Set to "True" for evaluating alternating measurements as difference.
         """
         if isinstance(use_delta, bool):
             with self._threadlock:
@@ -744,7 +794,7 @@ class PulsedMeasurementLogic(GenericLogic):
     @QtCore.Slot(bool, str)
     def toggle_pulsed_measurement(self, start, stash_raw_data_tag=''):
         """
-        Convenience method to start/stop measurement
+        Convenience method to start/stop measurement.
 
         @param bool start: Start the measurement (True) or stop the measurement (False)
         """
@@ -819,7 +869,10 @@ class PulsedMeasurementLogic(GenericLogic):
     @QtCore.Slot(str)
     def stop_pulsed_measurement(self, stash_raw_data_tag=''):
         """
-        Stop the measurement
+        Stop the measurement and optionally stash the raw data gathered so far with a string key.
+
+        @param str stash_raw_data_tag: If this string is not empty, stores the raw data upon
+                                       stopping the measurement using this string as key.
         """
         # Get raw data and analyze it a last time just before stopping the measurement.
         try:
@@ -941,9 +994,9 @@ class PulsedMeasurementLogic(GenericLogic):
     @QtCore.Slot(str)
     def set_alternative_data_type(self, alt_data_type):
         """
+        Qt slot to enable/disable the alternative data computation and set the type.
 
-        @param alt_data_type:
-        @return:
+        @param str alt_data_type: The alternative data plot type descriptor.
         """
         with self._threadlock:
             if alt_data_type == 'Delta' and not self._alternating:
@@ -963,7 +1016,8 @@ class PulsedMeasurementLogic(GenericLogic):
 
     @QtCore.Slot()
     def manually_pull_data(self):
-        """ Analyse and display the data
+        """
+        Analyse and display the data immediately bypassing the timed analysis loop.
         """
         if self.module_state() == 'locked' and not self.__is_paused:
             self._pulsed_analysis_loop()
@@ -1003,6 +1057,8 @@ class PulsedMeasurementLogic(GenericLogic):
 
     def _apply_invoked_settings(self):
         """
+        Helper method used to try applying the measurement_settings from the information given in a
+        loaded predefined pulse sequence.
         """
         if not isinstance(self._measurement_information, dict) or not self._measurement_information:
             self.log.warning('Can\'t invoke measurement settings from sequence information '
@@ -1066,6 +1122,9 @@ class PulsedMeasurementLogic(GenericLogic):
         return
 
     def _measurement_settings_sanity_check(self):
+        """
+        Helper method to perform sanity checks on the currently set measurement settings.
+        """
         number_of_analyzed_lasers = self._number_of_lasers - len(self._laser_ignore_list)
         if len(self._controlled_variable) < 1:
             self.log.error('Tried to set empty controlled variables array. This can not work.')
@@ -1086,8 +1145,10 @@ class PulsedMeasurementLogic(GenericLogic):
         return
 
     def _pulsed_analysis_loop(self):
-        """ Acquires laser pulses from fast counter,
-            calculates fluorescence signal and creates plots.
+        """
+        Acquires raw time trace data from the fast counter. Extracts laser pulse time traces from
+        the raw time trace. Analyzes the extracted laser traces and calculates a fluorescence
+        signal from it. Also calculates measurement error data.
         """
         with self._threadlock:
             if self.module_state() == 'locked' and not self.__is_paused:
@@ -1144,6 +1205,9 @@ class PulsedMeasurementLogic(GenericLogic):
             return
 
     def _extract_laser_pulses(self):
+        """
+        Helper method to extract the laser pulse time traces from the raw time trace.
+        """
         # Get counter raw data (including recalled raw data from previous measurement)
         self.raw_data = self._get_raw_data()
 
@@ -1153,6 +1217,12 @@ class PulsedMeasurementLogic(GenericLogic):
         return
 
     def _analyze_laser_pulses(self):
+        """
+        Helper method to analyze the laser pulse time traces and calculate a signal as well as
+        error margins.
+
+        @return (numpy.ndarrray, numpy.ndarrray): The calculated measurement signal and error
+        """
         # analyze pulses and get data points for signal array. Also check if extraction
         # worked (non-zero array returned).
         if self.laser_data.any():
@@ -1167,7 +1237,8 @@ class PulsedMeasurementLogic(GenericLogic):
         """
         Get the raw count data from the fast counting hardware and perform sanity checks.
         Also add recalled raw data to the newly received data.
-        :return numpy.ndarray: The count data (1D for ungated, 2D for gated counter)
+
+        @return numpy.ndarray: The count data (1D for ungated, 2D for gated counter)
         """
         # get raw data from fast counter
         fc_data = netobtain(self.fastcounter().get_data_trace())
@@ -1219,9 +1290,6 @@ class PulsedMeasurementLogic(GenericLogic):
         self.sigMeasurementDataUpdated.emit()
         return
 
-    # FIXME: Revise everything below
-
-    ############################################################################
     @QtCore.Slot(str, bool)
     def save_measurement_data(self, tag=None, with_error=True):
         """
@@ -1533,6 +1601,3 @@ class PulsedMeasurementLogic(GenericLogic):
             self.signal_alt_data = np.zeros(self.signal_data.shape, dtype=float)
             self.signal_alt_data[0] = self.signal_data[0]
         return
-
-
-

--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -1117,7 +1117,7 @@ class PulsedMeasurementLogic(GenericLogic):
                                                          (2, self.signal_data.shape[1]))
                             self.measurement_error = np.resize(self.measurement_error,
                                                                (2, self.measurement_error.shape[1]))
-                        self.signal_data[1] = np.abs(tmp_signal[::2] - tmp_signal[1::2])
+                        self.signal_data[1] = tmp_signal[::2] - tmp_signal[1::2]
                         self.measurement_error[1] = np.sqrt(
                             np.square(tmp_error[::2]) + np.square(tmp_error[1::2]))
                     else:

--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -617,10 +617,16 @@ class PulsedMeasurementLogic(GenericLogic):
 
     @QtCore.Slot(bool)
     def set_use_delta_for_alternating(self, use_delta):
+        """
+
+        @param use_delta:
+        @return:
+        """
         if isinstance(use_delta, bool):
             with self._threadlock:
                 self._use_delta_for_alternating = bool(use_delta)
-
+            self.sigUseDeltaForAlternatingUpdated.emit(self._use_delta_for_alternating)
+            self.manually_pull_data()
         return
 
     @QtCore.Slot(dict)
@@ -959,7 +965,7 @@ class PulsedMeasurementLogic(GenericLogic):
     def manually_pull_data(self):
         """ Analyse and display the data
         """
-        if self.module_state() == 'locked':
+        if self.module_state() == 'locked' and not self.__is_paused:
             self._pulsed_analysis_loop()
         return
 
@@ -1084,7 +1090,7 @@ class PulsedMeasurementLogic(GenericLogic):
             calculates fluorescence signal and creates plots.
         """
         with self._threadlock:
-            if self.module_state() == 'locked':
+            if self.module_state() == 'locked' and not self.__is_paused:
                 # Update elapsed time
                 self.__elapsed_time = time.time() - self.__start_time
 


### PR DESCRIPTION
## Description
Added the functionality to use the _show Delta_ CheckBox in the _analysis_ tab of the pulsed maingui.
You can now switch between analyzing an alternating measurement as two separate data sets or as a single differential data set.

## Motivation and Context
Fitting and other things could only be applied to the main data plot in pulsed measurements.

## How Has This Been Tested?
On dummy Win8.1 x64

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
