### PR TITLE
Pulsed alternative plot fit

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -118,6 +118,7 @@ This can be used to specify the axis labels for the measurement (excluding units
 	  into account. This method speeds up laser extractions from ungated timetraced by a lot.
 	* Improved pulsed measurement textfile and plot layout for saved data
     * Added buttons to delete all saved PulseBlock/PulseBlockEnsemble/PulseSequence objects at once.
+    * Introduced separate fit tools for each of the two plots in the pulsed analysis tab
 
 Config changes:
 * **All** pulsed related logic module paths need to be changed because they have been moved in the logic

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -283,6 +283,7 @@ class PulsedMeasurementGui(GUIBase):
 
         # Connect signals used in fit settings dialog
         self._fsd.sigFitsUpdated.connect(self._pa.fit_param_fit_func_ComboBox.setFitFunctions)
+        self._fsd.sigFitsUpdated.connect(self._pa.fit_param_alt_fit_func_ComboBox.setFitFunctions)
         return
 
     def _connect_pulse_generator_tab_signals(self):
@@ -335,6 +336,7 @@ class PulsedMeasurementGui(GUIBase):
     def _connect_analysis_tab_signals(self):
         # Connect pulse analysis tab signals
         self._pa.fit_param_PushButton.clicked.connect(self.fit_clicked)
+        self._pa.alt_fit_param_PushButton.clicked.connect(self.fit_clicked)
 
         self._pa.ext_control_use_mw_CheckBox.stateChanged.connect(self.microwave_settings_changed)
         self._pa.ext_control_mw_freq_DoubleSpinBox.editingFinished.connect(self.microwave_settings_changed)
@@ -488,6 +490,7 @@ class PulsedMeasurementGui(GUIBase):
     def _disconnect_analysis_tab_signals(self):
         # Connect pulse analysis tab signals
         self._pa.fit_param_PushButton.clicked.disconnect()
+        self._pa.alt_fit_param_PushButton.clicked.disconnect()
         self._pa.ext_control_use_mw_CheckBox.stateChanged.disconnect()
         self._pa.ext_control_mw_freq_DoubleSpinBox.editingFinished.disconnect()
         self._pa.ext_control_mw_power_DoubleSpinBox.editingFinished.disconnect()
@@ -2216,11 +2219,15 @@ class PulsedMeasurementGui(GUIBase):
         self._pa.pulse_analysis_second_PlotWidget.addItem(self.second_plot_image)
         self._pa.pulse_analysis_second_PlotWidget.addItem(self.second_plot_image2)
         self._pa.pulse_analysis_second_PlotWidget.showGrid(x=True, y=True, alpha=0.8)
+        # Configure the fit of the data in the secondary pulse analysis display:
+        self.second_fit_image = pg.PlotDataItem(pen=palette.c3)
+        self._pa.pulse_analysis_second_PlotWidget.addItem(self.second_fit_image)
 
         # Fit settings dialog
         self._fsd = FitSettingsDialog(self.pulsedmasterlogic().fit_container)
         self._fsd.applySettings()
         self._pa.fit_param_fit_func_ComboBox.setFitFunctions(self._fsd.currentFits)
+        self._pa.fit_param_alt_fit_func_ComboBox.setFitFunctions(self._fsd.currentFits)
 
         # set boundaries
         self._pa.ana_param_num_laser_pulse_SpinBox.setMinimum(1)
@@ -2341,23 +2348,26 @@ class PulsedMeasurementGui(GUIBase):
     @QtCore.Slot()
     def fit_clicked(self):
         """Fits the current data"""
-        current_fit_method = self._pa.fit_param_fit_func_ComboBox.getCurrentFit()[0]
-        self.pulsedmasterlogic().do_fit(current_fit_method)
+        if self.sender().objectName().startswith('alt_fit_param'):
+            current_fit_method = self._pa.fit_param_alt_fit_func_ComboBox.getCurrentFit()[0]
+            use_alt_data = True
+        else:
+            current_fit_method = self._pa.fit_param_fit_func_ComboBox.getCurrentFit()[0]
+            use_alt_data = False
+        self.pulsedmasterlogic().do_fit(current_fit_method, use_alt_data)
         return
 
-    @QtCore.Slot(str, np.ndarray, object)
-    def fit_data_updated(self, fit_method, fit_data, result):
+    @QtCore.Slot(str, np.ndarray, object, bool)
+    def fit_data_updated(self, fit_method, fit_data, result, use_alternative_data):
         """
 
-        @param fit_method:
-        @param fit_data:
-        @param result:
+        @param str fit_method:
+        @param numpy.ndarray fit_data:
+        @param object result:
+        @param bool use_alternative_data:
         @return:
         """
-        # block signals
-        self._pa.fit_param_fit_func_ComboBox.blockSignals(True)
-        # set widgets
-        self._pa.fit_param_results_TextBrowser.clear()
+        # Get formatted result string
         if fit_method == 'No Fit':
             formatted_fitresult = 'No Fit'
         else:
@@ -2365,17 +2375,35 @@ class PulsedMeasurementGui(GUIBase):
                 formatted_fitresult = units.create_formatted_output(result.result_str_dict)
             except:
                 formatted_fitresult = 'This fit does not return formatted results'
-        self._pa.fit_param_results_TextBrowser.setPlainText(formatted_fitresult)
 
-        self.fit_image.setData(x=fit_data[0], y=fit_data[1])
-        if fit_method == 'No Fit' and self.fit_image in self._pa.pulse_analysis_PlotWidget.items():
-            self._pa.pulse_analysis_PlotWidget.removeItem(self.fit_image)
-        elif fit_method != 'No Fit' and self.fit_image not in self._pa.pulse_analysis_PlotWidget.items():
-            self._pa.pulse_analysis_PlotWidget.addItem(self.fit_image)
-        if fit_method:
-            self._pa.fit_param_fit_func_ComboBox.setCurrentFit(fit_method)
-        # unblock signals
-        self._pa.fit_param_fit_func_ComboBox.blockSignals(False)
+        # block signals.
+        # Clear text widget and show formatted result string.
+        # Update plot and fit function selection ComboBox.
+        # Unblock signals.
+        if use_alternative_data:
+            self._pa.fit_param_alt_fit_func_ComboBox.blockSignals(True)
+            self._pa.alt_fit_param_results_TextBrowser.clear()
+            self._pa.alt_fit_param_results_TextBrowser.setPlainText(formatted_fitresult)
+            if fit_method:
+                self._pa.fit_param_alt_fit_func_ComboBox.setCurrentFit(fit_method)
+            self.second_fit_image.setData(x=fit_data[0], y=fit_data[1])
+            if fit_method == 'No Fit' and self.second_fit_image in self._pa.pulse_analysis_second_PlotWidget.items():
+                self._pa.pulse_analysis_second_PlotWidget.removeItem(self.second_fit_image)
+            elif fit_method != 'No Fit' and self.second_fit_image not in self._pa.pulse_analysis_second_PlotWidget.items():
+                self._pa.pulse_analysis_second_PlotWidget.addItem(self.second_fit_image)
+            self._pa.fit_param_alt_fit_func_ComboBox.blockSignals(False)
+        else:
+            self._pa.fit_param_fit_func_ComboBox.blockSignals(True)
+            self._pa.fit_param_results_TextBrowser.clear()
+            self._pa.fit_param_results_TextBrowser.setPlainText(formatted_fitresult)
+            if fit_method:
+                self._pa.fit_param_fit_func_ComboBox.setCurrentFit(fit_method)
+            self.fit_image.setData(x=fit_data[0], y=fit_data[1])
+            if fit_method == 'No Fit' and self.fit_image in self._pa.pulse_analysis_PlotWidget.items():
+                self._pa.pulse_analysis_PlotWidget.removeItem(self.fit_image)
+            elif fit_method != 'No Fit' and self.fit_image not in self._pa.pulse_analysis_PlotWidget.items():
+                self._pa.pulse_analysis_PlotWidget.addItem(self.fit_image)
+            self._pa.fit_param_fit_func_ComboBox.blockSignals(False)
         return
 
     @QtCore.Slot()

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -2214,8 +2214,18 @@ class PulsedMeasurementGui(GUIBase):
                                                         pen=palette.c5)
 
         # Configure the second pulse analysis plot display:
