### PR TITLE
Correctly considering wavelength steps

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -4,6 +4,7 @@
 
 Changes/New features:
 
+* Sequence Generator checks the step constraint and adds and idle block if necessary.
 * Save_logic now expands environment variables in the configured data path (e.g. $HOME under Unix or $HOMEPATH under Windows)
 * Added command line argument --logdir to specify the path to the logging directory
 * Added the keyword "labels" to the "measurement_information" dict container in predefined methods.

--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -173,12 +173,12 @@ class AWG70K(Base, PulserInterface):
         constraints.a_ch_amplitude.max = 0.5
         constraints.a_ch_amplitude.step = 0.0001
         constraints.a_ch_amplitude.default = 0.5
-        # FIXME: Enter the proper digital channel low constraints:
+
         constraints.d_ch_low.min = -1.4
         constraints.d_ch_low.max = 0.9
         constraints.d_ch_low.step = 0.1e-3
         constraints.d_ch_low.default = 0.0
-        # FIXME: Enter the proper digital channel high constraints:
+
         constraints.d_ch_high.min = -0.9
         constraints.d_ch_high.max = 1.4
         constraints.d_ch_high.step = 0.1e-3
@@ -188,8 +188,12 @@ class AWG70K(Base, PulserInterface):
 
         constraints.waveform_length.min = self.__min_waveform_length
         constraints.waveform_length.max = self.__max_waveform_length
-        constraints.waveform_length.step = 1
-        constraints.waveform_length.default = 1
+        if self.awg_model == 'AWG70002A':
+            constraints.waveform_length.step = 1
+            constraints.waveform_length.default = 1
+        elif self.awg_model == 'AWG70001A':
+            constraints.waveform_length.step = 2
+            constraints.waveform_length.default = 2
 
         # FIXME: Check the proper number for your device
         constraints.waveform_num.min = 1

--- a/hardware/awg/tektronix_awg7k.py
+++ b/hardware/awg/tektronix_awg7k.py
@@ -224,12 +224,12 @@ class AWG7k(Base, PulserInterface):
         constraints.d_ch_high.default = 1.4
 
         constraints.waveform_length.min = 1
-        constraints.waveform_length.step = 1
+        constraints.waveform_length.step = 4
         constraints.waveform_length.default = 80
         if '01' in self.installed_options:
             constraints.waveform_length.max = 64800000
         else:
-            constraints.waveform_length.max = 32000000
+            constraints.waveform_length.max = 32400000
 
         constraints.waveform_num.min = 1
         constraints.waveform_num.max = 32000

--- a/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
+++ b/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
@@ -100,6 +100,34 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         created_ensembles.append(block_ensemble)
         return created_blocks, created_ensembles, created_sequences
 
+    def generate_two_digital_high(self, name='digital_high', length=3.0e-6, digital_channel1='d_ch1', digital_channel2='d_ch1'):
+        """ General generation method for laser on and microwave on generation.
+
+        @param string name: Name of the PulseBlockEnsemble to be generated
+        @param float length: Length of the PulseBlockEnsemble in seconds
+
+        @return object: the generated PulseBlockEnsemble object.
+        """
+        created_blocks = list()
+        created_ensembles = list()
+        created_sequences = list()
+
+        digital_channels = list([digital_channel1, digital_channel2])
+        # create the laser_mw element
+        trigger_element = self._get_trigger_element(length =length,
+                                                    increment=0,
+                                                    channels=list(digital_channels))
+
+        # Create block and append to created_blocks list
+        laser_mw_block = PulseBlock(name=name)
+        laser_mw_block.append(trigger_element)
+        created_blocks.append(laser_mw_block)
+        # Create block ensemble and append to created_ensembles list
+        block_ensemble = PulseBlockEnsemble(name=name, rotating_frame=False)
+        block_ensemble.append((laser_mw_block.name, 0))
+        created_ensembles.append(block_ensemble)
+        return created_blocks, created_ensembles, created_sequences
+
     def generate_idle(self, name='idle', length=3.0e-6):
         """ Generate just a simple idle ensemble.
 

--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -534,6 +534,8 @@ class PulsedMeasurementLogic(GenericLogic):
                        'alternating',
                        'counting_length')
         if not isinstance(info_dict, dict) or not all(param in info_dict for param in mand_params):
+            self.log.debug('The set measurement_information did not contain all the necessary '
+                           'information or was not a dict. Setting empty dict.')
             self._measurement_information = dict()
             return
 

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1410,7 +1410,8 @@ class SequenceGeneratorLogic(GenericLogic):
             # TODO: take care of rounding errors!
             extension_samples = granularity - ensemble_info['number_of_samples'] % granularity
             target_total_samples = ensemble_info['number_of_samples'] + extension_samples
-            extension_seconds = (target_total_samples / self.__sample_rate) - ensemble_info['ideal_length']
+            extension_seconds = (target_total_samples / self.__sample_rate) - ensemble_info[
+                'ideal_length']
 
             pb_element = PulseBlockElement(
                 init_length_s=extension_seconds,
@@ -1423,13 +1424,19 @@ class SequenceGeneratorLogic(GenericLogic):
             ensemble.measurement_information = temp_measurement_info
 
             self.save_block(idle_extension)
-            # ensemble.sampling_information = dict()
             self.save_ensemble(ensemble)
 
             # get important parameters from the ensemble
             ensemble_info = self.analyze_block_ensemble(ensemble)
-            self.log.warn('Extending waveform {0} by {2} bins. New length {1}.'.format(
-                ensemble.name, ensemble_info['number_of_samples'], extension_samples))
+            if ensemble_info['number_of_samples'] != target_total_samples:
+                self.log.error('Expanding the PulseBlockEnsemble to match the waveform granularity '
+                               'has failed.\nTarget number of samples was {0:d}.\nfinal number of '
+                               'samples is {1:d}.\nThis is probably due to a rounding error in '
+                               'SequenceGeneratorLogic.sample_pulse_block_ensemble.'
+                               ''.format(target_total_samples, ensemble_info['number_of_samples']))
+            else:
+                self.log.warn('Extending waveform {0} by {2} bins. New length {1}.'.format(
+                    ensemble.name, ensemble_info['number_of_samples'], extension_samples))
 
         # Calculate the byte size per sample.
         # One analog sample per channel is 4 bytes (np.float32) and one digital sample per channel


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request adds functionality to the Sequence Generator of the Pulser.
The waveform ensembles are now also checked for the step constraints of the Hardware and bins are added to confirm to htese constraints.

## Description
<!--- Describe your changes in detail -->
The waveform is extended by an additional Idle-Block of the required length in order to make the full waveform dividible by the constraint waveform_length.step.
Also a new predefined method is added to generate a digital high on two channels. This is usefull, if the Pulse Generators is also used to shwitch a laser- or microwave bypass.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
**For the QDyne Users:** As before, you should make sure that you predefined methods conform to the step requirements before sampling them. Nevertheless, a warning is posted, if the waveform is extended.
Also the sampled waveform has is longer than the one sent to the sampling, so with this condition, you can automatically find out, if the waveform was extended.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on Quantentunnel with AWG7k and long sequences that blow the memory on the device if not confirming to the step constraint.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
