### PR TITLE
Bugfix issue #475

### DIFF
--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1713,7 +1713,8 @@ class SequenceGeneratorLogic(GenericLogic):
         sequence.sampling_information['ensemble_info'] = generated_ensembles
         sequence.sampling_information['pulse_generator_settings'] = self.pulse_generator_settings
         sequence.sampling_information['waveforms'] = sorted(written_waveforms)
-        sequence.sampling_information['step_parameters'] = sequence_param_dict_list
+        sequence.sampling_information['step_waveform_list'] = [step[0] for step in
+                                                               sequence_param_dict_list]
         self.save_sequence(sequence)
 
         self.log.info('Time needed for sampling and writing PulseSequence {0} to device: {1} sec.'


### PR DESCRIPTION
## Description
Fixed a bug with saving the `sampling_information` dict in a `PulsedMeasurementLogic` `StatusVar`.

The `SequenceStep` objects contained in `sampling_information` were not compatible with YAML.
Since this information (repetitions, flags etc.) is redundant with the `PulseSequence` object, only a list of waveform name tuples is saved representing each sequence step.

## Motivation and Context
Presence of `SequenceStep` instances inside of `sampling_information` caused the `PulsedMeasurementLogic` deactivation to fail mid-way.
Fixes #475 

## How Has This Been Tested?
Win8.1 x64 dummy config

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
