### PR TITLE
Sweeps in pulsed measurement

### DIFF
--- a/hardware/fast_counter_dummy.py
+++ b/hardware/fast_counter_dummy.py
@@ -224,6 +224,14 @@ class FastCounterDummy(Base, FastCounterInterface):
         time.sleep(0.5)
         return self._count_data
 
+    def get_current_sweeps(self):
+        """ Get the current number of sweeps
+
+        @return int: current number of sweeps
+
+        Let's not return 0 because some logic might be dividing by this """
+        return 1
+
     def get_frequency(self):
         freq = 950.
         time.sleep(0.5)

--- a/hardware/fast_counter_dummy.py
+++ b/hardware/fast_counter_dummy.py
@@ -228,8 +228,8 @@ class FastCounterDummy(Base, FastCounterInterface):
 
         # include an artificial waiting time
         time.sleep(0.5)
-        info_dict = {'elapsed_sweeps': 424242, 'elapsed_time': 42}
-        return self._count_data#, info_dict
+        info_dict = {'elapsed_sweeps': None, 'elapsed_time': None}
+        return self._count_data, info_dict
 
     def get_frequency(self):
         freq = 950.

--- a/hardware/fast_counter_dummy.py
+++ b/hardware/fast_counter_dummy.py
@@ -229,8 +229,9 @@ class FastCounterDummy(Base, FastCounterInterface):
 
         @return int: current number of sweeps
 
-        Let's not return 0 because some logic might be dividing by this """
-        return 1
+        return -1 if not supported/implemented
+        """
+        return -1
 
     def get_frequency(self):
         freq = 950.

--- a/hardware/fast_counter_dummy.py
+++ b/hardware/fast_counter_dummy.py
@@ -214,24 +214,22 @@ class FastCounterDummy(Base, FastCounterInterface):
         The binning, specified by calling configure() in forehand, must be
         taken care of in this hardware class. A possible overflow of the
         histogram bins must be caught here and taken care of.
-        If the counter is NOT GATED it will return a 1D-numpy-array with
+        If the counter is NOT GATED it will return a tuple (1D-numpy-array, info_dict) with
             returnarray[timebin_index]
-        If the counter is GATED it will return a 2D-numpy-array with
+        If the counter is GATED it will return a tuple (2D-numpy-array, info_dict) with
             returnarray[gate_index, timebin_index]
+
+        info_dict is a dictionary with keys :
+            - 'elapsed_sweeps' : the elapsed number of sweeps
+            - 'elapsed_time' : the elapsed time in seconds
+
+        If the hardware does not support these features, the values should be None
         """
 
         # include an artificial waiting time
         time.sleep(0.5)
-        return self._count_data
-
-    def get_current_sweeps(self):
-        """ Get the current number of sweeps
-
-        @return int: current number of sweeps
-
-        return -1 if not supported/implemented
-        """
-        return -1
+        info_dict = {'elapsed_sweeps': 424242, 'elapsed_time': 42}
+        return self._count_data#, info_dict
 
     def get_frequency(self):
         freq = 950.

--- a/hardware/fastcomtec/fastcomtecmcs6.py
+++ b/hardware/fastcomtec/fastcomtecmcs6.py
@@ -415,6 +415,13 @@ class FastComtec(Base, FastCounterInterface):
 
         return time_trace
 
+    def get_current_sweeps(self):
+        """ Get the current number of sweeps
+
+        @return int: current number of sweeps
+
+        Let's not return 0 because some logic might be dividing by this """
+        return 1
 
 
     # =========================================================================

--- a/hardware/fastcomtec/fastcomtecmcs6.py
+++ b/hardware/fastcomtec/fastcomtecmcs6.py
@@ -420,8 +420,9 @@ class FastComtec(Base, FastCounterInterface):
 
         @return int: current number of sweeps
 
