### PR TITLE
Delete all pulsed assets buttons

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -117,7 +117,7 @@ This can be used to specify the axis labels for the measurement (excluding units
 	  the ungated trace. For fine-tuning additional delays (for example from AOMs) can be taken 
 	  into account. This method speeds up laser extractions from ungated timetraced by a lot.
 	* Improved pulsed measurement textfile and plot layout for saved data
-    
+    * Added buttons to delete all saved PulseBlock/PulseBlockEnsemble/PulseSequence objects at once.
 
 Config changes:
 * **All** pulsed related logic module paths need to be changed because they have been moved in the logic

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -625,10 +625,16 @@ class PulsedMeasurementGui(GUIBase):
         self._mw.pulser_on_off_PushButton.blockSignals(True)
         # set widgets
         if is_running:
+            self._pg.curr_ensemble_del_all_PushButton.setEnabled(False)
+            self._sg.curr_sequence_del_all_PushButton.setEnabled(False)
+            self._mw.clear_device_PushButton.setEnabled(False)
             self._mw.pulser_on_off_PushButton.setText('Pulser OFF')
             if not self._mw.pulser_on_off_PushButton.isChecked():
                 self._mw.pulser_on_off_PushButton.toggle()
         else:
+            self._pg.curr_ensemble_del_all_PushButton.setEnabled(True)
+            self._sg.curr_sequence_del_all_PushButton.setEnabled(True)
+            self._mw.clear_device_PushButton.setEnabled(True)
             self._mw.pulser_on_off_PushButton.setText('Pulser ON')
             if self._mw.pulser_on_off_PushButton.isChecked():
                 self._mw.pulser_on_off_PushButton.toggle()
@@ -716,10 +722,13 @@ class PulsedMeasurementGui(GUIBase):
             self._pa.ana_param_alternating_CheckBox.setEnabled(False)
             self._pa.ana_param_invoke_settings_CheckBox.setEnabled(False)
             self._pg.load_ensemble_PushButton.setEnabled(False)
+            self._pg.curr_ensemble_del_all_PushButton.setEnabled(False)
+            self._sg.curr_sequence_del_all_PushButton.setEnabled(False)
             self._sg.load_sequence_PushButton.setEnabled(False)
             self._mw.pulser_on_off_PushButton.setEnabled(False)
             self._mw.action_continue_pause.setEnabled(True)
             self._mw.action_pull_data.setEnabled(True)
+            self._mw.clear_device_PushButton.setEnabled(False)
             if not self._mw.action_run_stop.isChecked():
                 self._mw.action_run_stop.toggle()
         else:
@@ -737,10 +746,13 @@ class PulsedMeasurementGui(GUIBase):
             self._pa.ext_control_mw_power_DoubleSpinBox.setEnabled(True)
             self._pa.ana_param_fc_bins_ComboBox.setEnabled(True)
             self._pg.load_ensemble_PushButton.setEnabled(True)
+            self._pg.curr_ensemble_del_all_PushButton.setEnabled(True)
+            self._sg.curr_sequence_del_all_PushButton.setEnabled(True)
             self._sg.load_sequence_PushButton.setEnabled(True)
             self._mw.pulser_on_off_PushButton.setEnabled(True)
             self._mw.action_continue_pause.setEnabled(False)
             self._mw.action_pull_data.setEnabled(False)
+            self._mw.clear_device_PushButton.setEnabled(True)
             self._pa.ana_param_invoke_settings_CheckBox.setEnabled(True)
             if not self._pa.ana_param_invoke_settings_CheckBox.isChecked():
                 self._pa.ana_param_ignore_first_CheckBox.setEnabled(True)

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -307,9 +307,11 @@ class PulsedMeasurementGui(GUIBase):
         self._pg.organizer_clear_PushButton.clicked.connect(self.organizer_clear_clicked)
         self._pg.curr_block_generate_PushButton.clicked.connect(self.editor_generate_block_clicked)
         self._pg.curr_block_del_PushButton.clicked.connect(self.editor_delete_block_clicked)
+        self._pg.curr_block_del_all_PushButton.clicked.connect(self.editor_delete_all_blocks_clicked)
         self._pg.curr_block_load_PushButton.clicked.connect(self.editor_load_block_clicked)
         self._pg.curr_ensemble_generate_PushButton.clicked.connect(self.editor_generate_ensemble_clicked)
         self._pg.curr_ensemble_del_PushButton.clicked.connect(self.editor_delete_ensemble_clicked)
+        self._pg.curr_ensemble_del_all_PushButton.clicked.connect(self.editor_delete_all_ensembles_clicked)
         self._pg.curr_ensemble_load_PushButton.clicked.connect(self.editor_load_ensemble_clicked)
         return
 
@@ -326,6 +328,7 @@ class PulsedMeasurementGui(GUIBase):
         self._sg.sequence_clear_PushButton.clicked.connect(self.sequence_clear_clicked)
         self._sg.curr_sequence_generate_PushButton.clicked.connect(self.editor_generate_sequence_clicked)
         self._sg.curr_sequence_del_PushButton.clicked.connect(self.editor_delete_sequence_clicked)
+        self._sg.curr_sequence_del_all_PushButton.clicked.connect(self.editor_delete_all_sequences_clicked)
         self._sg.curr_sequence_load_PushButton.clicked.connect(self.editor_load_sequence_clicked)
         return
 
@@ -457,9 +460,11 @@ class PulsedMeasurementGui(GUIBase):
         self._pg.organizer_clear_PushButton.clicked.disconnect()
         self._pg.curr_block_generate_PushButton.clicked.disconnect()
         self._pg.curr_block_del_PushButton.clicked.disconnect()
+        self._pg.curr_block_del_all_PushButton.clicked.disconnect()
         self._pg.curr_block_load_PushButton.clicked.disconnect()
         self._pg.curr_ensemble_generate_PushButton.clicked.disconnect()
         self._pg.curr_ensemble_del_PushButton.clicked.disconnect()
+        self._pg.curr_ensemble_del_all_PushButton.clicked.disconnect()
         self._pg.curr_ensemble_load_PushButton.clicked.disconnect()
         return
 
@@ -476,6 +481,7 @@ class PulsedMeasurementGui(GUIBase):
         self._sg.sequence_clear_PushButton.clicked.disconnect()
         self._sg.curr_sequence_generate_PushButton.clicked.disconnect()
         self._sg.curr_sequence_del_PushButton.clicked.disconnect()
+        self._sg.curr_sequence_del_all_PushButton.clicked.disconnect()
         self._sg.curr_sequence_load_PushButton.clicked.disconnect()
         return
 
@@ -1658,6 +1664,19 @@ class PulsedMeasurementGui(GUIBase):
         return
 
     @QtCore.Slot()
+    def editor_delete_all_blocks_clicked(self):
+        # Prompt user and ask for confirmation
+        result = QtWidgets.QMessageBox.question(
+            self._mw,
+            'Qudi: Delete all PulseBlocks?',
+            'Do you really want to delete all saved PulseBlocks?',
+            QtWidgets.QMessageBox.Yes,
+            QtWidgets.QMessageBox.No)
+        if result == QtWidgets.QMessageBox.Yes:
+            self.pulsedmasterlogic().delete_all_pulse_blocks()
+        return
+
+    @QtCore.Slot()
     def editor_load_block_clicked(self):
         name = self._pg.saved_blocks_ComboBox.currentText()
         block = self.pulsedmasterlogic().saved_pulse_blocks[name]
@@ -1696,6 +1715,19 @@ class PulsedMeasurementGui(GUIBase):
     def editor_delete_ensemble_clicked(self):
         name = self._pg.saved_ensembles_ComboBox.currentText()
         self.pulsedmasterlogic().delete_block_ensemble(name)
+        return
+
+    @QtCore.Slot()
+    def editor_delete_all_ensembles_clicked(self):
+        # Prompt user and ask for confirmation
+        result = QtWidgets.QMessageBox.question(
+            self._mw,
+            'Qudi: Delete all PulseBlockEnsembles?',
+            'Do you really want to delete all saved PulseBlockEnsembles?',
+            QtWidgets.QMessageBox.Yes,
+            QtWidgets.QMessageBox.No)
+        if result == QtWidgets.QMessageBox.Yes:
+            self.pulsedmasterlogic().delete_all_block_ensembles()
         return
 
     @QtCore.Slot()
@@ -1996,6 +2028,19 @@ class PulsedMeasurementGui(GUIBase):
     def editor_delete_sequence_clicked(self):
         name = self._sg.saved_sequences_ComboBox.currentText()
         self.pulsedmasterlogic().delete_sequence(name)
+        return
+
+    @QtCore.Slot()
+    def editor_delete_all_sequences_clicked(self):
+        # Prompt user and ask for confirmation
+        result = QtWidgets.QMessageBox.question(
+            self._mw,
+            'Qudi: Delete all PulseSequences?',
+            'Do you really want to delete all saved PulseSequences?',
+            QtWidgets.QMessageBox.Yes,
+            QtWidgets.QMessageBox.No)
+        if result == QtWidgets.QMessageBox.Yes:
+            self.pulsedmasterlogic().delete_all_pulse_sequences()
         return
 
     @QtCore.Slot()

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -1723,7 +1723,8 @@ class PulsedMeasurementGui(GUIBase):
         result = QtWidgets.QMessageBox.question(
             self._mw,
             'Qudi: Delete all PulseBlockEnsembles?',
-            'Do you really want to delete all saved PulseBlockEnsembles?',
+            'Do you really want to delete all saved PulseBlockEnsembles?\n'
+            'This will also delete all waveforms within the pulse generator memory.',
             QtWidgets.QMessageBox.Yes,
             QtWidgets.QMessageBox.No)
         if result == QtWidgets.QMessageBox.Yes:
@@ -2036,7 +2037,8 @@ class PulsedMeasurementGui(GUIBase):
         result = QtWidgets.QMessageBox.question(
             self._mw,
             'Qudi: Delete all PulseSequences?',
-            'Do you really want to delete all saved PulseSequences?',
+            'Do you really want to delete all saved PulseSequences?\n'
+            'This will also delete all sequences within the pulse generator memory.',
             QtWidgets.QMessageBox.Yes,
             QtWidgets.QMessageBox.No)
         if result == QtWidgets.QMessageBox.Yes:

--- a/gui/pulsed/ui_pulse_editor.ui
+++ b/gui/pulsed/ui_pulse_editor.ui
@@ -34,13 +34,63 @@
      <layout class="QGridLayout" name="gridLayout_24">
       <item row="0" column="0" colspan="3">
        <layout class="QGridLayout" name="gridLayout_3">
-        <item row="2" column="0">
-         <widget class="QLabel" name="pbe_num_laser_label">
-          <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;# of Laser-&lt;br/&gt;pulses:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <item row="6" column="1">
+         <widget class="QLineEdit" name="curr_ensemble_name_LineEdit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="ScienDSpinBox" name="curr_ensemble_length_DSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
           </property>
           <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+          <property name="buttonSymbols">
+           <enum>QAbstractSpinBox::NoButtons</enum>
+          </property>
+          <property name="suffix">
+           <string>s</string>
+          </property>
+          <property name="decimals">
+           <number>6</number>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0" colspan="2">
+         <widget class="QPushButton" name="curr_ensemble_generate_PushButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Generate Pulse Block Ensemble</string>
           </property>
          </widget>
         </item>
@@ -66,16 +116,10 @@
           </property>
          </widget>
         </item>
-        <item row="9" column="0">
-         <widget class="QPushButton" name="curr_ensemble_del_PushButton">
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Delete</string>
+        <item row="3" column="0" rowspan="2" colspan="2">
+         <widget class="Line" name="line">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
          </widget>
         </item>
@@ -117,6 +161,39 @@
           </property>
          </widget>
         </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="pbe_length_label">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Length:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="pbe_name_label">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ensemble &lt;br/&gt;Name:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="0">
+         <widget class="QPushButton" name="curr_ensemble_del_PushButton">
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Delete</string>
+          </property>
+         </widget>
+        </item>
         <item row="5" column="1">
          <widget class="QCheckBox" name="curr_ensemble_rot_frame_CheckBox">
           <property name="enabled">
@@ -139,23 +216,13 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="0" rowspan="2" colspan="2">
-         <widget class="Line" name="line">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0" colspan="2">
-         <widget class="QPushButton" name="curr_ensemble_generate_PushButton">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
+        <item row="2" column="0">
+         <widget class="QLabel" name="pbe_num_laser_label">
           <property name="text">
-           <string>Generate Pulse Block Ensemble</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;# of Laser-&lt;br/&gt;pulses:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
@@ -166,26 +233,6 @@
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="pbe_length_label">
-          <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Length:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="pbe_name_label">
-          <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ensemble &lt;br/&gt;Name:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
@@ -233,50 +280,14 @@
           </property>
          </widget>
         </item>
-        <item row="6" column="1">
-         <widget class="QLineEdit" name="curr_ensemble_name_LineEdit">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+        <item row="10" column="0">
+         <widget class="QPushButton" name="curr_ensemble_del_all_PushButton">
+          <property name="text">
+           <string>Delete All</string>
           </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="ScienDSpinBox" name="curr_ensemble_length_DSpinBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-          <property name="readOnly">
-           <bool>true</bool>
-          </property>
-          <property name="buttonSymbols">
-           <enum>QAbstractSpinBox::NoButtons</enum>
-          </property>
-          <property name="suffix">
-           <string>s</string>
-          </property>
-          <property name="decimals">
-           <number>6</number>
+          <property name="icon">
+           <iconset>
+            <normaloff>../../artwork/icons/oxygen/22x22/dialog-warning.png</normaloff>../../artwork/icons/oxygen/22x22/dialog-warning.png</iconset>
           </property>
          </widget>
         </item>
@@ -528,6 +539,80 @@ sel.</string>
      <layout class="QGridLayout" name="gridLayout_23">
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout_4">
+        <item row="0" column="0">
+         <widget class="QLabel" name="block_name_label">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Block &lt;br/&gt;Name:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="curr_block_name_LineEdit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="saved_blocks_label">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Saved &lt;br/&gt;Blocks:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QPushButton" name="curr_block_load_PushButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Load</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QPushButton" name="curr_block_del_PushButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Delete</string>
+          </property>
+         </widget>
+        </item>
         <item row="2" column="1">
          <widget class="QComboBox" name="saved_blocks_ComboBox">
           <property name="sizePolicy">
@@ -551,77 +636,14 @@ sel.</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
-         <widget class="QPushButton" name="curr_block_load_PushButton">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
+        <item row="4" column="0">
+         <widget class="QPushButton" name="curr_block_del_all_PushButton">
           <property name="text">
-           <string>Load</string>
+           <string>Delete All</string>
           </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="saved_blocks_label">
-          <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Saved &lt;br/&gt;Blocks:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="curr_block_name_LineEdit">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QPushButton" name="curr_block_del_PushButton">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Delete</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="block_name_label">
-          <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Block &lt;br/&gt;Name:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <property name="icon">
+           <iconset>
+            <normaloff>../../artwork/icons/oxygen/22x22/dialog-warning.png</normaloff>../../artwork/icons/oxygen/22x22/dialog-warning.png</iconset>
           </property>
          </widget>
         </item>

--- a/gui/pulsed/ui_sequence_editor.ui
+++ b/gui/pulsed/ui_sequence_editor.ui
@@ -69,104 +69,6 @@
           </property>
          </widget>
         </item>
-        <item row="7" column="1">
-         <widget class="QComboBox" name="saved_sequences_ComboBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0" colspan="2">
-         <widget class="Line" name="line">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_15">
-          <property name="text">
-           <string>Length:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label_20">
-          <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Saved&lt;br/&gt;Sequences:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="QLineEdit" name="curr_sequence_name_LineEdit">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="1">
-         <widget class="QPushButton" name="curr_sequence_load_PushButton">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Load</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0" colspan="2">
-         <widget class="QPushButton" name="curr_sequence_generate_PushButton">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Generate Sequence</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="0">
-         <widget class="QPushButton" name="curr_sequence_del_PushButton">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Delete</string>
-          </property>
-         </widget>
-        </item>
         <item row="5" column="0">
          <widget class="QLabel" name="label_23">
           <property name="text">
@@ -174,22 +76,6 @@
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QCheckBox" name="curr_sequence_rot_frame_CheckBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
           </property>
          </widget>
         </item>
@@ -212,14 +98,52 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string># of Laser-
-pulses:</string>
+        <item row="4" column="1">
+         <widget class="QCheckBox" name="curr_sequence_rot_frame_CheckBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="1">
+         <widget class="QComboBox" name="saved_sequences_ComboBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0" colspan="2">
+         <widget class="Line" name="line">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="1">
+         <widget class="QPushButton" name="curr_sequence_load_PushButton">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Load</string>
           </property>
          </widget>
         </item>
@@ -257,6 +181,93 @@ pulses:</string>
           </property>
           <property name="maximum">
            <double>100000000.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="label_20">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Saved&lt;br/&gt;Sequences:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="0">
+         <widget class="QPushButton" name="curr_sequence_del_PushButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Delete</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QLineEdit" name="curr_sequence_name_LineEdit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string># of Laser-
+pulses:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0" colspan="2">
+         <widget class="QPushButton" name="curr_sequence_generate_PushButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Generate Sequence</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_15">
+          <property name="text">
+           <string>Length:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="0">
+         <widget class="QPushButton" name="curr_sequence_del_all_PushButton">
+          <property name="text">
+           <string>Delete All</string>
+          </property>
+          <property name="icon">
+           <iconset>
+            <normaloff>../../artwork/icons/oxygen/22x22/dialog-warning.png</normaloff>../../artwork/icons/oxygen/22x22/dialog-warning.png</iconset>
           </property>
          </widget>
         </item>

--- a/logic/pulsed/pulsed_master_logic.py
+++ b/logic/pulsed/pulsed_master_logic.py
@@ -797,6 +797,16 @@ class PulsedMasterLogic(GenericLogic):
         self.sigDeletePulseBlock.emit(block_name)
         return
 
+    @QtCore.Slot()
+    def delete_all_pulse_blocks(self):
+        """
+        Helper method to delete all pulse blocks at once.
+        """
+        to_delete = tuple(self.saved_pulse_blocks)
+        for block_name in to_delete:
+            self.sigDeletePulseBlock.emit(block_name)
+        return
+
     @QtCore.Slot(str)
     def delete_block_ensemble(self, ensemble_name):
         """
@@ -807,6 +817,16 @@ class PulsedMasterLogic(GenericLogic):
         self.sigDeleteBlockEnsemble.emit(ensemble_name)
         return
 
+    @QtCore.Slot()
+    def delete_all_block_ensembles(self):
+        """
+        Helper method to delete all pulse block ensembles at once.
+        """
+        to_delete = tuple(self.saved_pulse_block_ensembles)
+        for ensemble_name in to_delete:
+            self.sigDeleteBlockEnsemble.emit(ensemble_name)
+        return
+
     @QtCore.Slot(str)
     def delete_sequence(self, sequence_name):
         """
@@ -815,6 +835,16 @@ class PulsedMasterLogic(GenericLogic):
         @return:
         """
         self.sigDeleteSequence.emit(sequence_name)
+        return
+
+    @QtCore.Slot()
+    def delete_all_pulse_sequences(self):
+        """
+        Helper method to delete all pulse sequences at once.
+        """
+        to_delete = tuple(self.saved_pulse_sequences)
+        for sequence_name in to_delete:
+            self.sigDeleteSequence.emit(sequence_name)
         return
 
     @QtCore.Slot(dict)

--- a/logic/pulsed/pulsed_master_logic.py
+++ b/logic/pulsed/pulsed_master_logic.py
@@ -814,7 +814,12 @@ class PulsedMasterLogic(GenericLogic):
         @param ensemble_name:
         @return:
         """
-        self.sigDeleteBlockEnsemble.emit(ensemble_name)
+        if self.status_dict['pulser_running'] and self.loaded_asset[0] == ensemble_name and self.loaded_asset[1] == 'PulseBlockEnsemble':
+            self.log.error('Can not delete PulseBlockEnsemble "{0}" since the corresponding '
+                           'waveform(s) is(are) currently loaded and running.'
+                           ''.format(ensemble_name))
+        else:
+            self.sigDeleteBlockEnsemble.emit(ensemble_name)
         return
 
     @QtCore.Slot()
@@ -822,9 +827,13 @@ class PulsedMasterLogic(GenericLogic):
         """
         Helper method to delete all pulse block ensembles at once.
         """
-        to_delete = tuple(self.saved_pulse_block_ensembles)
-        for ensemble_name in to_delete:
-            self.sigDeleteBlockEnsemble.emit(ensemble_name)
+        if self.status_dict['pulser_running'] or self.status_dict['measurement_running']:
+            self.log.error('Can not delete all PulseBlockEnsembles. Pulse generator is currently '
+                           'running or measurement is in progress.')
+        else:
+            to_delete = tuple(self.saved_pulse_block_ensembles)
+            for ensemble_name in to_delete:
+                self.sigDeleteBlockEnsemble.emit(ensemble_name)
         return
 
     @QtCore.Slot(str)
@@ -834,7 +843,11 @@ class PulsedMasterLogic(GenericLogic):
         @param sequence_name:
         @return:
         """
-        self.sigDeleteSequence.emit(sequence_name)
+        if self.status_dict['pulser_running'] and self.loaded_asset[0] == sequence_name and self.loaded_asset[1] == 'PulseSequence':
+            self.log.error('Can not delete PulseSequence "{0}" since the corresponding sequence is '
+                           'currently loaded and running.'.format(sequence_name))
+        else:
+            self.sigDeleteSequence.emit(sequence_name)
         return
 
     @QtCore.Slot()
@@ -842,9 +855,13 @@ class PulsedMasterLogic(GenericLogic):
         """
         Helper method to delete all pulse sequences at once.
         """
-        to_delete = tuple(self.saved_pulse_sequences)
-        for sequence_name in to_delete:
-            self.sigDeleteSequence.emit(sequence_name)
+        if self.status_dict['pulser_running'] or self.status_dict['measurement_running']:
+            self.log.error('Can not delete all PulseSequences. Pulse generator is currently '
+                           'running or measurement is in progress.')
+        else:
+            to_delete = tuple(self.saved_pulse_sequences)
+            for sequence_name in to_delete:
+                self.sigDeleteSequence.emit(sequence_name)
         return
 
     @QtCore.Slot(dict)

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -716,9 +716,10 @@ class SequenceGeneratorLogic(GenericLogic):
             try:
                 with open(filepath, 'rb') as file:
                     block = pickle.load(file)
-            except:
+            except pickle.UnpicklingError:
                 self.log.error('Failed to de-serialize PulseBlock "{0}" from file.'
                                ''.format(block_name))
+                os.remove(filepath)
         return block
 
     def _update_blocks_from_file(self):
@@ -818,9 +819,10 @@ class SequenceGeneratorLogic(GenericLogic):
             try:
                 with open(filepath, 'rb') as file:
                     ensemble = pickle.load(file)
-            except:
-                self.log.error('Failed to de-serialize PulseBlockEnsemble "{0}" from file.'
-                               ''.format(ensemble_name))
+            except pickle.UnpicklingError:
+                self.log.error('Failed to de-serialize PulseBlockEnsemble "{0}" from file. '
+                               'Deleting broken file.'.format(ensemble_name))
+                os.remove(filepath)
         return ensemble
 
     def _update_ensembles_from_file(self):
@@ -934,9 +936,10 @@ class SequenceGeneratorLogic(GenericLogic):
             try:
                 with open(filepath, 'rb') as file:
                     sequence = pickle.load(file)
-            except:
+            except pickle.UnpicklingError:
                 self.log.error('Failed to de-serialize PulseSequence "{0}" from file.'
                                ''.format(sequence_name))
+                os.remove(filepath)
         return sequence
 
     def _update_sequences_from_file(self):


### PR DESCRIPTION
## Description
Introduced new buttons in each pulse editor to delete all saved assets (PulseBlock, PulseBlockEnsemble, PulseSequence) and not just a single one.
The user will be asked to confirm the deletion.

## Motivation and Context
It can be tedious to delete a large number of saved assets one by one. The other way to delete efficiently a large number is to delete the corresponding serialized files in the "saved_pulsed_assets" folder while the SequenceGeneratorLogic is deactivated.

Fixes issue #441 

## How Has This Been Tested?
On dummy Win8.1 x64

## Screenshots:
![blockeditor](https://user-images.githubusercontent.com/18266223/48941026-22fd1680-ef1a-11e8-99aa-deeea712df34.PNG)
![sequenceeditor](https://user-images.githubusercontent.com/18266223/48941029-25f80700-ef1a-11e8-9ea5-da00e0fbe45c.PNG)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
