### PR TITLE
Clear fit data in pulsed measurements

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -121,6 +121,8 @@ This can be used to specify the axis labels for the measurement (excluding units
 	* Improved pulsed measurement textfile and plot layout for saved data
     * Added buttons to delete all saved PulseBlock/PulseBlockEnsemble/PulseSequence objects at once.
     * Introduced separate fit tools for each of the two plots in the pulsed analysis tab
+    * Automatically clears fit data when changing the alternative plot type or starting a new 
+      measurement.
 
 Config changes:
 * **All** pulsed related logic module paths need to be changed because they have been moved in the logic

--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -756,7 +756,8 @@ class PulsedMeasurementLogic(GenericLogic):
                 self.module_state.lock()
 
                 # Clear previous fits
-                self.fc.clear_result()
+                self.do_fit('No Fit', False)
+                self.do_fit('No Fit', True)
 
                 # initialize data arrays
                 self._initialize_data_arrays()
@@ -923,6 +924,8 @@ class PulsedMeasurementLogic(GenericLogic):
         @return:
         """
         with self._threadlock:
+            if alt_data_type != self.alternative_data_type:
+                self.do_fit('No Fit', True)
             if alt_data_type == 'Delta' and not self._alternating:
                 if self._alternative_data_type == 'Delta':
                     self._alternative_data_type = None


### PR DESCRIPTION
## Description
Automatically clears fit data when changing the alternative plot type or when starting a new measurement

## Motivation and Context
Persistent fit data could be confusing when the underlying measurement data has changed

## How Has This Been Tested?
On dummy Win8.1 x64

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