-        Let's not return 0 because some logic might be dividing by this """
-        return 1
+        return -1 if not supported/implemented
+        """
+        return -1
 
 
     # =========================================================================

--- a/hardware/fastcomtec/fastcomtecmcs6.py
+++ b/hardware/fastcomtec/fastcomtecmcs6.py
@@ -413,7 +413,9 @@ class FastComtec(Base, FastCounterInterface):
         if self.gated and self.timetrace_tmp != []:
             time_trace = time_trace + self.timetrace_tmp
 
-        return time_trace
+        info_dict = {'elapsed_sweeps': None,
+                     'elapsed_time': None}  # TODO : implement that according to hardware capabilities
+        return time_trace, info_dict
 
 
     # =========================================================================

--- a/hardware/fastcomtec/fastcomtecmcs6.py
+++ b/hardware/fastcomtec/fastcomtecmcs6.py
@@ -415,15 +415,6 @@ class FastComtec(Base, FastCounterInterface):
 
         return time_trace
 
-    def get_current_sweeps(self):
-        """ Get the current number of sweeps
-
-        @return int: current number of sweeps
-
-        return -1 if not supported/implemented
-        """
-        return -1
-
 
     # =========================================================================
     #                           Non Interface methods

--- a/hardware/fastcomtec/fastcomtecp7887.py
+++ b/hardware/fastcomtec/fastcomtecp7887.py
@@ -315,7 +315,7 @@ class FastComtec(Base, FastCounterInterface):
 
     def get_current_sweeps(self):
         """
-        Returns the current runtime.
+        Returns the current sweeps.
         @return int sweeps: in sweeps
         """
         status = AcqStatus()

--- a/hardware/fastcomtec/fastcomtecp7887.py
+++ b/hardware/fastcomtec/fastcomtecp7887.py
@@ -411,7 +411,9 @@ class FastComtec(Base, FastCounterInterface):
         if self.gated and self.timetrace_tmp != []:
             time_trace = time_trace + self.timetrace_tmp
 
-        return time_trace
+        info_dict = {'elapsed_sweeps': self.get_current_sweeps(),
+                     'elapsed_time': None} 
+        return time_trace, info_dict
 
 
     def get_data_testfile(self):

--- a/hardware/fpga_fastcounter/fast_counter_fpga_pi3.py
+++ b/hardware/fpga_fastcounter/fast_counter_fpga_pi3.py
@@ -233,3 +233,11 @@ class FastCounterFGAPiP3(Base, FastCounterInterface):
         """ Returns the width of a single timebin in the timetrace in seconds. """
         width_in_seconds = self._bin_width * 1e-9
         return width_in_seconds
+
+    def get_current_sweeps(self):
+        """ Get the current number of sweeps
+
+        @return int: current number of sweeps
+
+        Let's not return 0 because some logic might be dividing by this """
+        return 1

--- a/hardware/fpga_fastcounter/fast_counter_fpga_pi3.py
+++ b/hardware/fpga_fastcounter/fast_counter_fpga_pi3.py
@@ -214,7 +214,9 @@ class FastCounterFGAPiP3(Base, FastCounterInterface):
         care of in this hardware class. A possible overflow of the histogram
         bins must be caught here and taken care of.
         """
-        return np.array(self.pulsed.getData(), dtype='int64')
+        info_dict = {'elapsed_sweeps': None,
+                     'elapsed_time': None}  # TODO : implement that according to hardware capabilities
+        return np.array(self.pulsed.getData(), dtype='int64'), info_dict
 
 
     def get_status(self):

--- a/hardware/fpga_fastcounter/fast_counter_fpga_pi3.py
+++ b/hardware/fpga_fastcounter/fast_counter_fpga_pi3.py
@@ -234,11 +234,3 @@ class FastCounterFGAPiP3(Base, FastCounterInterface):
         width_in_seconds = self._bin_width * 1e-9
         return width_in_seconds
 
-    def get_current_sweeps(self):
-        """ Get the current number of sweeps
-
-        @return int: current number of sweeps
-
-        return -1 if not supported/implemented
-        """
-        return -1

--- a/hardware/fpga_fastcounter/fast_counter_fpga_pi3.py
+++ b/hardware/fpga_fastcounter/fast_counter_fpga_pi3.py
@@ -239,5 +239,6 @@ class FastCounterFGAPiP3(Base, FastCounterInterface):
 
         @return int: current number of sweeps
 
-        Let's not return 0 because some logic might be dividing by this """
-        return 1
+        return -1 if not supported/implemented
+        """
+        return -1

--- a/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
+++ b/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
@@ -577,3 +577,11 @@ class FastCounterFPGAQO(Base, FastCounterInterface):
         -1 = error state
         """
         return self.statusvar
