### PR TITLE
Added Properties to PredefinedGeneratorBase

### DIFF
--- a/documentation/pulsed/how_to_add_predefined_methods.md
+++ b/documentation/pulsed/how_to_add_predefined_methods.md
@@ -43,7 +43,7 @@ dictionary containing a variety of information about the to-be-sampled waveform/
 Refer to the documentation in `SequenceGeneratorLogic` to learn more about this dictionary.
 If you want to analyze the currently created `PulseBlockEnsemble`/`PulseSequence` within the 
 generate method, you need to explicitly save the corresponding `PulseBlocks` 
-(and `PulseBlockEnsembles`) beforehand by calling `save_block` and `save_sequence`.
+(and `PulseBlockEnsembles`) beforehand by calling `save_block` and `save_ensemble`.
 So getting sampling information about the soon-to-be waveform in a generate method could look like:
 ```
 # Save blocks needed for the PulseBlockEnsemble

--- a/documentation/pulsed/how_to_add_predefined_methods.md
+++ b/documentation/pulsed/how_to_add_predefined_methods.md
@@ -35,8 +35,31 @@ laser_channel etc.)
 * `rabi_period` (the rabi period of the spin to manipulate in seconds)
 * `sample_rate` (the sampling rate of the hardware device)
 
+There are also properties providing easy access to helpful `SequenceGeneratorLogic` methods.
+For more advanced generation methods you may need preliminary information about the 
+waveform/sequence that will be produced from the generate method with the current settings. 
+Therefore you can use `analyze_block_ensemble` and `analyze_sequence`. Both return a large 
+dictionary containing a variety of information about the to-be-sampled waveform/sequence. 
+Refer to the documentation in `SequenceGeneratorLogic` to learn more about this dictionary.
+If you want to analyze the currently created `PulseBlockEnsemble`/`PulseSequence` within the 
+generate method, you need to explicitly save the corresponding `PulseBlocks` 
+(and `PulseBlockEnsembles`) beforehand by calling `save_block` and `save_sequence`.
+So getting sampling information about the soon-to-be waveform in a generate method could look like:
+```
+# Save blocks needed for the PulseBlockEnsemble
+for block in created_blocks:
+    self.save_block(block)
+    
+# Get the waveform information corresponding to the PulseBlockEnsemble
+information_dict = self.analyze_block_ensemble(ensemble=created_ensembles[0])
+
+# Get e.g. the number of samples
+print(information_dict['number_of_samples'])
+```
+
 If you need access to another attribute of the logic module simply add it as property to 
-`PredefinedGeneratorBase` but make sure to protect it properly against changes to the logic module.
+`PredefinedGeneratorBase` or your derived class but make sure to protect it properly against 
+changes to the logic module.
 
 The base class also provides commonly used helper methods to reduce code duplication in the actual 
 generate methods. If you think a helper method of general interest is missing feel free to add it to

--- a/logic/pulsed/pulse_objects.py
+++ b/logic/pulsed/pulse_objects.py
@@ -983,6 +983,14 @@ class PredefinedGeneratorBase:
         return self.__sequencegeneratorlogic.log
 
     @property
+    def analyze_block_ensemble(self):
+        return self.__sequencegeneratorlogic.analyze_block_ensemble
+
+    @property
+    def analyze_sequence(self):
+        return self.__sequencegeneratorlogic.analyze_sequence
+
+    @property
     def pulse_generator_settings(self):
         return self.__sequencegeneratorlogic.pulse_generator_settings
 

--- a/logic/pulsed/pulse_objects.py
+++ b/logic/pulsed/pulse_objects.py
@@ -995,6 +995,18 @@ class PredefinedGeneratorBase:
         return self.__sequencegeneratorlogic.pulse_generator_settings
 
     @property
+    def save_block(self):
+        return self.__sequencegeneratorlogic.save_block
+
+    @property
+    def save_ensemble(self):
+        return self.__sequencegeneratorlogic.save_ensemble
+
+    @property
+    def save_sequence(self):
+        return self.__sequencegeneratorlogic.save_sequence
+
+    @property
     def generation_parameters(self):
         return self.__sequencegeneratorlogic.generation_parameters
 


### PR DESCRIPTION
## Description
Added the two `SequenceGeneratorLogic` methods to analyze PulseBlockEnsembles and PulseSequences as properties to `PredefinedGeneratorBase`:

- `analyze_block_ensemble`
- `analyze_sequence`

Also added the methods to save PulseBlocks/PulseBlockEnsembles/PulseSequences:

- `save_block`
- `save_ensemble`
- `save_sequence`

It should be noted that if you want to make use of the analyze-methods inside a predefined generate method you would need to explicitly save the corresponding blocks/ensembles beforehand.

## Motivation and Context
If you want to do some calculations inside the predefined methods that require exact knowledge of the sampled waveform/sequence (e.g. matching an exact waveform length) you need to be able to access these analysis methods. You could also do that by using the reference to `SequenceGeneratorLogic` but this should be avoided since it is sensitive to changes, thus the new properties.

## How Has This Been Tested?
On dummy Win8.1 x64

## Types of changes
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
