### PR TITLE
Bugfix: ensemble length in bins and waveform length mismatch

### DIFF
--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1036,66 +1036,29 @@ class SequenceGeneratorLogic(GenericLogic):
     # ---------------------------------------------------------------------------
     def get_ensemble_info(self, ensemble):
         """
-        This helper method will analyze a PulseBlockEnsemble and return information like length in
-        seconds and bins (with currently set sampling rate), number of laser pulses (with currently
-        selected laser/gate channel)
+        This helper method is just there for backwards compatibility. Essentially it will call the
+        method "analyze_block_ensemble".
+
+        Will return information like length in seconds and bins (with currently set sampling rate)
+        as well as number of laser pulses (with currently selected laser/gate channel)
 
         @param PulseBlockEnsemble ensemble: The PulseBlockEnsemble instance to analyze
         @return (float, int, int): length in seconds, length in bins, number of laser/gate pulses
         """
-        # variables to keep track of the current timeframe and number of laser/gate pulses
-        ensemble_length_s = 0.0
-        ensemble_length_bins = 0
-        number_of_lasers = 0
-        # memorize the channel state of the previous element.
-        tmp_digital_high = False
+        # Return if the ensemble is empty
+        if len(ensemble) == 0:
+            return 0.0, 0, 0
 
         # Determine the right laser channel to choose. For gated counting it should be the gate
         # channel instead of the laser trigger.
         laser_channel = self.generation_parameters['gate_channel'] if self.generation_parameters[
             'gate_channel'] else self.generation_parameters['laser_channel']
 
-        # check for active channels in last block and take the laser_channel state of the very last
-        # element as initial state for the tmp_digital_high. Return if the ensemble is empty
-        if len(ensemble.block_list) > 0:
-            block = self.get_block(ensemble.block_list[-1][0])
-            digital_channels = block.digital_channels
-            analog_channels = block.analog_channels
-            channel_set = analog_channels.union(digital_channels)
-            if laser_channel in channel_set:
-                if laser_channel.startswith('a'):
-                    tmp_digital_high = type(
-                        block.element_list[-1].pulse_function[laser_channel]).__name__ != 'Idle'
-                else:
-                    tmp_digital_high = block.element_list[-1].digital_high[laser_channel]
-        else:
-            return ensemble_length_s, ensemble_length_bins, number_of_lasers
-
-        # Loop over all blocks in the ensemble
-        for block_name, reps in ensemble.block_list:
-            block = self.get_block(block_name)
-            # Iterate over all repetitions of the current block
-            for rep_no in range(reps + 1):
-                # ideal end time for the sequence up until this point in sec
-                ensemble_length_s += block.init_length_s + rep_no * block.increment_s
-                if laser_channel in channel_set:
-                    # Iterate over the Block_Elements inside the current block
-                    for block_element in block.element_list:
-                        # save bin position if transition from low to high has occured in
-                        # laser channel
-                        if laser_channel.startswith('a'):
-                            is_high = type(
-                                block_element.pulse_function[laser_channel]).__name__ != 'Idle'
-                        else:
-                            is_high = block_element.digital_high[laser_channel]
-
-                        if is_high and not tmp_digital_high:
-                            number_of_lasers += 1
-                        tmp_digital_high = is_high
-
-        # Nearest possible match including the discretization in bins
-        ensemble_length_bins = int(np.rint(ensemble_length_s * self.__sample_rate))
-        return ensemble_length_s, ensemble_length_bins, number_of_lasers
+        info_dict = self.analyze_block_ensemble(ensemble=ensemble)
+        ens_bins = info_dict['number_of_samples']
+        ens_length = ens_bins / self.__sample_rate
+        ens_lasers = len(info_dict['digital_rising_bins'][laser_channel])
+        return ens_length, ens_bins, ens_lasers
 
     def get_sequence_info(self, sequence):
         """
@@ -1106,6 +1069,11 @@ class SequenceGeneratorLogic(GenericLogic):
         @param PulseSequence sequence: The PulseSequence instance to analyze
         @return (float, int, int): length in seconds, length in bins, number of laser/gate pulses
         """
+        # Determine the right laser channel to choose. For gated counting it should be the gate
+        # channel instead of the laser trigger.
+        laser_channel = self.generation_parameters['gate_channel'] if self.generation_parameters[
+            'gate_channel'] else self.generation_parameters['laser_channel']
+
         length_bins = 0
         length_s = 0 if sequence.is_finite else np.inf
         number_of_lasers = 0 if sequence.is_finite else -1
@@ -1116,7 +1084,10 @@ class SequenceGeneratorLogic(GenericLogic):
                 length_s = np.inf
                 number_of_lasers = -1
                 break
-            ens_length, ens_bins, ens_lasers = self.get_ensemble_info(ensemble=ensemble)
+            info_dict = self.analyze_block_ensemble(ensemble=ensemble)
+            ens_bins = info_dict['number_of_samples']
+            ens_length = ens_bins / self.__sample_rate
+            ens_lasers = len(info_dict['digital_rising_bins'][laser_channel])
             length_bins += ens_bins
             if sequence.is_finite:
                 length_s += ens_length * (seq_step.repetitions + 1)
@@ -1269,6 +1240,11 @@ class SequenceGeneratorLogic(GenericLogic):
                                              (in timebins; incl. repetitions) for each digital
                                              channel.
         """
+        # Determine the right laser channel to choose. For gated counting it should be the gate
+        # channel instead of the laser trigger.
+        laser_channel = self.generation_parameters['gate_channel'] if self.generation_parameters[
+            'gate_channel'] else self.generation_parameters['laser_channel']
+
         # Determine channel activation
         digital_channels = set()
         analog_channels = set()
@@ -1285,7 +1261,10 @@ class SequenceGeneratorLogic(GenericLogic):
         length_s = 0 if sequence.is_finite else np.inf
         for seq_step in sequence:
             ensemble = self.get_ensemble(seq_step.ensemble)
-            ens_length, ens_bins, ens_lasers = self.get_ensemble_info(ensemble=ensemble)
+            info_dict = self.analyze_block_ensemble(ensemble=ensemble)
+            ens_bins = info_dict['number_of_samples']
+            ens_length = ens_bins / self.__sample_rate
+            ens_lasers = len(info_dict['digital_rising_bins'][laser_channel])
             length_bins += ens_bins
             if sequence.is_finite:
                 length_s += ens_length * (seq_step.repetitions + 1)


### PR DESCRIPTION
## Description
Fixed a very subtle bug that caused the length of the `PulseBlockEnsemble` shown in the editor in bins to differ from the actually sampled waveform length by +-1 bin.

## Motivation and Context
This mismatch has not been reported so far and occurred now with a certain very long waveform.
The mismatch was in the output of the `SequenceGeneratorLogic` methods `analyze_block_ensemble` and `get_ensemble_info`. Both return the `PulseBlockEnsemble` length in bins but in rare cases these numbers differ due to a subtle difference in the calculation method.
`analyze_block_ensemble` is a much more complex computation that was only used for wavfeform creation (sampling) and that's why `get_ensemble_info` has been used to display the information in the GUI.
Now everything uses the more complex method but `get_ensemble_info` is still there in case someone uses it in a script but is effectively just calling `analyze_block_ensemble`.

## How Has This Been Tested?
Cryo lab setup and dummy Win8.1 x64

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