+
+    def get_current_sweeps(self):
+        """ Get the current number of sweeps
+
+        @return int: current number of sweeps
+
+        Let's not return 0 because some logic might be dividing by this """
+        return 1

--- a/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
+++ b/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
@@ -578,11 +578,3 @@ class FastCounterFPGAQO(Base, FastCounterInterface):
         """
         return self.statusvar
 
-    def get_current_sweeps(self):
-        """ Get the current number of sweeps
-
-        @return int: current number of sweeps
-
-        return -1 if not supported/implemented
-        """
-        return -1

--- a/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
+++ b/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
@@ -423,6 +423,8 @@ class FastCounterFPGAQO(Base, FastCounterInterface):
         care of in this hardware class. A possible overflow of the histogram
         bins must be caught here and taken care of.
         """
+        info_dict = {'elapsed_sweeps': None,
+                     'elapsed_time': None}  # TODO : implement that according to hardware capabilities
         with self.threadlock:
             # check for error status in FPGA timetagger
             error_messages = self._get_error_messages()
@@ -430,7 +432,7 @@ class FastCounterFPGAQO(Base, FastCounterInterface):
                 for err_message in error_messages:
                     self.log.error(err_message)
                 self.stop_measure()
-                return self.count_data
+                return self.count_data, info_dict
 
             # check for running status
             status_messages = self._get_status_messages()
@@ -439,7 +441,7 @@ class FastCounterFPGAQO(Base, FastCounterInterface):
                                'trace of the device. An empty numpy array[{0},{1}] filled with '
                                'zeros will be returned.'.format(self._number_of_gates,
                                                                 self._gate_length_bins))
-                return self.count_data
+                return self.count_data, info_dict
 
             # initialize the read buffer for the USB transfer.
             # one timebin of the data to read is 32 bit wide and the data is transferred in bytes.
@@ -453,7 +455,7 @@ class FastCounterFPGAQO(Base, FastCounterInterface):
             if read_err_code != buffersize:
                 self.log.error('Data transfer from FPGA via USB failed with error code {0}. '
                                'Returning old count data.'.format(read_err_code))
-                return self.count_data
+                return self.count_data, info_dict
 
             # Encode bytes into 32bit unsigned integers
             buffer_encode = np.frombuffer(data_buffer, dtype='uint32')
@@ -476,7 +478,7 @@ class FastCounterFPGAQO(Base, FastCounterInterface):
             # bin the data according to the specified bin width
             #if self._binwidth != 1:
             #    buffer_encode = buffer_encode[:(buffer_encode.size // self._binwidth) * self._binwidth].reshape(-1, self._binwidth).sum(axis=1)
-            return self.count_data
+            return self.count_data, info_dict
 
     def stop_measure(self):
         """ Stop the fast counter. """

--- a/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
+++ b/hardware/fpga_fastcounter/fast_counter_fpga_qo.py
@@ -583,5 +583,6 @@ class FastCounterFPGAQO(Base, FastCounterInterface):
 
         @return int: current number of sweeps
 
-        Let's not return 0 because some logic might be dividing by this """
-        return 1
+        return -1 if not supported/implemented
+        """
+        return -1

--- a/hardware/picoquant/picoharp300.py
+++ b/hardware/picoquant/picoharp300.py
@@ -1147,6 +1147,14 @@ class PicoHarp300(Base, SlowCounterInterface, FastCounterInterface):
 
         return self.data_trace
 
+    def get_current_sweeps(self):
+        """ Get the current number of sweeps
+
+        @return int: current number of sweeps
+
+        Let's not return 0 because some logic might be dividing by this """
+        return 1
+
 
 
     # =========================================================================