-        self.second_plot_image = pg.PlotDataItem(np.arange(10), np.zeros(10), pen=palette.c1)
-        self.second_plot_image2 = pg.PlotDataItem(pen=palette.c4)
+        self.second_plot_image = pg.PlotDataItem(pen=pg.mkPen(palette.c1, style=QtCore.Qt.DotLine),
+                                            style=QtCore.Qt.DotLine,
+                                            symbol='o',
+                                            symbolPen=palette.c1,
+                                            symbolBrush=palette.c1,
+                                            symbolSize=7)
+        self.second_plot_image2 = pg.PlotDataItem(pen=pg.mkPen(palette.c4, style=QtCore.Qt.DotLine),
+                                             style=QtCore.Qt.DotLine,
+                                             symbol='o',
+                                             symbolPen=palette.c4,
+                                             symbolBrush=palette.c4,
+                                             symbolSize=7)
         self._pa.pulse_analysis_second_PlotWidget.addItem(self.second_plot_image)
         self._pa.pulse_analysis_second_PlotWidget.addItem(self.second_plot_image2)
         self._pa.pulse_analysis_second_PlotWidget.showGrid(x=True, y=True, alpha=0.8)

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -2244,7 +2244,6 @@ class PulsedMeasurementGui(GUIBase):
         self._pa.ana_param_errorbars_CheckBox.setChecked(self._ana_param_errorbars)
         self._pa.ana_param_errorbars_CheckBox.blockSignals(False)
         self.second_plot_changed(self.pulsedmasterlogic().alternative_data_type)
