### PR TITLE
Confocal button range

### DIFF
--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -657,6 +657,7 @@ class ConfocalGui(GUIBase):
 
         # Configure and connect the zoom actions with the desired buttons and
         # functions if
+        self._mw.actionFocus_on_cursor.triggered.connect(self.focus_cursor)
         self._mw.action_full_range_xy.triggered.connect(self.set_full_scan_range_xy)
         self._mw.action_full_range_z.triggered.connect(self.set_full_scan_range_z)
 
@@ -2264,3 +2265,22 @@ class ConfocalGui(GUIBase):
         if tag == 'logic':
             self.disable_scan_actions()
 
+    def focus_cursor(self):
+        """Focus the range on the current position of the cursor
+        """
+        h_size = self._scanning_logic.image_x_range[1] - self._scanning_logic.image_x_range[0]
+        v_size = self._scanning_logic.image_y_range[1] - self._scanning_logic.image_y_range[0]
+        z_size = self._scanning_logic.image_z_range[1] - self._scanning_logic.image_z_range[0]
+        x_pos = self._scanning_logic._current_x
+        y_pos = self._scanning_logic._current_y
+        z_pos = self._scanning_logic._current_z
+
+        self._scanning_logic.image_x_range = [x_pos - h_size/2.0, x_pos + h_size/2.0]
+        self._scanning_logic.image_y_range = [y_pos - v_size/2.0, y_pos + v_size/2.0]
+        self._scanning_logic.image_z_range = [z_pos - z_size/2.0, z_pos + z_size/2.0]
+        
+        self.update_scan_range_inputs()
+        
+        return
+    
+    

--- a/gui/confocal/ui_confocalgui.ui
+++ b/gui/confocal/ui_confocalgui.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1261</width>
+    <width>1367</width>
     <height>1362</height>
    </rect>
   </property>
@@ -27,8 +27,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1261</width>
-     <height>21</height>
+     <width>1367</width>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -1462,6 +1462,7 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
+   <addaction name="actionFocus_on_cursor"/>
    <addaction name="action_zoom"/>
    <addaction name="action_full_range_xy"/>
    <addaction name="action_full_range_z"/>
@@ -2299,6 +2300,15 @@
    </property>
    <property name="shortcut">
     <string>Shift+C</string>
+   </property>
+  </action>
+  <action name="actionFocus_on_cursor">
+   <property name="icon">
+    <iconset>
+     <normaloff>../../artwork/icons/qudiTheme/22x22/goto-poi.png</normaloff>../../artwork/icons/qudiTheme/22x22/goto-poi.png</iconset>
+   </property>
+   <property name="text">
+    <string>Focus on cursor</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Add an option to focus the range on the cursor

## Description
I added a button in the confocal module which centers the x, y, z range on the current position.
Basically, for example, let's start with a range from 0µm to 20µm in each direction and we move the cursor to (50µm, 50µm, 50µm). It will move the x, y, z range from min = 40µm to max = 60µm if we click on the button.

## Motivation and Context
It may be annoying to always change the range parameters when we want to move somewhere else on the sample. It is not a breakthrough, but it may be interesting.

## How Has This Been Tested?
I am on an Ubuntu with the qudi environment.

I tested it by moving the cursor and the range in different configurations directly in qudi.
I played with the cursors, the sliders and the spinboxes and everything is working.

This function only affects the self._scanning_logic.image_x(y, z)_range variables.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [ x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