--- a/hardware/picoquant/picoharp300.py
+++ b/hardware/picoquant/picoharp300.py
@@ -1152,9 +1152,9 @@ class PicoHarp300(Base, SlowCounterInterface, FastCounterInterface):
 
         @return int: current number of sweeps
 
-        Let's not return 0 because some logic might be dividing by this """
-        return 1
-
+        return -1 if not supported/implemented
+        """
+        return -1
 
 
     # =========================================================================

--- a/hardware/picoquant/picoharp300.py
+++ b/hardware/picoquant/picoharp300.py
@@ -1147,16 +1147,6 @@ class PicoHarp300(Base, SlowCounterInterface, FastCounterInterface):
 
         return self.data_trace
 
-    def get_current_sweeps(self):
-        """ Get the current number of sweeps
-
-        @return int: current number of sweeps
-
-        return -1 if not supported/implemented
-        """
-        return -1
-
-
     # =========================================================================
     #  Test routine for continuous readout
     # =========================================================================

--- a/hardware/picoquant/picoharp300.py
+++ b/hardware/picoquant/picoharp300.py
@@ -1144,8 +1144,9 @@ class PicoHarp300(Base, SlowCounterInterface, FastCounterInterface):
             returnarray[gate_index, timebin_index]
         """
 
-
-        return self.data_trace
+        info_dict = {'elapsed_sweeps': None,
+                     'elapsed_time': None}  # TODO : implement that according to hardware capabilities
+        return self.data_trace, info_dict
 
     # =========================================================================
     #  Test routine for continuous readout

--- a/hardware/swabian_instruments/timetagger_fast_counter.py
+++ b/hardware/swabian_instruments/timetagger_fast_counter.py
@@ -234,3 +234,11 @@ class TimeTaggerFastCounter(Base, FastCounterInterface):
         """ Returns the width of a single timebin in the timetrace in seconds. """
         width_in_seconds = self._bin_width * 1e-9
         return width_in_seconds
+
+    def get_current_sweeps(self):
+        """ Get the current number of sweeps
+
+        @return int: current number of sweeps
+
+        Let's not return 0 because some logic might be dividing by this """
+        return 1

--- a/hardware/swabian_instruments/timetagger_fast_counter.py
+++ b/hardware/swabian_instruments/timetagger_fast_counter.py
@@ -215,7 +215,9 @@ class TimeTaggerFastCounter(Base, FastCounterInterface):
         care of in this hardware class. A possible overflow of the histogram
         bins must be caught here and taken care of.
         """
-        return np.array(self.pulsed.getData(), dtype='int64')
+        info_dict = {'elapsed_sweeps': None,
+                     'elapsed_time': None}  # TODO : implement that according to hardware capabilities
+        return np.array(self.pulsed.getData(), dtype='int64'), info_dict
 
 
     def get_status(self):

--- a/hardware/swabian_instruments/timetagger_fast_counter.py
+++ b/hardware/swabian_instruments/timetagger_fast_counter.py
@@ -240,5 +240,6 @@ class TimeTaggerFastCounter(Base, FastCounterInterface):
 
         @return int: current number of sweeps
 
-        Let's not return 0 because some logic might be dividing by this """
-        return 1
+        return -1 if not supported/implemented
+        """
+        return -1

--- a/hardware/swabian_instruments/timetagger_fast_counter.py
+++ b/hardware/swabian_instruments/timetagger_fast_counter.py
@@ -235,11 +235,3 @@ class TimeTaggerFastCounter(Base, FastCounterInterface):
         width_in_seconds = self._bin_width * 1e-9
         return width_in_seconds
 
-    def get_current_sweeps(self):
-        """ Get the current number of sweeps
-
-        @return int: current number of sweeps
-
-        return -1 if not supported/implemented
-        """
-        return -1

--- a/interface/fast_counter_interface.py
+++ b/interface/fast_counter_interface.py
@@ -163,3 +163,10 @@ class FastCounterInterface(metaclass=InterfaceMetaclass):
             returnarray[gate_index, timebin_index]
         """
         pass