-        self._pa.ana_param_delta_CheckBox.setEnabled(False)  # FIXME: non-functional CheckBox
 
         # Update measurement, microwave and fast counter settings from logic
         self.measurement_settings_updated(self.pulsedmasterlogic().measurement_settings)

--- a/gui/pulsed/ui_pulse_analysis.ui
+++ b/gui/pulsed/ui_pulse_analysis.ui
@@ -792,6 +792,19 @@
        </layout>
       </widget>
      </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
     </layout>
    </item>
   </layout>

--- a/gui/pulsed/ui_pulse_analysis.ui
+++ b/gui/pulsed/ui_pulse_analysis.ui
@@ -21,9 +21,77 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_23">
       <item row="0" column="0">
-       <layout class="QGridLayout" name="gridLayout_18">
-        <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <property name="spacing">
+         <number>12</number>
+        </property>
+        <item>
          <widget class="PlotWidget" name="pulse_analysis_second_PlotWidget"/>
+        </item>
+        <item>
+         <widget class="Line" name="line_3">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QGridLayout" name="gridLayout_31">
+          <item row="0" column="0">
+           <widget class="QPushButton" name="alt_fit_param_PushButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Fit</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QTextBrowser" name="alt_fit_param_results_TextBrowser">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <kerning>false</kerning>
+             </font>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="FitSettingsComboBox" name="fit_param_alt_fit_func_ComboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_27">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Fit Resuts</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </item>
@@ -50,9 +118,93 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_19">
       <item row="1" column="0">
-       <layout class="QGridLayout" name="gridLayout_12">
-        <item row="0" column="0">
-         <widget class="PlotWidget" name="pulse_analysis_PlotWidget"/>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="spacing">
+         <number>12</number>
+        </property>
+        <item>
+         <widget class="PlotWidget" name="pulse_analysis_PlotWidget">
+          <property name="sizeAdjustPolicy">
+           <enum>QAbstractScrollArea::AdjustIgnored</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Line" name="line_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QGridLayout" name="gridLayout_29">
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_26">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Fit Resuts</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QPushButton" name="fit_param_PushButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Fit</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="FitSettingsComboBox" name="fit_param_fit_func_ComboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QTextBrowser" name="fit_param_results_TextBrowser">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <kerning>false</kerning>
+             </font>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </item>
@@ -649,76 +801,6 @@
            <widget class="QCheckBox" name="ana_param_delta_CheckBox">
             <property name="text">
              <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox_10">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="title">
