### PR TITLE
Lock-In ODMR

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -26,7 +26,7 @@ This can be used to specify the axis labels for the measurement (excluding units
 * For SMIQs added config options to additionally limit frequency and power. Added constraint for SMQ06B model.
 * Added live OMDR functionality to only calculate the average signal over a limited amount of scanned lines
 * New hardware file for Microwave source - Anritsu MG3691C with SCPI commands has been added.
-* **Potential Config Change:** Hardware file for mw_source_anritsu70GHz.py with class MicrowaveAnritsu70GHz was changed to file mw_source_anritsu_MG369x.py with class MicrowaveAnritsuMG369x to make it universal. Also hardware constraints are set per model.
+* **Config Change:** Hardware file for mw_source_anritsu70GHz.py with class MicrowaveAnritsu70GHz was changed to file mw_source_anritsu_MG369x.py with class MicrowaveAnritsuMG369x to make it universal. Also hardware constraints are set per model.
 * Lock-In functionality was added to the ODMR counter and implemented for the NI-Card. All other hardware and interfuse with ODMRCounterInterface were updated.
 * New hardware file for Microwave source - WindFreak Technologies SynthHDPro 54MHz-13GHz source
 * New hardware file for AWG - Keysight M3202A 1GS/s 4-channel PXIe AWG

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -25,7 +25,9 @@ This can be used to specify the axis labels for the measurement (excluding units
 * Bug fixes and support for SMD12 laser controller
 * For SMIQs added config options to additionally limit frequency and power. Added constraint for SMQ06B model.
 * Added live OMDR functionality to only calculate the average signal over a limited amount of scanned lines
-* New hardware file for Microwave source - Anritsu MG3691C has been added.
+* New hardware file for Microwave source - Anritsu MG3691C with SCPI commands has been added.
+* **Potential Config Change:** Hardware file for mw_source_anritsu70GHz.py with class MicrowaveAnritsu70GHz was changed to file mw_source_anritsu_MG369x.py with class MicrowaveAnritsuMG369x to make it universal. Also hardware constraints are set per model.
+* Lock-In functionality was added to the ODMR counter and implemented for the NI-Card. All other hardware and interfuse with ODMRCounterInterface were updated.
 * New hardware file for Microwave source - WindFreak Technologies SynthHDPro 54MHz-13GHz source
 * New hardware file for AWG - Keysight M3202A 1GS/s 4-channel PXIe AWG
 * Add separate conda environments for windows 7 32bit, windows 7 64bit, and windows 10 64bit. 

--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -85,6 +85,7 @@ class ODMRGui(GUIBase):
     sigMwCwParamsChanged = QtCore.Signal(float, float)
     sigMwSweepParamsChanged = QtCore.Signal(float, float, float, float)
     sigClockFreqChanged = QtCore.Signal(float)
+    sigOversamplingChanged = QtCore.Signal(int)
     sigFitChanged = QtCore.Signal(str)
     sigNumberOfLinesChanged = QtCore.Signal(int)
     sigRuntimeChanged = QtCore.Signal(float)
@@ -219,6 +220,7 @@ class ODMRGui(GUIBase):
 
         self._sd.matrix_lines_SpinBox.setValue(self._odmr_logic.number_of_lines)
         self._sd.clock_frequency_DoubleSpinBox.setValue(self._odmr_logic.clock_frequency)
+        self._sd.oversampling_SpinBox.setValue(self._odmr_logic.oversampling)
 
         # fit settings
         self._fsd = FitSettingsDialog(self._odmr_logic.fc)
@@ -271,6 +273,7 @@ class ODMRGui(GUIBase):
                                              QtCore.Qt.QueuedConnection)
         self.sigClockFreqChanged.connect(self._odmr_logic.set_clock_frequency,
                                          QtCore.Qt.QueuedConnection)
+        self.sigOversamplingChanged.connect(self._odmr_logic.set_oversampling, QtCore.Qt.QueuedConnection)
         self.sigSaveMeasurement.connect(self._odmr_logic.save_odmr_data, QtCore.Qt.QueuedConnection)
         self.sigAverageLinesChanged.connect(self._odmr_logic.set_average_length,
                                             QtCore.Qt.QueuedConnection)
@@ -323,6 +326,7 @@ class ODMRGui(GUIBase):
         self.sigRuntimeChanged.disconnect()
         self.sigNumberOfLinesChanged.disconnect()
         self.sigClockFreqChanged.disconnect()
+        self.sigOversamplingChanged.disconnect()
         self.sigSaveMeasurement.disconnect()
         self.sigAverageLinesChanged.disconnect()
         self._mw.odmr_cb_manual_RadioButton.clicked.disconnect()
@@ -377,6 +381,7 @@ class ODMRGui(GUIBase):
             self._mw.stop_freq_DoubleSpinBox.setEnabled(False)
             self._mw.runtime_DoubleSpinBox.setEnabled(False)
             self._sd.clock_frequency_DoubleSpinBox.setEnabled(False)
+            self._sd.oversampling_SpinBox.setEnabled(False)
             self.sigStartOdmrScan.emit()
         else:
             self._mw.action_run_stop.setEnabled(False)
@@ -398,6 +403,7 @@ class ODMRGui(GUIBase):
             self._mw.stop_freq_DoubleSpinBox.setEnabled(False)
             self._mw.runtime_DoubleSpinBox.setEnabled(False)
             self._sd.clock_frequency_DoubleSpinBox.setEnabled(False)
+            self._sd.oversampling_SpinBox.setEnabled(False)
             self.sigContinueOdmrScan.emit()
         else:
             self._mw.action_run_stop.setEnabled(False)
@@ -447,6 +453,7 @@ class ODMRGui(GUIBase):
                 self._mw.sweep_power_DoubleSpinBox.setEnabled(False)
                 self._mw.runtime_DoubleSpinBox.setEnabled(False)
                 self._sd.clock_frequency_DoubleSpinBox.setEnabled(False)
+                self._sd.oversampling_SpinBox.setEnabled(False)
                 self._mw.action_run_stop.setChecked(True)
                 self._mw.action_resume_odmr.setChecked(True)
                 self._mw.action_toggle_cw.setChecked(False)
@@ -460,6 +467,7 @@ class ODMRGui(GUIBase):
                 self._mw.sweep_power_DoubleSpinBox.setEnabled(True)
                 self._mw.runtime_DoubleSpinBox.setEnabled(True)
                 self._sd.clock_frequency_DoubleSpinBox.setEnabled(True)
+                self._sd.oversampling_SpinBox.setEnabled(True)
                 self._mw.action_run_stop.setChecked(False)
                 self._mw.action_resume_odmr.setChecked(False)
                 self._mw.action_toggle_cw.setChecked(True)
@@ -476,6 +484,7 @@ class ODMRGui(GUIBase):
             self._mw.stop_freq_DoubleSpinBox.setEnabled(True)
             self._mw.runtime_DoubleSpinBox.setEnabled(True)
             self._sd.clock_frequency_DoubleSpinBox.setEnabled(True)
+            self._sd.oversampling_SpinBox.setEnabled(True)
             self._mw.action_run_stop.setChecked(False)
             self._mw.action_resume_odmr.setChecked(False)
             self._mw.action_toggle_cw.setChecked(False)
@@ -583,6 +592,8 @@ class ODMRGui(GUIBase):
         """ Write the new settings from the gui to the file. """
         number_of_lines = self._sd.matrix_lines_SpinBox.value()
         clock_frequency = self._sd.clock_frequency_DoubleSpinBox.value()
+        oversampling = self._sd.oversampling_SpinBox.value()
+        self.sigOversamplingChanged.emit(oversampling)
         self.sigClockFreqChanged.emit(clock_frequency)
         self.sigNumberOfLinesChanged.emit(number_of_lines)
         return
@@ -591,6 +602,7 @@ class ODMRGui(GUIBase):
         """ Keep the old settings and restores the old settings in the gui. """
         self._sd.matrix_lines_SpinBox.setValue(self._odmr_logic.number_of_lines)
         self._sd.clock_frequency_DoubleSpinBox.setValue(self._odmr_logic.clock_frequency)
+        self._sd.oversampling_SpinBox.setValue(self._odmr_logic.oversampling)
         return
 
     def do_fit(self):
@@ -677,6 +689,12 @@ class ODMRGui(GUIBase):
             self._sd.clock_frequency_DoubleSpinBox.blockSignals(True)
             self._sd.clock_frequency_DoubleSpinBox.setValue(param)
             self._sd.clock_frequency_DoubleSpinBox.blockSignals(False)
+
+        param = param_dict.get('oversampling')
+        if param is not None:
+            self._sd.oversampling_SpinBox.blockSignals(True)
+            self._sd.oversampling_SpinBox.setValue(param)
+            self._sd.oversampling_SpinBox.blockSignals(False)
 
         param = param_dict.get('cw_mw_frequency')
         if param is not None:

--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -86,6 +86,7 @@ class ODMRGui(GUIBase):
     sigMwSweepParamsChanged = QtCore.Signal(float, float, float, float)
     sigClockFreqChanged = QtCore.Signal(float)
     sigOversamplingChanged = QtCore.Signal(int)
+    sigLockInChanged = QtCore.Signal(bool)
     sigFitChanged = QtCore.Signal(str)
     sigNumberOfLinesChanged = QtCore.Signal(int)
     sigRuntimeChanged = QtCore.Signal(float)
@@ -221,6 +222,7 @@ class ODMRGui(GUIBase):
         self._sd.matrix_lines_SpinBox.setValue(self._odmr_logic.number_of_lines)
         self._sd.clock_frequency_DoubleSpinBox.setValue(self._odmr_logic.clock_frequency)
         self._sd.oversampling_SpinBox.setValue(self._odmr_logic.oversampling)
+        self._sd.lock_in_CheckBox.setChecked(self._odmr_logic.lock_in)
 
         # fit settings
         self._fsd = FitSettingsDialog(self._odmr_logic.fc)
@@ -274,6 +276,7 @@ class ODMRGui(GUIBase):
         self.sigClockFreqChanged.connect(self._odmr_logic.set_clock_frequency,
                                          QtCore.Qt.QueuedConnection)
         self.sigOversamplingChanged.connect(self._odmr_logic.set_oversampling, QtCore.Qt.QueuedConnection)
+        self.sigLockInChanged.connect(self._odmr_logic.set_lock_in, QtCore.Qt.QueuedConnection)
         self.sigSaveMeasurement.connect(self._odmr_logic.save_odmr_data, QtCore.Qt.QueuedConnection)
         self.sigAverageLinesChanged.connect(self._odmr_logic.set_average_length,
                                             QtCore.Qt.QueuedConnection)
@@ -327,6 +330,7 @@ class ODMRGui(GUIBase):
         self.sigNumberOfLinesChanged.disconnect()
         self.sigClockFreqChanged.disconnect()
         self.sigOversamplingChanged.disconnect()
+        self.sigLockInChanged.disconnect()
         self.sigSaveMeasurement.disconnect()
         self.sigAverageLinesChanged.disconnect()
         self._mw.odmr_cb_manual_RadioButton.clicked.disconnect()
@@ -382,6 +386,7 @@ class ODMRGui(GUIBase):
             self._mw.runtime_DoubleSpinBox.setEnabled(False)
             self._sd.clock_frequency_DoubleSpinBox.setEnabled(False)
             self._sd.oversampling_SpinBox.setEnabled(False)
+            self._sd.lock_in_CheckBox.setEnabled(False)
             self.sigStartOdmrScan.emit()
         else:
             self._mw.action_run_stop.setEnabled(False)
@@ -404,6 +409,7 @@ class ODMRGui(GUIBase):
             self._mw.runtime_DoubleSpinBox.setEnabled(False)
             self._sd.clock_frequency_DoubleSpinBox.setEnabled(False)
             self._sd.oversampling_SpinBox.setEnabled(False)
+            self._sd.lock_in_CheckBox.setEnabled(False)
             self.sigContinueOdmrScan.emit()
         else:
             self._mw.action_run_stop.setEnabled(False)
@@ -454,6 +460,7 @@ class ODMRGui(GUIBase):
                 self._mw.runtime_DoubleSpinBox.setEnabled(False)
                 self._sd.clock_frequency_DoubleSpinBox.setEnabled(False)
                 self._sd.oversampling_SpinBox.setEnabled(False)
+                self._sd.lock_in_CheckBox.setEnabled(False)
                 self._mw.action_run_stop.setChecked(True)
                 self._mw.action_resume_odmr.setChecked(True)
                 self._mw.action_toggle_cw.setChecked(False)
@@ -468,6 +475,7 @@ class ODMRGui(GUIBase):
                 self._mw.runtime_DoubleSpinBox.setEnabled(True)
                 self._sd.clock_frequency_DoubleSpinBox.setEnabled(True)
                 self._sd.oversampling_SpinBox.setEnabled(True)
+                self._sd.lock_in_CheckBox.setEnabled(True)
                 self._mw.action_run_stop.setChecked(False)
                 self._mw.action_resume_odmr.setChecked(False)
                 self._mw.action_toggle_cw.setChecked(True)
@@ -485,6 +493,7 @@ class ODMRGui(GUIBase):
             self._mw.runtime_DoubleSpinBox.setEnabled(True)
             self._sd.clock_frequency_DoubleSpinBox.setEnabled(True)
             self._sd.oversampling_SpinBox.setEnabled(True)
+            self._sd.lock_in_CheckBox.setEnabled(True)
             self._mw.action_run_stop.setChecked(False)
             self._mw.action_resume_odmr.setChecked(False)
             self._mw.action_toggle_cw.setChecked(False)
@@ -593,7 +602,9 @@ class ODMRGui(GUIBase):
         number_of_lines = self._sd.matrix_lines_SpinBox.value()
         clock_frequency = self._sd.clock_frequency_DoubleSpinBox.value()
         oversampling = self._sd.oversampling_SpinBox.value()
+        lock_in = self._sd.lock_in_CheckBox.isChecked()
         self.sigOversamplingChanged.emit(oversampling)
+        self.sigLockInChanged.emit(lock_in)
         self.sigClockFreqChanged.emit(clock_frequency)
         self.sigNumberOfLinesChanged.emit(number_of_lines)
         return
@@ -603,6 +614,7 @@ class ODMRGui(GUIBase):
         self._sd.matrix_lines_SpinBox.setValue(self._odmr_logic.number_of_lines)
         self._sd.clock_frequency_DoubleSpinBox.setValue(self._odmr_logic.clock_frequency)
         self._sd.oversampling_SpinBox.setValue(self._odmr_logic.oversampling)
+        self._sd.lock_in_CheckBox.setChecked(self._odmr_logic.oversampling)
         return
 
     def do_fit(self):
@@ -695,6 +707,12 @@ class ODMRGui(GUIBase):
             self._sd.oversampling_SpinBox.blockSignals(True)
             self._sd.oversampling_SpinBox.setValue(param)
             self._sd.oversampling_SpinBox.blockSignals(False)
+
+        param = param_dict.get('lock_in')
+        if param is not None:
+            self._sd.lock_in_CheckBox.blockSignals(True)
+            self._sd.lock_in_CheckBox.setChecked(param)
+            self._sd.lock_in_CheckBox.blockSignals(False)
 
         param = param_dict.get('cw_mw_frequency')
         if param is not None:

--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -614,7 +614,7 @@ class ODMRGui(GUIBase):
         self._sd.matrix_lines_SpinBox.setValue(self._odmr_logic.number_of_lines)
         self._sd.clock_frequency_DoubleSpinBox.setValue(self._odmr_logic.clock_frequency)
         self._sd.oversampling_SpinBox.setValue(self._odmr_logic.oversampling)
-        self._sd.lock_in_CheckBox.setChecked(self._odmr_logic.oversampling)
+        self._sd.lock_in_CheckBox.setChecked(self._odmr_logic.lock_in)
         return
 
     def do_fit(self):

--- a/gui/odmr/ui_odmr_settings.ui
+++ b/gui/odmr/ui_odmr_settings.ui
@@ -31,6 +31,53 @@
        <string>ODMR</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="font">
+          <font>
+           <pointsize>10</pointsize>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string>That is the inverse time how long the scanner stays at the desired frequency and counts.</string>
+         </property>
+         <property name="text">
+          <string>Clock frequency :</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="1">
+        <widget class="QDoubleSpinBox" name="clock_frequency_DoubleSpinBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>75</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="maximum">
+          <double>10000.000000000000000</double>
+         </property>
+        </widget>
+       </item>
        <item row="0" column="0">
         <widget class="QLabel" name="label">
          <property name="font">
@@ -65,68 +112,6 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="font">
-          <font>
-           <pointsize>10</pointsize>
-          </font>
-         </property>
-         <property name="toolTip">
-          <string>That is the inverse time how long the scanner stays at the desired frequency and counts.</string>
-         </property>
-         <property name="text">
-          <string>Clock frequency :</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QDoubleSpinBox" name="clock_frequency_DoubleSpinBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>75</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="maximum">
-          <double>10000.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="font">
-          <font>
-           <pointsize>10</pointsize>
-          </font>
-         </property>
-         <property name="toolTip">
-          <string>That is the inverse time how long the scanner stays at the desired frequency and counts.</string>
-         </property>
-         <property name="text">
-          <string>Oversampling :</string>
-         </property>
-        </widget>
-       </item>
        <item row="2" column="1">
         <widget class="QSpinBox" name="oversampling_SpinBox">
          <property name="sizePolicy">
@@ -146,6 +131,43 @@
          </property>
          <property name="maximum">
           <number>100000</number>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="font">
+          <font>
+           <pointsize>10</pointsize>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string>That is the inverse time how long the scanner stays at the desired frequency and counts.</string>
+         </property>
+         <property name="text">
+          <string>Oversampling :</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="font">
+          <font>
+           <pointsize>10</pointsize>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string>That is the inverse time how long the scanner stays at the desired frequency and counts.</string>
+         </property>
+         <property name="text">
+          <string>Lock-In detection :</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QCheckBox" name="lock_in_CheckBox">
+         <property name="text">
+          <string>active</string>
          </property>
         </widget>
        </item>

--- a/gui/odmr/ui_odmr_settings.ui
+++ b/gui/odmr/ui_odmr_settings.ui
@@ -31,6 +31,21 @@
        <string>ODMR</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label">
+         <property name="font">
+          <font>
+           <pointsize>10</pointsize>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string>This is the number of lines plotted in the Matrix Plot (lower plot).</string>
+         </property>
+         <property name="text">
+          <string>Matrix Lines :</string>
+         </property>
+        </widget>
+       </item>
        <item row="0" column="1">
         <widget class="QSpinBox" name="matrix_lines_SpinBox">
          <property name="sizePolicy">
@@ -50,22 +65,7 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label">
-         <property name="font">
-          <font>
-           <pointsize>10</pointsize>
-          </font>
-         </property>
-         <property name="toolTip">
-          <string>This is the number of lines plotted in the Matrix Plot (lower plot).</string>
-         </property>
-         <property name="text">
-          <string>Matrix Lines :</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
+       <item row="3" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -77,6 +77,21 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="font">
+          <font>
+           <pointsize>10</pointsize>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string>That is the inverse time how long the scanner stays at the desired frequency and counts.</string>
+         </property>
+         <property name="text">
+          <string>Clock frequency :</string>
+         </property>
+        </widget>
        </item>
        <item row="1" column="1">
         <widget class="QDoubleSpinBox" name="clock_frequency_DoubleSpinBox">
@@ -97,8 +112,8 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_2">
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_3">
          <property name="font">
           <font>
            <pointsize>10</pointsize>
@@ -108,7 +123,29 @@
           <string>That is the inverse time how long the scanner stays at the desired frequency and counts.</string>
          </property>
          <property name="text">
-          <string>Clock frequency :</string>
+          <string>Oversampling :</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QSpinBox" name="oversampling_SpinBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>75</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>100000</number>
          </property>
         </widget>
        </item>

--- a/hardware/camera/andor/iXon897_ultra.py
+++ b/hardware/camera/andor/iXon897_ultra.py
@@ -40,12 +40,14 @@ class ReadMode(Enum):
     SINGLE_TRACK = 3
     IMAGE = 4
 
+
 class AcquisitionMode(Enum):
     SINGLE_SCAN = 1
     ACCUMULATE = 2
     KINETICS = 3
     FAST_KINETICS = 4
     RUN_TILL_ABORT = 5
+
 
 class TriggerMode(Enum):
     INTERNAL = 0
@@ -54,6 +56,7 @@ class TriggerMode(Enum):
     EXTERNAL_EXPOSURE = 7
     SOFTWARE_TRIGGER = 10
     EXTERNAL_CHARGE_SHIFTING = 12
+
 
 ERROR_DICT = {
     20001: "DRV_ERROR_CODES",
@@ -96,6 +99,7 @@ ERROR_DICT = {
     20991: "DRV_NOT_SUPPORTED",
     20992: "DRV_NOT_AVAILABLE"
 }
+
 
 class IxonUltra(Base, CameraInterface):
     """
@@ -390,7 +394,7 @@ class IxonUltra(Base, CameraInterface):
             images.append(img)
         self.log.debug('expected number of images:{0}'.format(length))
         self.log.debug('number of images acquired:{0}'.format(len(images)))
-        return np.array(images).transpose()
+        return False, np.array(images).transpose()
 
     def get_down_time(self):
         return self._exposure

--- a/hardware/gated_ni_card.py
+++ b/hardware/gated_ni_card.py
@@ -19,18 +19,8 @@ along with Qudi. If not, see <http://www.gnu.org/licenses/>.
 Copyright (c) the Qudi Developers. See the COPYRIGHT.txt file at the
 top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi/>
 """
-
-import numpy as np
-import re
-
-import PyDAQmx as daq
-
-from core.module import Base, ConfigOption
-from interface.slow_counter_interface import SlowCounterInterface
 from interface.slow_counter_interface import SlowCounterConstraints
 from interface.slow_counter_interface import CountingMode
-from interface.odmr_counter_interface import ODMRCounterInterface
-from interface.confocal_scanner_interface import ConfocalScannerInterface
 from .national_instruments_x_series import NationalInstrumentsXSeries
 
 
@@ -72,13 +62,20 @@ class SlowGatedNICard(NationalInstrumentsXSeries):
         return constraints
 
     #overwrite the SlowCounterInterface commands of the class NICard:
-    def set_up_clock(self, clock_frequency=None, clock_channel=None):
+    def set_up_clock(self, clock_frequency=None, clock_channel=None, scanner=False, idle=False):
         """ Configures the hardware clock of the NiDAQ card to give the timing.
 
         @param float clock_frequency: if defined, this sets the frequency of
-                                      the clock
+                                      the clock in Hz
         @param string clock_channel: if defined, this is the physical channel
-                                     of the clock
+                                     of the clock within the NI card.
+        @param bool scanner: if set to True method will set up a clock function
+                             for the scanner, otherwise a clock function for a
+                             counter will be set.
+        @param bool idle: set whether idle situation of the counter (where
+                          counter is doing nothing) is defined as
+                                True  = 'Voltage High/Rising Edge'
+                                False = 'Voltage Low/Falling Edge'
 
         @return int: error code (0:OK, -1:error)
         """
@@ -122,8 +119,13 @@ class SlowGatedNICard(NationalInstrumentsXSeries):
         """
         return self.get_gated_counts(samples=samples)
 
-    def close_counter(self):
-        """ Closes the counter and cleans up afterwards.
+    def close_counter(self, scanner=False):
+        """ Closes the counter or scanner and cleans up afterwards.
+
+        @param bool scanner: specifies if the counter- or scanner- function
+                             will be excecuted to close the device.
+                                True = scanner
+                                False = counter
 
         @return int: error code (0:OK, -1:error)
         """
@@ -131,8 +133,13 @@ class SlowGatedNICard(NationalInstrumentsXSeries):
             return -1
         return self.close_gated_counter()
 
-    def close_clock(self):
+    def close_clock(self, scanner=False):
         """ Closes the clock and cleans up afterwards.
+
+        @param bool scanner: specifies if the counter- or scanner- function
+                             should be used to close the device.
+                                True = scanner
+                                False = counter
 
         @return int: error code (0:OK, -1:error)
         """

--- a/hardware/microwave/mw_source_anritsu_MG369x.py
+++ b/hardware/microwave/mw_source_anritsu_MG369x.py
@@ -33,7 +33,7 @@ from interface.microwave_interface import MicrowaveMode
 from interface.microwave_interface import TriggerEdge
 
 
-class MicrowaveAnritsu70GHz(Base, MicrowaveInterface):
+class MicrowaveAnritsuMG369x(Base, MicrowaveInterface):
     """ Hardware control file for Anritsu 70GHz Devices.
         Tested for the model MG3696B.
     """
@@ -95,12 +95,27 @@ class MicrowaveAnritsu70GHz(Base, MicrowaveInterface):
         limits.min_power = -20
         limits.max_power = 10
 
+        if self.model == 'MG3696B':
+            limits.min_frequency = 10e6
+            limits.max_frequency = 70e9
+
+            limits.min_power = -20
+            limits.max_power = 10
+        elif self.model == 'MG3691C':
+            limits.min_frequency = 10e6  # only with Option 4 or 5
+            limits.max_frequency = 10e9
+
+            limits.min_power = -120
+            limits.max_power = 20  # could be up to 26 dBm for Option 15
+        else:
+            self.log.warning('Model string unknown, hardware limits may be wrong.')
+
         limits.list_minstep = 0.001
-        limits.list_maxstep = 70e9
+        limits.list_maxstep = limits.max_frequency
         limits.list_maxentries = 1999
 
         limits.sweep_minstep = 0.001
-        limits.sweep_maxstep = 70e9
+        limits.sweep_maxstep = limits.max_frequency
         limits.sweep_maxentries = 10001
         return limits
 
@@ -238,6 +253,9 @@ class MicrowaveAnritsu70GHz(Base, MicrowaveInterface):
         self._gpib_connection.write('LEA')
         # activate output
         self._gpib_connection.write('RF1')
+
+        if self.model == 'MG3691C':
+            time.sleep(5)  # for model MG3691C wait 5 seconds for the microwave to switch on
         self._is_running = True
         return 0
 

--- a/hardware/microwave/mw_source_anritsu_MG369x.py
+++ b/hardware/microwave/mw_source_anritsu_MG369x.py
@@ -263,7 +263,7 @@ class MicrowaveAnritsuMG369x(Base, MicrowaveInterface):
         self._gpib_connection.write('RF1')
 
         if self.model == 'MG3691C':
-            time.sleep(5)  # for model MG3691C wait 5 seconds for the microwave to switch on
+            time.sleep(10)  # for model MG3691C wait 5 seconds for the microwave to switch on
         self._is_running = True
         return 0
 
@@ -280,11 +280,11 @@ class MicrowaveAnritsuMG369x(Base, MicrowaveInterface):
 
         if is_running:
             self.off()
-        if mode != 'list':
-            self._gpib_connection.write('LST')
-            self._gpib_connection.write('ELN0')
-            self._gpib_connection.write('ELI0000')
-            self._current_mode = 'list'
+        #if mode != 'list':
+        self._gpib_connection.write('LST')
+        self._gpib_connection.write('ELN0')
+        self._gpib_connection.write('ELI0000')
+        self._current_mode = 'list'
 
         # if self.set_cw(freq[0], power) != 0:
         #     error = -1

--- a/hardware/national_instruments_x_series.py
+++ b/hardware/national_instruments_x_series.py
@@ -123,7 +123,6 @@ class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInte
     # timeout for the Read or/and write process in s
     _RWTimeout = ConfigOption('read_write_timeout', default=10)
     _counting_edge_rising = ConfigOption('counting_edge_rising', default=True)
-    _default_oversampling = ConfigOption('oversampling', 10)
 
     def on_activate(self):
         """ Starts up the NI Card at activation.
@@ -140,7 +139,7 @@ class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInte
         self._gated_counter_daq_task = None
         self._scanner_analog_daq_task = None
         self._odmr_pulser_daq_task = None
-        self._oversampling = self._default_oversampling
+        self._oversampling = 0
         self._lock_in_active = False
 
         # handle all the parameters given by the config

--- a/hardware/national_instruments_x_series.py
+++ b/hardware/national_instruments_x_series.py
@@ -1460,6 +1460,7 @@ class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInte
 
         @return int: error code (0:OK, -1:error)
         """
+
         return self.set_up_clock(
             clock_frequency=clock_frequency,
             clock_channel=clock_channel,
@@ -1567,7 +1568,7 @@ class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInte
             # otherwise, it will be low until task starts, and MW will receive wrong pulses.
             daq.DAQmxStopTask(self._scanner_clock_daq_task)
 
-            if self._lock_in_active:
+            if self.lock_in_active:
                 ptask = daq.TaskHandle()
                 daq.DAQmxCreateTask('ODMRPulser', daq.byref(ptask))
                 daq.DAQmxCreateDOChan(
@@ -1716,7 +1717,7 @@ class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInte
             return True, np.array([-1.])
 
         # check if length setup is correct, if not, adjust.
-        odmr_length_to_set = length * self._oversampling * 2 if self._odmr_pulser_daq_task else length
+        odmr_length_to_set = length * self.oversampling * 2 if self._odmr_pulser_daq_task else length
         if self.set_odmr_length(odmr_length_to_set) < 0:
             self.log.error('An error arose while setting the odmr lenth to {}.'.format(odmr_length_to_set))
             return True, np.array([-1.])
@@ -1735,11 +1736,11 @@ class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInte
                 # The pulse pattern is an alternating 0 and 1 on the switching channel (line0),
                 # while the first half of the whole microwave pulse is 1 and the other half is 0.
                 # This way the beginning of the microwave has a rising edge.
-                pulse_pattern = np.zeros(self._oversampling*2, dtype=np.uint32)
-                pulse_pattern[:self._oversampling:2] = 3
-                pulse_pattern[1:self._oversampling:2] = 1
-                pulse_pattern[self._oversampling:-1:2] = 2
-                pulse_pattern[self._oversampling+1:-1:2] = 0
+                pulse_pattern = np.zeros(self.oversampling * 2, dtype=np.uint32)
+                pulse_pattern[:self.oversampling:2] = 3
+                pulse_pattern[1:self.oversampling:2] = 1
+                pulse_pattern[self.oversampling:-1:2] = 2
+                pulse_pattern[self.oversampling+1:-1:2] = 0
                 daq.DAQmxWriteDigitalU32(self._odmr_pulser_daq_task,
                                          len(pulse_pattern),
                                          0,
@@ -1834,7 +1835,7 @@ class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInte
             self._real_data += self._odmr_data[:-1:2]
 
             if self._odmr_pulser_daq_task:
-                self._differential_data = np.zeros((self._oversampling*length, ), dtype=np.float64)
+                self._differential_data = np.zeros((self.oversampling * length, ), dtype=np.float64)
 
                 self._differential_data += self._real_data[1::2]
                 self._differential_data -= self._real_data[::2]
@@ -1843,12 +1844,12 @@ class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInte
                                                     where=self._real_data[::2] != 0)
 
                 all_data[0] = np.median(np.reshape(self._differential_data,
-                                                   (-1, self._oversampling)),
+                                                   (-1, self.oversampling)),
                                         axis=1
                                         )
                 if len(self._scanner_ai_channels) > 0:
                     for i, analog_data in enumerate(self._odmr_analog_data):
-                        self._differential_data = np.zeros((self._oversampling*length, ), dtype=np.float64)
+                        self._differential_data = np.zeros((self.oversampling * length, ), dtype=np.float64)
 
                         self._differential_data += analog_data[1:-1:2]
                         self._differential_data -= analog_data[:-1:2]
@@ -1857,7 +1858,7 @@ class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInte
                                                             where=analog_data[:-1:2] != 0)
 
                         all_data[i+1] = np.median(np.reshape(self._differential_data,
-                                                             (-1, self._oversampling)),
+                                                             (-1, self.oversampling)),
                                                   axis=1
                                                   )
 

--- a/hardware/national_instruments_x_series.py
+++ b/hardware/national_instruments_x_series.py
@@ -101,7 +101,7 @@ class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInte
         self._scanner_analog_daq_task = None
         self._odmr_pulser_daq_task = None
         self._oversampling = self._default_oversampling
-        self._lock_in_active = True
+        self._lock_in_active = False
 
         # handle all the parameters given by the config
         self._current_position = np.zeros(len(self._scanner_ao_channels))
@@ -1654,6 +1654,12 @@ class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInte
             self.log.error('lock_in_active has to be boolean.')
         else:
             self._lock_in_active = val
+            if self._lock_in_active:
+                self.log.warn('You just switched the ODMR counter to Lock-In-mode. \n'
+                              'Please make sure you connected all triggers correctly:\n'
+                              '  {0:s}/line0 is the microwave trigger channel\n'
+                              '  {0:s}/line1 is the switching channel for the lock in\n'
+                              ''.format(self._pulse_out_channel))
 
     def count_odmr(self, length=100):
         """ Sweeps the microwave and returns the counts on that sweep.

--- a/hardware/national_instruments_x_series.py
+++ b/hardware/national_instruments_x_series.py
@@ -1795,7 +1795,6 @@ class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInte
             if self._odmr_pulser_daq_task:
                 self._differential_data = np.zeros((self._oversampling*length, ), dtype=np.float64)
 
-                print('digital', n_read_samples.value, len(self._real_data), len(self._differential_data))
                 self._differential_data += self._real_data[1::2]
                 self._differential_data -= self._real_data[::2]
                 self._differential_data = np.divide(self._differential_data, self._real_data[::2],
@@ -1810,7 +1809,6 @@ class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInte
                     for i, analog_data in enumerate(self._odmr_analog_data):
                         self._differential_data = np.zeros((self._oversampling*length, ), dtype=np.float64)
 
-                        print('analog channel', i, analog_read_samples.value, self._odmr_length, len(self._differential_data))
                         self._differential_data += analog_data[1:-1:2]
                         self._differential_data -= analog_data[:-1:2]
                         self._differential_data = np.divide(self._differential_data, analog_data[:-1:2],
@@ -2170,7 +2168,7 @@ class NationalInstrumentsXSeries(Base, SlowCounterInterface, ConfocalScannerInte
             daq.DAQmxStartTask(self.digital_out_task)
             daq.DAQmxWriteDigitalU32(self.digital_out_task, self.digital_samples_channel, True,
                                         self._RWTimeout, daq.DAQmx_Val_GroupByChannel,
-                                        np.array(self.digital_data), self.digital_read, None);
+                                        np.array(self.digital_data), self.digital_read, None)
 
             daq.DAQmxStopTask(self.digital_out_task)
             daq.DAQmxClearTask(self.digital_out_task)

--- a/hardware/odmr_counter_dummy.py
+++ b/hardware/odmr_counter_dummy.py
@@ -38,6 +38,10 @@ class ODMRCounterDummy(Base, ODMRCounterInterface):
     _clock_frequency = ConfigOption('clock_frequency', 100, missing='warn')
     _number_of_channels = ConfigOption('number_of_channels', 2, missing='warn')
 
+    _pulse_out_channel = 'dummy'
+    _lock_in_active = False
+    _oversampling = 10
+
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
 
@@ -178,3 +182,27 @@ class ODMRCounterDummy(Base, ODMRCounterInterface):
         @return list(str): channels recorded during ODMR measurement
         """
         return ['ch{0:d}'.format(i) for i in range(1, self._number_of_channels + 1)]
+
+    @property
+    def oversampling(self):
+        return self._oversampling
+
+    @oversampling.setter
+    def oversampling(self, val):
+        if not isinstance(val, (int, float)):
+            self.log.error('oversampling has to be int of float.')
+        else:
+            self._oversampling = int(val)
+
+    @property
+    def lock_in_active(self):
+        return self._lock_in_active
+
+    @lock_in_active.setter
+    def lock_in_active(self, val):
+        if not isinstance(val, bool):
+            self.log.error('lock_in_active has to be boolean.')
+        else:
+            self._lock_in_active = val
+            if self._lock_in_active:
+                self.log.warn('Lock-In is not implemented')

--- a/hardware/odmr_counter_dummy.py
+++ b/hardware/odmr_counter_dummy.py
@@ -49,15 +49,14 @@ class ODMRCounterDummy(Base, ODMRCounterInterface):
     _clock_frequency = ConfigOption('clock_frequency', 100, missing='warn')
     _number_of_channels = ConfigOption('number_of_channels', 2, missing='warn')
 
-    _pulse_out_channel = 'dummy'
-    _lock_in_active = False
-    _oversampling = 10
-
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
 
         self._scanner_counter_daq_task = None
         self._odmr_length = None
+        self._pulse_out_channel = 'dummy'
+        self._lock_in_active = False
+        self._oversampling = 10
 
     def on_activate(self):
         """ Initialisation performed during activation of the module.

--- a/hardware/odmr_counter_dummy.py
+++ b/hardware/odmr_counter_dummy.py
@@ -25,6 +25,7 @@ import time
 from core.module import Base, Connector, ConfigOption
 from interface.odmr_counter_interface import ODMRCounterInterface
 
+
 class ODMRCounterDummy(Base, ODMRCounterInterface):
     """This is the Dummy hardware class that simulates the controls for a simple ODMR.
     """
@@ -151,7 +152,7 @@ class ODMRCounterDummy(Base, ODMRCounterInterface):
         time.sleep(self._odmr_length*1./self._clock_frequency)
 
         self.module_state.unlock()
-        return ret
+        return False, ret
 
 
     def close_odmr(self):

--- a/interface/odmr_counter_interface.py
+++ b/interface/odmr_counter_interface.py
@@ -29,10 +29,6 @@ class ODMRCounterInterface(metaclass=InterfaceMetaclass):
     _modtype = 'ODMRCounterInterface'
     _modclass = 'interface'
 
-    _pulse_out_channel = 'dummy'
-    _lock_in_active = False
-    _oversampling = 10
-
     @abc.abstractmethod
     def set_up_odmr_clock(self, clock_frequency=None, clock_channel=None):
         """ Configures the hardware clock of the NiDAQ card to give the timing.
@@ -109,29 +105,21 @@ class ODMRCounterInterface(metaclass=InterfaceMetaclass):
         pass
 
     @property
+    @abc.abstractmethod
     def oversampling(self):
-        return self._oversampling
+        pass
 
     @oversampling.setter
+    @abc.abstractmethod
     def oversampling(self, val):
-        if not isinstance(val, (int, float)):
-            self.log.error('oversampling has to be int of float.')
-        else:
-            self._oversampling = int(val)
+        pass
 
     @property
+    @abc.abstractmethod
     def lock_in_active(self):
-        return self._lock_in_active
+        pass
 
     @lock_in_active.setter
+    @abc.abstractmethod
     def lock_in_active(self, val):
-        if not isinstance(val, bool):
-            self.log.error('lock_in_active has to be boolean.')
-        else:
-            self._lock_in_active = val
-            if self._lock_in_active:
-                self.log.warn('You just switched the ODMR counter to Lock-In-mode. \n'
-                              'Please make sure you connected all triggers correctly:\n'
-                              '  {0:s}/line0 is the microwave trigger channel\n'
-                              '  {0:s}/line1 is the switching channel for the lock in\n'
-                              ''.format(self._pulse_out_channel))
+        pass

--- a/interface/odmr_counter_interface.py
+++ b/interface/odmr_counter_interface.py
@@ -29,6 +29,10 @@ class ODMRCounterInterface(metaclass=InterfaceMetaclass):
     _modtype = 'ODMRCounterInterface'
     _modclass = 'interface'
 
+    _pulse_out_channel = 'dummy'
+    _lock_in_active = False
+    _oversampling = 10
+
     @abc.abstractmethod
     def set_up_odmr_clock(self, clock_frequency=None, clock_channel=None):
         """ Configures the hardware clock of the NiDAQ card to give the timing.
@@ -103,3 +107,31 @@ class ODMRCounterInterface(metaclass=InterfaceMetaclass):
         @return list(str): channels recorded during ODMR measurement
         """
         pass
+
+    @property
+    def oversampling(self):
+        return self._oversampling
+
+    @oversampling.setter
+    def oversampling(self, val):
+        if not isinstance(val, (int, float)):
+            self.log.error('oversampling has to be int of float.')
+        else:
+            self._oversampling = int(val)
+
+    @property
+    def lock_in_active(self):
+        return self._lock_in_active
+
+    @lock_in_active.setter
+    def lock_in_active(self, val):
+        if not isinstance(val, bool):
+            self.log.error('lock_in_active has to be boolean.')
+        else:
+            self._lock_in_active = val
+            if self._lock_in_active:
+                self.log.warn('You just switched the ODMR counter to Lock-In-mode. \n'
+                              'Please make sure you connected all triggers correctly:\n'
+                              '  {0:s}/line0 is the microwave trigger channel\n'
+                              '  {0:s}/line1 is the switching channel for the lock in\n'
+                              ''.format(self._pulse_out_channel))

--- a/interface/odmr_counter_interface.py
+++ b/interface/odmr_counter_interface.py
@@ -80,7 +80,7 @@ class ODMRCounterInterface(metaclass=InterfaceMetaclass):
 
         @param int length: length of microwave sweep in pixel
 
-        @return float[]: the photon counts per second
+        @return (bool, float[]): tuple: was there an error, the photon counts per second
         """
         pass
 

--- a/logic/interfuse/odmr_counter_microwave_interfuse.py
+++ b/logic/interfuse/odmr_counter_microwave_interfuse.py
@@ -44,13 +44,13 @@ class ODMRCounterMicrowaveInterfuse(GenericLogic, ODMRCounterInterface,
     slowcounter = Connector(interface='SlowCounterInterface')
     microwave = Connector(interface='MicrowaveInterface')
 
-    _pulse_out_channel = 'dummy'
-    _lock_in_active = False
-    _oversampling = 10
-    _odmr_length = 100
-
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
+        self._pulse_out_channel = 'dummy'
+        self._lock_in_active = False
+        self._oversampling = 10
+        self._odmr_length = 100
+
 
     def on_activate(self):
         """ Initialisation performed during activation of the module."""

--- a/logic/interfuse/odmr_counter_microwave_interfuse.py
+++ b/logic/interfuse/odmr_counter_microwave_interfuse.py
@@ -47,7 +47,7 @@ class ODMRCounterMicrowaveInterfuse(GenericLogic, ODMRCounterInterface,
     _pulse_out_channel = 'dummy'
     _lock_in_active = False
     _oversampling = 10
-
+    _odmr_length = 100
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -76,7 +76,6 @@ class ODMRCounterMicrowaveInterfuse(GenericLogic, ODMRCounterInterface,
         return self._sc_device.set_up_clock(clock_frequency=clock_frequency,
                                                    clock_channel=clock_channel)
 
-
     def set_up_odmr(self, counter_channel=None, photon_source=None,
                     clock_channel=None, odmr_trigger_channel=None):
         """ Configures the actual counter with a given clock.
@@ -98,7 +97,6 @@ class ODMRCounterMicrowaveInterfuse(GenericLogic, ODMRCounterInterface,
                                                 clock_channel=clock_channel,
                                                 counter_buffer=None)
 
-
     def set_odmr_length(self, length=100):
         """Set up the trigger sequence for the ODMR and the triggered microwave.
 
@@ -108,7 +106,6 @@ class ODMRCounterMicrowaveInterfuse(GenericLogic, ODMRCounterInterface,
         """
         self._odmr_length = length
         return 0
-
 
     def count_odmr(self, length = 100):
         """ Sweeps the microwave and returns the counts on that sweep.
@@ -124,7 +121,7 @@ class ODMRCounterMicrowaveInterfuse(GenericLogic, ODMRCounterInterface,
             self.trigger()
             counts[:, i] = self._sc_device.get_counter(samples=1)[0]
         self.trigger()
-        return counts
+        return False, counts
 
     def close_odmr(self):
         """ Close the odmr and clean up afterwards.
@@ -152,7 +149,6 @@ class ODMRCounterMicrowaveInterfuse(GenericLogic, ODMRCounterInterface,
     def trigger(self):
 
         return self._mw_device.trigger()
-
 
     def off(self):
         """

--- a/logic/interfuse/odmr_counter_microwave_interfuse.py
+++ b/logic/interfuse/odmr_counter_microwave_interfuse.py
@@ -44,6 +44,11 @@ class ODMRCounterMicrowaveInterfuse(GenericLogic, ODMRCounterInterface,
     slowcounter = Connector(interface='SlowCounterInterface')
     microwave = Connector(interface='MicrowaveInterface')
 
+    _pulse_out_channel = 'dummy'
+    _lock_in_active = False
+    _oversampling = 10
+
+
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
 
@@ -282,3 +287,27 @@ class ODMRCounterMicrowaveInterfuse(GenericLogic, ODMRCounterInterface,
           @return MicrowaveLimits: Microwave limits object
         """
         return self._mw_device.get_limits()
+
+    @property
+    def oversampling(self):
+        return self._oversampling
+
+    @oversampling.setter
+    def oversampling(self, val):
+        if not isinstance(val, (int, float)):
+            self.log.error('oversampling has to be int of float.')
+        else:
+            self._oversampling = int(val)
+
+    @property
+    def lock_in_active(self):
+        return self._lock_in_active
+
+    @lock_in_active.setter
+    def lock_in_active(self, val):
+        if not isinstance(val, bool):
+            self.log.error('lock_in_active has to be boolean.')
+        else:
+            self._lock_in_active = val
+            if self._lock_in_active:
+                self.log.warn('Lock-In is not implemented')

--- a/logic/odmr_logic.py
+++ b/logic/odmr_logic.py
@@ -318,7 +318,7 @@ class ODMRLogic(GenericLogic):
         # checks if scanner is still running
         if self.module_state() != 'locked' and isinstance(active, bool):
             self._lock_in_active = active
-            self._odmr_counter._lock_in_active = self._lock_in_active
+            self._odmr_counter.lock_in_active = self._lock_in_active
         else:
             self.log.warning('setter of lock in failed. Logic is either locked or input value is no boolean.')
 

--- a/logic/odmr_logic.py
+++ b/logic/odmr_logic.py
@@ -223,6 +223,9 @@ class ODMRLogic(GenericLogic):
 
         @return object: actually set trigger polarity returned from hardware
         """
+        if self._lock_in_active:
+            frequency = frequency / self._oversampling
+
         if self.module_state() != 'locked':
             self.mw_trigger_pol, triggertime = self._mw_device.set_ext_trigger(trigger_pol, 1/frequency)
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added the capability to oversample the counter on the ODMR for the NI-Card. Thereby, a switch can be added after the microwave source for fast microwave switching which then let's you measure the delta between MW ON and MW OFF.
Also made the Anritsu microwave source hardware file more general to cope with more microwave sources.

## Description
<!--- Describe your changes in detail -->
Added two parameters to ODMR: first to determine the oversampling and the second to activate the lock in itself. There will be a warning that tell you which outputs to connect the triggers to.
The signal with Lock-In active is the ODMR contrast calculated from the differential signal and normalized to the counts at microwave off.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In some experiments the detected signal varies quite a lot. This is especially true for detecting analogue signals in the ODMR. Here it is more beneficial to additionally switch the microwave off and on very fast and then compare the signals from MW OFF and ON. This gets rid of all noise slower than the frequency of oversampling. If oversampling is done to fast at low laser powers the oversampling is not to be done to fast, because otherwise the NV has not enough time to be polarized, reducing the contrast.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested in Qunatentunnel Win10 64x 1803 and digital counting.
Testing on LP-Optics Win10 64x 1803 and analogue counting.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