+
+    @abc.abstractmethod
+    def get_current_sweeps(self):
+        """ Get the current number of sweeps
+
+        @return int: current number of sweeps"""
+        pass

--- a/interface/fast_counter_interface.py
+++ b/interface/fast_counter_interface.py
@@ -157,19 +157,15 @@ class FastCounterInterface(metaclass=InterfaceMetaclass):
         The binning, specified by calling configure() in forehand, must be
         taken care of in this hardware class. A possible overflow of the
         histogram bins must be caught here and taken care of.
-        If the counter is NOT GATED it will return a 1D-numpy-array with
+        If the counter is NOT GATED it will return a tuple (1D-numpy-array, info_dict) with
             returnarray[timebin_index]
-        If the counter is GATED it will return a 2D-numpy-array with
+        If the counter is GATED it will return a tuple (2D-numpy-array, info_dict) with
             returnarray[gate_index, timebin_index]
-        """
-        pass
 
-    @abc.abstractmethod
-    def get_current_sweeps(self):
-        """ Get the current number of sweeps
+        info_dict is a dictionary with keys :
+            - 'elapsed_sweeps' : the elapsed number of sweeps
+            - 'elapsed_time' : the elapsed time in seconds
 
-        @return int: current number of sweeps
-
-        return -1 if not supported/implemented
+        If the hardware does not support these features, the values should be None
         """
         pass

--- a/interface/fast_counter_interface.py
+++ b/interface/fast_counter_interface.py
@@ -168,5 +168,8 @@ class FastCounterInterface(metaclass=InterfaceMetaclass):
     def get_current_sweeps(self):
         """ Get the current number of sweeps
 
-        @return int: current number of sweeps"""
+        @return int: current number of sweeps
+
+        return -1 if not supported/implemented
+        """
         pass

--- a/logic/pulsed/pulsed_master_logic.py
+++ b/logic/pulsed/pulsed_master_logic.py
@@ -317,6 +317,14 @@ class PulsedMasterLogic(GenericLogic):
         return self.pulsedmeasurementlogic().fast_counter_settings
 
     @property
+    def elapsed_sweeps(self):
+        return self.pulsedmeasurementlogic().elapsed_sweeps
+
+    @property
+    def elapsed_time(self):
+        return self.pulsedmeasurementlogic().elapsed_time
+
+    @property
     def ext_microwave_constraints(self):
         return self.pulsedmeasurementlogic().ext_microwave_constraints
 

--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -141,6 +141,8 @@ class PulsedMeasurementLogic(GenericLogic):
 
         # Paused measurement flag
         self.__is_paused = False
+        self._time_of_pause = None
+        self._elapsed_pause = 0
 
         # for fit:
         self.fc = None  # Fit container
@@ -793,6 +795,7 @@ class PulsedMeasurementLogic(GenericLogic):
 
                 # initialize analysis_timer
                 self.__elapsed_time = 0.0
+                self._elapsed_pause = 0
                 self.sigTimerUpdated.emit(self.__elapsed_time,
                                           self.__elapsed_sweeps,
                                           self.__timer_interval)
@@ -839,6 +842,7 @@ class PulsedMeasurementLogic(GenericLogic):
 
                 # Set measurement paused flag
                 self.__is_paused = False
+                self._elapsed_pause = 0
 
                 self.module_state.unlock()
                 self.sigMeasurementStatusUpdated.emit(False, False)
@@ -876,6 +880,7 @@ class PulsedMeasurementLogic(GenericLogic):
 
                 # Set measurement paused flag
                 self.__is_paused = True
+                self._time_of_pause = time.time()
 
                 self.sigMeasurementStatusUpdated.emit(True, True)
             else:
@@ -901,6 +906,7 @@ class PulsedMeasurementLogic(GenericLogic):
 
                 # Set measurement paused flag
                 self.__is_paused = False
+                self._elapsed_pause = time.time() - self._time_of_pause
 
                 self.sigMeasurementStatusUpdated.emit(True, False)
             else:
@@ -1093,7 +1099,8 @@ class PulsedMeasurementLogic(GenericLogic):
         with self._threadlock:
             if self.module_state() == 'locked':
                 # Update elapsed time
-                self.__elapsed_time = time.time() - self.__start_time + self._current_saved_elapsed_time
+                self.__elapsed_time = time.time() - self.__start_time + self._current_saved_elapsed_time \
+                                      - self._elapsed_pause
 
                 self._extract_laser_pulses()
 

--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -1157,7 +1157,7 @@ class PulsedMeasurementLogic(GenericLogic):
         """
         Get the raw count data from the fast counting hardware and perform sanity checks.
         Also add recalled raw data to the newly received data.
-        :return tuple(numpy.ndarray, info_dict): The count data (1D for ungated, 2D for gated counter) and
+        @return tuple(numpy.ndarray, info_dict): The count data (1D for ungated, 2D for gated counter) and
                                                  info_dict with keys 'elapsed_sweeps' and 'elapsed_time'
         """
         # get raw data from fast counter
@@ -1167,12 +1167,12 @@ class PulsedMeasurementLogic(GenericLogic):
         else:
             info_dict = {'elapsed_sweeps': None, 'elapsed_time': None}
 
-        if type(info_dict) == dict and 'elapsed_sweeps' in info_dict.keys() and info_dict['elapsed_sweeps'] is not None:
+        if isinstance(info_dict, dict) and info_dict.get('elapsed_sweeps') is not None:
             elapsed_sweeps = info_dict['elapsed_sweeps']
         else:
             elapsed_sweeps = -1
 
-        if type(info_dict) == dict and 'elapsed_time' in info_dict.keys() and info_dict['elapsed_time'] is not None:
+        if isinstance(info_dict, dict) and info_dict.get('elapsed_time') is not None:
             elapsed_time = info_dict['elapsed_time']
         else:
             elapsed_time = time.time() - self.__start_time

--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -1138,7 +1138,7 @@ class PulsedMeasurementLogic(GenericLogic):
 
     def _extract_laser_pulses(self):
         # Get counter raw data (including recalled raw data from previous measurement)
-        self._fetch_raw_data()
+        self._get_raw_data()
 
         # extract laser pulses from raw data
         return_dict = self._pulseextractor.extract_laser_pulses(self.raw_data)
@@ -1156,10 +1156,11 @@ class PulsedMeasurementLogic(GenericLogic):
             tmp_error = np.zeros(self.laser_data.shape[0])
         return tmp_signal, tmp_error
 
-    def _fetch_raw_data(self):
+    def _get_raw_data(self):
         """
         Get the raw count data from the fast counting hardware and perform sanity checks.
         Also add recalled raw data to the newly received data.
+        :return numpy.ndarray: The count data (1D for ungated, 2D for gated counter)
         """
         # get raw data from fast counter
         fc_data = netobtain(self.fastcounter().get_data_trace())
@@ -1185,6 +1186,7 @@ class PulsedMeasurementLogic(GenericLogic):
             fc_data = np.zeros(fc_data.shape, dtype='int64')
         self.raw_data = fc_data
         self.__elapsed_sweeps = sweeps
+        return fc_data
 
     def _initialize_data_arrays(self):
         """

--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -906,7 +906,7 @@ class PulsedMeasurementLogic(GenericLogic):
 
                 # Set measurement paused flag
                 self.__is_paused = False
-                self._elapsed_pause = time.time() - self._time_of_pause
+                self._elapsed_pause += time.time() - self._time_of_pause
 
                 self.sigMeasurementStatusUpdated.emit(True, False)
             else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I've modified the fast_counter_interface to get the number of sweeps, and updated all the hardware with a dummy function. I've also updated the logic to take this into account, espacially in the stop and restart features. I've finally taken paused time into account in elapsed time.

## Motivation and Context
The sweeps feature was shown in the GUI but not implemented yet.
The elapsed time should not increase when the acquisition is paused.

## How Has This Been Tested?
I've tested this on the dummies and on a real setup with a fastcomtec 7887.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