-        <string>Curve Fitting</string>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_30">
-        <item row="0" column="1">
-         <layout class="QGridLayout" name="gridLayout_29">
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_26">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Fit Resuts</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QPushButton" name="fit_param_PushButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Fit</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="FitSettingsComboBox" name="fit_param_fit_func_ComboBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QTextBrowser" name="fit_param_results_TextBrowser">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="font">
-             <font>
-              <kerning>false</kerning>
-             </font>
             </property>
            </widget>
           </item>

--- a/gui/pulsed/ui_pulse_analysis.ui
+++ b/gui/pulsed/ui_pulse_analysis.ui
@@ -787,23 +787,6 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Show Delta:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QCheckBox" name="ana_param_delta_CheckBox">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
          </layout>
         </item>
        </layout>
@@ -841,7 +824,6 @@
   <tabstop>ext_control_mw_power_DoubleSpinBox</tabstop>
   <tabstop>ana_param_fc_bins_ComboBox</tabstop>
   <tabstop>ana_param_invoke_settings_CheckBox</tabstop>
-  <tabstop>ana_param_delta_CheckBox</tabstop>
   <tabstop>ana_param_errorbars_CheckBox</tabstop>
   <tabstop>second_plot_ComboBox</tabstop>
   <tabstop>ana_param_record_length_DoubleSpinBox</tabstop>

--- a/logic/pulsed/pulsed_master_logic.py
+++ b/logic/pulsed/pulsed_master_logic.py
@@ -54,7 +54,7 @@ class PulsedMasterLogic(GenericLogic):
     sequencegeneratorlogic = Connector(interface='SequenceGeneratorLogic')
 
     # PulsedMeasurementLogic control signals
-    sigDoFit = QtCore.Signal(str)
+    sigDoFit = QtCore.Signal(str, bool)
     sigToggleMeasurement = QtCore.Signal(bool, str)
     sigToggleMeasurementPause = QtCore.Signal(bool)
     sigTogglePulser = QtCore.Signal(bool)
@@ -71,7 +71,7 @@ class PulsedMasterLogic(GenericLogic):
     # signals for master module (i.e. GUI) coming from PulsedMeasurementLogic
     sigMeasurementDataUpdated = QtCore.Signal()
     sigTimerUpdated = QtCore.Signal(float, int, float)
-    sigFitUpdated = QtCore.Signal(str, np.ndarray, object)
+    sigFitUpdated = QtCore.Signal(str, np.ndarray, object, bool)
     sigMeasurementStatusUpdated = QtCore.Signal(bool, bool)
     sigPulserRunningUpdated = QtCore.Signal(bool)
     sigExtMicrowaveRunningUpdated = QtCore.Signal(bool)
@@ -550,24 +550,26 @@ class PulsedMasterLogic(GenericLogic):
         return
 
     @QtCore.Slot(str)
-    def do_fit(self, fit_function):
+    @QtCore.Slot(str, bool)
+    def do_fit(self, fit_function, use_alternative_data=False):
         """
 
-        @param fit_function:
+        @param str fit_function:
+        @param bool use_alternative_data:
         """
-        if isinstance(fit_function, str):
+        if isinstance(fit_function, str) and isinstance(use_alternative_data, bool):
             self.status_dict['fitting_busy'] = True
-            self.sigDoFit.emit(fit_function)
+            self.sigDoFit.emit(fit_function, use_alternative_data)
         return
 
-    @QtCore.Slot(str, np.ndarray, object)
-    def fit_updated(self, fit_name, fit_data, fit_result):
+    @QtCore.Slot(str, np.ndarray, object, bool)
+    def fit_updated(self, fit_name, fit_data, fit_result, use_alternative_data):
         """
 
         @return:
         """
         self.status_dict['fitting_busy'] = False
-        self.sigFitUpdated.emit(fit_name, fit_data, fit_result)
+        self.sigFitUpdated.emit(fit_name, fit_data, fit_result, use_alternative_data)
         return
 
     def save_measurement_data(self, tag, with_error):

--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -972,22 +972,19 @@ class PulsedMeasurementLogic(GenericLogic):
         x_fit, y_fit, result = self.fc.do_fit(data[0], data[1])
 
         fit_data = np.array([x_fit, y_fit])
-        fit_name = self.fc.current_fit
-        fit_result = self.fc.current_fit_result
 
         if update_fit_data:
             if use_alternative_data:
                 self.signal_fit_alt_data = fit_data
-                self.fit_result = copy.deepcopy(fit_result)
-                self.sigFitUpdated.emit(fit_name, self.signal_fit_alt_data, fit_result,
-                                        use_alternative_data)
+                self.alt_fit_result = copy.deepcopy(self.fc.current_fit_result)
+                self.sigFitUpdated.emit(self.fc.current_fit, self.signal_fit_alt_data,
+                                        self.alt_fit_result, use_alternative_data)
             else:
                 self.signal_fit_data = fit_data
-                self.alt_fit_result = copy.deepcopy(fit_result)
-                self.sigFitUpdated.emit(fit_name, self.signal_fit_data, fit_result,
+                self.fit_result = copy.deepcopy(self.fc.current_fit_result)
+                self.sigFitUpdated.emit(self.fc.current_fit, self.signal_fit_data, self.fit_result,
                                         use_alternative_data)
-
-        return fit_data, fit_result
+        return fit_data, self.fc.current_fit_result
 
     def _apply_invoked_settings(self):
         """
@@ -1343,13 +1340,11 @@ class PulsedMeasurementLogic(GenericLogic):
 
             # create the formatted fit text:
             if hasattr(self.fit_result, 'result_str_dict'):
-                fit_res = units.create_formatted_output(self.fit_result.result_str_dict)
+                result_str = units.create_formatted_output(self.fit_result.result_str_dict)
             else:
-                self.log.warning('The fit container does not contain any data '
-                                 'from the fit! Apply the fit once again.')
-                fit_res = ''
+                result_str = ''
             # do reverse processing to get each entry in a list
-            entry_list = fit_res.split('\n')
+            entry_list = result_str.split('\n')
             # slice the entry_list in entries_per_col
             chunks = [entry_list[x:x+entries_per_col] for x in range(0, len(entry_list), entries_per_col)]
 
@@ -1447,13 +1442,11 @@ class PulsedMeasurementLogic(GenericLogic):
 
                 # create the formatted fit text:
                 if hasattr(self.alt_fit_result, 'result_str_dict'):
-                    fit_res = units.create_formatted_output(self.alt_fit_result.result_str_dict)
+                    result_str = units.create_formatted_output(self.alt_fit_result.result_str_dict)
                 else:
-                    self.log.warning('The fit container does not contain any data '
-                                     'from the fit! Apply the fit once again.')
-                    fit_res = ''
+                    result_str = ''
                 # do reverse processing to get each entry in a list
-                entry_list = fit_res.split('\n')
+                entry_list = result_str.split('\n')
                 # slice the entry_list in entries_per_col
                 chunks = [entry_list[x:x+entries_per_col] for x in range(0, len(entry_list), entries_per_col)]
 

--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -1401,7 +1401,8 @@ class PulsedMeasurementLogic(GenericLogic):
                 ft_label = 'FT of data trace 1'
             else:
                 if self._data_units[0]:
-                    x_axis_ft_label = '{0} ({1})'.format(self._data_labels[0], self._data_units[0])
+                    x_axis_ft_label = '{0} ({1}{2})'.format(self._data_labels[0], x_axis_prefix,
+                                                            self._data_units[0])
                 else:
                     x_axis_ft_label = '{0}'.format(self._data_labels[0])
                 if self._data_units[1]:
@@ -1409,7 +1410,7 @@ class PulsedMeasurementLogic(GenericLogic):
                 else:
                     y_axis_ft_label = '{0}'.format(self._data_labels[1])
 
-                ft_label = ''
+                ft_label = '{0} of data traces'.format(self._alternative_data_type)
 
             ax2.plot(x_axis_ft_scaled, self.signal_alt_data[1], '-o',
                      linestyle=':', linewidth=0.5, color=colors[0],


### PR DESCRIPTION
## Description
Introduced separate fitting widgets to each plot in pulsed measurements. (main plot and alternative plot)

## Motivation and Context
There has been a request for fitting capability on both plots

## How Has This Been Tested?
On dummy Win8.1 x64

## Screenshots (only if appropriate, delete if not):
![capture](https://user-images.githubusercontent.com/18266223/49147656-8bc30500-f305-11e8-9bb2-10c4473f3325.PNG)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
