### PR TITLE
Pass additional arguments to lmfit

### DIFF
--- a/logic/fitmethods/decaylikemethods.py
+++ b/logic/fitmethods/decaylikemethods.py
@@ -171,7 +171,7 @@ def make_decayexponentialstretched_model(self, prefix=None):
 #  single exponential decay with offset  #
 ##########################################
 
-def make_decayexponential_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_decayexponential_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Performes a exponential decay with offset fit on the provided data.
 
     @param numpy.array x_axis: 1D axis values
@@ -192,9 +192,9 @@ def make_decayexponential_fit(self, x_axis, data, estimator, units=None, add_par
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = exponentialdecay.fit(data, x=x_axis, params=params)
+        result = exponentialdecay.fit(data, x=x_axis, params=params, **kwargs)
     except:
-        result = exponentialdecay.fit(data, x=x_axis, params=params)
+        result = exponentialdecay.fit(data, x=x_axis, params=params, **kwargs)
         self.log.warning('The exponentialdecay with offset fit did not work. '
                        'Message: {}'.format(str(result.message)))
 
@@ -291,7 +291,7 @@ def estimate_decayexponential(self, x_axis, data, params):
 #  stretched exponential decay with offset  #
 #############################################
 
-def make_decayexponentialstretched_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_decayexponentialstretched_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Performes a stretched exponential decay with offset fit on the provided data.
 
     @param numpy.array x_axis: 1D axis values
@@ -314,9 +314,9 @@ def make_decayexponentialstretched_fit(self, x_axis, data, estimator, units=None
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = stret_exp_decay_offset.fit(data, x=x_axis, params=params)
+        result = stret_exp_decay_offset.fit(data, x=x_axis, params=params, **kwargs)
     except:
-        result = stret_exp_decay_offset.fit(data, x=x_axis, params=params)
+        result = stret_exp_decay_offset.fit(data, x=x_axis, params=params, **kwargs)
         self.log.warning('The double exponentialdecay with offset fit did not work. '
                        'Message: {}'.format(str(result.message)))
 

--- a/logic/fitmethods/gaussianlikemethods.py
+++ b/logic/fitmethods/gaussianlikemethods.py
@@ -301,7 +301,7 @@ def make_twoDgaussian_model(self, prefix=None):
 # 1D Gaussian with flat offset    #
 ###################################
 
-def make_gaussian_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_gaussian_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Perform a 1D gaussian peak fit on the provided data.
 
     @param numpy.array x_axis: 1D axis values
@@ -325,7 +325,7 @@ def make_gaussian_fit(self, x_axis, data, estimator, units=None, add_params=None
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = mod_final.fit(data, x=x_axis, params=params)
+        result = mod_final.fit(data, x=x_axis, params=params, **kwargs)
     except:
         self.log.warning('The 1D gaussian peak fit did not work. Error '
                        'message: {0}\n'.format(result.message))
@@ -474,7 +474,7 @@ def estimate_gaussian_dip(self, x_axis, data, params):
 # 1D Gaussian with linear inclined offset    #
 ##############################################
 
-def make_gaussianlinearoffset_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_gaussianlinearoffset_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Perform a 1D gaussian peak fit with linear offset on the provided data.
     @param numpy.array x_axis: 1D axis values
     @param numpy.array data: 1D data, should have the same dimension as x_axis.
@@ -496,7 +496,7 @@ def make_gaussianlinearoffset_fit(self, x_axis, data, estimator, units=None, add
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = mod_final.fit(data, x=x_axis, params=params)
+        result = mod_final.fit(data, x=x_axis, params=params, **kwargs)
     except:
         self.log.warning('The 1D gaussian peak fit did not work. Error '
                        'message: {0}\n'.format(result.message))
@@ -589,7 +589,7 @@ def make_gaussiandouble_fit(self, x_axis, data, estimator,
                             add_params=None,
                             threshold_fraction=0.4,
                             minimal_threshold=0.2,
-                            sigma_threshold_fraction=0.3):
+                            sigma_threshold_fraction=0.3, **kwargs):
     """ Perform a 1D two gaussian dip fit on the provided data.
 
     @param numpy.array x_axis: 1D axis values
@@ -624,9 +624,9 @@ def make_gaussiandouble_fit(self, x_axis, data, estimator,
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = model.fit(data, x=x_axis, params=params)
+        result = model.fit(data, x=x_axis, params=params, **kwargs)
     except:
-        result = model.fit(data, x=x_axis, params=params)
+        result = model.fit(data, x=x_axis, params=params, **kwargs)
         self.log.warning('The double gaussian dip fit did not work: {0}'.format(
             result.message))
 
@@ -758,7 +758,7 @@ def estimate_gaussiandouble_dip(self, x_axis, data, params,
 # TODO: I think this has an offset, and it should be named so to be consistent with
 #       the 1D functions.
 
-def make_twoDgaussian_fit(self, xy_axes, data, estimator, units=None, add_params=None):
+def make_twoDgaussian_fit(self, xy_axes, data, estimator, units=None, add_params=None, **kwargs):
     """ This method performes a 2D gaussian fit on the provided data.
 
     @param numpy.array xy_axes: 2D axes values. xy_axes[0] contains x_axis and
@@ -787,9 +787,9 @@ def make_twoDgaussian_fit(self, xy_axes, data, estimator, units=None, add_params
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = gaussian_2d_model.fit(data, x=xy_axes, params=params)
+        result = gaussian_2d_model.fit(data, x=xy_axes, params=params, **kwargs)
     except:
-        result = gaussian_2d_model.fit(data, x=xy_axes, params=params)
+        result = gaussian_2d_model.fit(data, x=xy_axes, params=params, **kwargs)
         self.log.warning('The 2D gaussian fit did not work: {0}'.format(
                        result.message))
 

--- a/logic/fitmethods/hyperbolicsaturationmethods.py
+++ b/logic/fitmethods/hyperbolicsaturationmethods.py
@@ -80,7 +80,7 @@ def make_hyperbolicsaturation_model(self, prefix=None):
     return complete_model, params
 
 
-def make_hyperbolicsaturation_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_hyperbolicsaturation_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Perform a fit on the provided data with a fluorescence depending function.
 
     @param numpy.array x_axis: 1D axis values
@@ -106,7 +106,7 @@ def make_hyperbolicsaturation_fit(self, x_axis, data, estimator, units=None, add
         initial_params=params,
         update_params=add_params)
 
-    result = mod_final.fit(data, x=x_axis, params=params)
+    result = mod_final.fit(data, x=x_axis, params=params, **kwargs)
 
     return result
 

--- a/logic/fitmethods/linearmethods.py
+++ b/logic/fitmethods/linearmethods.py
@@ -189,7 +189,7 @@ def make_linear_model(self, prefix=None):
     return model, params
 
 
-def make_linear_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_linear_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Performe a linear fit on the provided data.
 
     @param numpy.array x_axis: 1D axis values
@@ -212,7 +212,7 @@ def make_linear_fit(self, x_axis, data, estimator, units=None, add_params=None):
 
     params = self._substitute_params(initial_params=params, update_params=add_params)
 
-    result = linear.fit(data, x=x_axis, params=params)
+    result = linear.fit(data, x=x_axis, params=params, **kwargs)
 
     if units is None:
         units = ['arb. unit', 'arb. unit']

--- a/logic/fitmethods/lorentzianlikemethods.py
+++ b/logic/fitmethods/lorentzianlikemethods.py
@@ -306,9 +306,9 @@ def make_lorentzian_fit(self, x_axis, data, estimator, units=None,
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = model.fit(data, x=x_axis, params=params)
+        result = model.fit(data, x=x_axis, params=params, **kwargs)
     except:
-        result = model.fit(data, x=x_axis, params=params)
+        result = model.fit(data, x=x_axis, params=params, **kwargs)
         self.log.warning('The 1D lorentzian fit did not work. Error '
                          'message: {0}\n'.format(result.message))
 
@@ -459,9 +459,9 @@ def make_lorentziandouble_fit(self, x_axis, data, estimator, units=None, add_par
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = model.fit(data, x=x_axis, params=params)
+        result = model.fit(data, x=x_axis, params=params, **kwargs)
     except:
-        result = model.fit(data, x=x_axis, params=params)
+        result = model.fit(data, x=x_axis, params=params, **kwargs)
         self.log.error('The double lorentzian fit did not '
                      'work: {0}'.format(result.message))
 
@@ -847,7 +847,7 @@ def estimate_lorentziandouble_N15(self, x_axis, data, params):
 
 
 def make_lorentziantriple_fit(self, x_axis, data, estimator, units=None,
-                            add_params=None):
+                            add_params=None, **kwargs):
     """ Perform a triple lorentzian fit
 
     @param numpy.array x_axis: 1D axis values
@@ -871,9 +871,9 @@ def make_lorentziantriple_fit(self, x_axis, data, estimator, units=None,
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = model.fit(data, x=x_axis, params=params)
+        result = model.fit(data, x=x_axis, params=params, **kwargs)
     except:
-        result = model.fit(data, x=x_axis, params=params)
+        result = model.fit(data, x=x_axis, params=params, **kwargs)
         self.log.error('The triple lorentzian fit did not '
                        'work: {0}'.format(result.message))
 

--- a/logic/fitmethods/lorentzianlikemethods.py
+++ b/logic/fitmethods/lorentzianlikemethods.py
@@ -429,11 +429,12 @@ def estimate_lorentzian_peak (self, x_axis, data, params):
 
     return error, params
 
+
 ################################################################################
 #                   Double Lorentzian with offset fitting                      #
 ################################################################################
 
-def make_lorentziandouble_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_lorentziandouble_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Perform a 1D double lorentzian dip fit with offset on the provided data.
 
     @param numpy.array x_axis: 1D axis values
@@ -651,36 +652,6 @@ def estimate_lorentziandouble_peak(self, x_axis, data, params,
     return error, params
 
 
-# def make_doublelorentzpeakoffset_fit(self, x_axis, data, add_params=None):
-#     """ Perform a 1D double lorentzian peak fit with offset on the provided data.
-#
-#     @param numpy.array x_axis: 1D axis values
-#     @param numpy.array data: 1D data, should have the same dimension as x_axis.
-#     @param Parameters or dict add_params: optional, additional parameters of
-#                 type lmfit.parameter.Parameters, OrderedDict or dict for the fit
-#                 which will be used instead of the values from the estimator.
-#
-#     @return object model: lmfit.model.ModelFit object, all parameters
-#                           provided about the fitting, like: success,
-#                           initial fitting values, best fitting values, data
-#                           with best fit with given axis,...
-#     """
-#
-#     model, params = self.make_multiplelorentzian_model(no_of_functions=2)
-#     error, params = self.estimate_doublelorentzpeakoffset(x_axis, data, params)
-#
-#     #redefine values of additional parameters
-#     params = self._substitute_params(initial_params=params,
-#                                      update_params=add_params)
-#     try:
-#         result = model.fit(data, x=x_axis, params=params)
-#     except:
-#         result = model.fit(data, x=x_axis, params=params)
-#         self.log.error('The double lorentzian fit did not '
-#                      'work: {0}'.format(result.message))
-#
-#     return result
-
 ############################################################################
 #                               N15 fitting                                #
 ############################################################################
@@ -776,66 +747,6 @@ def estimate_lorentziandouble_N15(self, x_axis, data, params):
     return error, params
 
 
-# def make_N15_fit(self, x_axis, data, units, add_params=None):
-#     """ Performes a fit where a N15 hyperfine interaction of 3.03 MHz is taken
-#         into account.
-#
-#     @param numpy.array x_axis: 1D axis values
-#     @param numpy.array data: 1D data, should have the same dimension as x_axis.
-#     @param Parameters or dict add_params: optional, additional parameters of
-#                 type lmfit.parameter.Parameters, OrderedDict or dict for the fit
-#                 which will be used instead of the values from the estimator.
-#
-#     @return object model: lmfit.model.ModelFit object, all parameters
-#                           provided about the fitting, like: success,
-#                           initial fitting values, best fitting values, data
-#                           with best fit with given axis,...
-#     """
-#
-#     model, params = self.make_multiplelorentzian_model(no_of_functions=2)
-#     error, params = self.estimate_N15(x_axis, data, params)
-#
-#     params = self._substitute_params(initial_params=params,
-#                                      update_params=add_params)
-#
-#     try:
-#         result = model.fit(data, x=x_axis, params=params)
-#     except:
-#         result = model.fit(data, x=x_axis, params=params)
-#         self.log.error('The N15 fit did not '
-#                      'work: {0}'.format(result.message))
-#
-#     # Write the parameters to allow human-readable output to be generated
-#     param_dict = OrderedDict()
-#
-#     param_dict['Freq. 0'] = {'value': result.params['l0_center'].value,
-#                              'error': result.params['l0_center'].stderr,
-#                              'unit': units[0]}
-#
-#     param_dict['Freq. 1'] = {'value': result.params['l1_center'].value,
-#                              'error': result.params['l1_center'].stderr,
-#                              'unit': units[0]}
-#
-#     param_dict['Contrast 0'] = {'value': abs(result.params['l0_contrast'].value),
-#                                 'error': result.params['l0_contrast'].stderr,
-#                                 'unit': '%'}
-#
-#     param_dict['Contrast 1'] = {'value': abs(result.params['l1_contrast'].value),
-#                                 'error': result.params['l1_contrast'].stderr,
-#                                 'unit': '%'}
-#
-#     param_dict['Linewidth 0'] = {'value': result.params['l0_sigma'].value,
-#                                  'error': result.params['l0_sigma'].stderr,
-#                                  'unit': units[0]}
-#
-#     param_dict['Linewidth 1'] = {'value': result.params['l1_sigma'].value,
-#                                  'error': result.params['l1_sigma'].stderr,
-#                                  'unit': units[0]}
-#
-#     param_dict['chi_sqr'] = {'value': result.chisqr, 'unit': ''}
-#
-#     return result, param_dict
-
 ############################################################################
 #                                                                          #
 #                      Triple Lorentzian fitting                           #
@@ -844,7 +755,6 @@ def estimate_lorentziandouble_N15(self, x_axis, data, params):
 #Todo: check where code breaks
 # Old Method Names:
 # make_N14_fit
-
 
 def make_lorentziantriple_fit(self, x_axis, data, estimator, units=None,
                             add_params=None, **kwargs):

--- a/logic/fitmethods/lorentzianlikemethods.py
+++ b/logic/fitmethods/lorentzianlikemethods.py
@@ -282,7 +282,7 @@ def make_lorentziantriple_model(self):
 ################################################################################
 
 def make_lorentzian_fit(self, x_axis, data, estimator, units=None,
-                        add_params=None):
+                        add_params=None, **kwargs):
     """ Perform a 1D lorentzian fit on the provided data.
 
     @param numpy.array x_axis: 1D axis values

--- a/logic/fitmethods/poissonianlikemethods.py
+++ b/logic/fitmethods/poissonianlikemethods.py
@@ -156,7 +156,7 @@ def make_poissoniandouble_model(self):
 ################################################################################
 
 
-def make_poissonian_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_poissonian_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Performe a poissonian fit on the provided data.
 
     @param numpy.array x_axis: 1D axis values
@@ -181,13 +181,13 @@ def make_poissonian_fit(self, x_axis, data, estimator, units=None, add_params=No
                                      update_params=add_params)
 
     try:
-        result = poissonian_model.fit(data, x=x_axis, params=params)
+        result = poissonian_model.fit(data, x=x_axis, params=params, **kwargs)
     except:
         self.log.warning('The poissonian fit did not work. Check if a poisson '
                          'distribution is needed or a normal approximation can be'
                          'used. For values above 10 a normal/ gaussian distribution '
                          'is a good approximation.')
-        result = poissonian_model.fit(data, x=x_axis, params=params)
+        result = poissonian_model.fit(data, x=x_axis, params=params, **kwargs)
         print(result.message)
 
     if units is None:
@@ -240,7 +240,7 @@ def estimate_poissonian(self, x_axis, data, params):
     return error, params
 
 
-def make_poissoniandouble_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_poissoniandouble_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Perform a double poissonian fit on the provided data.
 
     @param numpy.array x_axis: 1D axis values
@@ -265,14 +265,14 @@ def make_poissoniandouble_fit(self, x_axis, data, estimator, units=None, add_par
                                      update_params=add_params)
 
     try:
-        result = double_poissonian_model.fit(data, x=x_axis, params=params)
+        result = double_poissonian_model.fit(data, x=x_axis, params=params, **kwargs)
     except:
         self.log.warning('The double poissonian fit did not work. Check if a '
                          'poisson distribution is needed or a normal '
                          'approximation can be used. For values above 10 a '
                          'normal/ gaussian distribution is a good '
                          'approximation.')
-        result = double_poissonian_model.fit(data, x=x_axis, params=params)
+        result = double_poissonian_model.fit(data, x=x_axis, params=params, **kwargs)
 
     # Write the parameters to allow human-readable output to be generated
     result_str_dict = OrderedDict()

--- a/logic/fitmethods/sinemethods.py
+++ b/logic/fitmethods/sinemethods.py
@@ -619,8 +619,8 @@ def make_sine_fit(self, x_axis, data, estimator, units=None, add_params=None, **
                                     'error': result.params['frequency'].stderr,
                                     'unit': 'Hz' if units[0] == 's' else '1/' + units[0]}
 
-    result_str_dict['Phase'] = {'value': result.params['phase'].value,
-                                'error': result.params['phase'].stderr,
+    result_str_dict['Phase'] = {'value': 180/np.pi*result.params['phase'].value,
+                                'error': 180/np.pi*result.params['phase'].stderr,
                                 'unit': 'deg'}
 
     result_str_dict['Offset'] = {'value': result.params['offset'].value,
@@ -744,8 +744,8 @@ def make_sineexponentialdecay_fit(self, x_axis, data, estimator, units=None, add
                                              result.params['amplitude'].stderr))*100,
                                    'unit': '%'}
 
-    result_str_dict['Phase'] = {'value': result.params['phase'].value,
-                                'error': result.params['phase'].stderr,
+    result_str_dict['Phase'] = {'value': 180/np.pi*result.params['phase'].value,
+                                'error': 180/np.pi*result.params['phase'].stderr,
                                 'unit': 'deg'}
 
     result_str_dict['Offset'] = {'value': result.params['offset'].value,
@@ -919,8 +919,8 @@ def make_sinestretchedexponentialdecay_fit(self, x_axis, data, estimator, units=
                                              result.params['amplitude'].stderr))*100,
                                    'unit': '%'}
 
-    result_str_dict['Phase'] = {'value': result.params['phase'].value,
-                                'error': result.params['phase'].stderr,
+    result_str_dict['Phase'] = {'value': 180/np.pi*result.params['phase'].value,
+                                'error': 180/np.pi*result.params['phase'].stderr,
                                 'unit': 'deg'}
 
     result_str_dict['Offset'] = {'value': result.params['offset'].value,
@@ -1059,12 +1059,12 @@ def make_sinedouble_fit(self, x_axis, data, estimator, units=None, add_params=No
                                              result.params[amp_string].stderr))*100,
                                    'unit': '%'}
 
-    result_str_dict['Phase 1'] = {'value': result.params['s1_phase'].value,
-                                  'error': result.params['s1_phase'].stderr,
+    result_str_dict['Phase 1'] = {'value': 180/np.pi*result.params['s1_phase'].value,
+                                  'error': 180/np.pi*result.params['s1_phase'].stderr,
                                   'unit': 'deg'}
 
-    result_str_dict['Phase 2'] = {'value': result.params['s2_phase'].value,
-                                  'error': result.params['s2_phase'].stderr,
+    result_str_dict['Phase 2'] = {'value': 180/np.pi*result.params['s2_phase'].value,
+                                  'error': 180/np.pi*result.params['s2_phase'].stderr,
                                   'unit': 'deg'}
 
     result_str_dict['Offset'] = {'value': result.params['offset'].value,
@@ -1214,12 +1214,12 @@ def make_sinedoublewithexpdecay_fit(self, x_axis, data, estimator, units=None, a
                                                result.params[amp_string].stderr))*100,
                                      'unit': '%'}
 
-    result_str_dict['Phase 1'] = {'value': result.params['s1_phase'].value,
-                                  'error': result.params['s1_phase'].stderr,
+    result_str_dict['Phase 1'] = {'value': 180/np.pi*result.params['s1_phase'].value,
+                                  'error': 180/np.pi*result.params['s1_phase'].stderr,
                                   'unit': 'deg'}
 
-    result_str_dict['Phase 2'] = {'value': result.params['s2_phase'].value,
-                                  'error': result.params['s2_phase'].stderr,
+    result_str_dict['Phase 2'] = {'value': 180/np.pi*result.params['s2_phase'].value,
+                                  'error': 180/np.pi*result.params['s2_phase'].stderr,
                                   'unit': 'deg'}
 
     result_str_dict['Offset'] = {'value': result.params['offset'].value,
@@ -1384,12 +1384,12 @@ def make_sinedoublewithtwoexpdecay_fit(self, x_axis, data, estimator, units=None
                                                result.params[amp_string].stderr))*100,
                                      'unit': '%'}
 
-    result_str_dict['Phase 1'] = {'value': result.params['e1_phase'].value,
-                                  'error': result.params['e1_phase'].stderr,
+    result_str_dict['Phase 1'] = {'value': 180/np.pi*result.params['e1_phase'].value,
+                                  'error': 180/np.pi*result.params['e1_phase'].stderr,
                                   'unit': 'deg'}
 
-    result_str_dict['Phase 2'] = {'value': result.params['e2_phase'].value,
-                                  'error': result.params['e2_phase'].stderr,
+    result_str_dict['Phase 2'] = {'value': 180/np.pi*result.params['e2_phase'].value,
+                                  'error': 180/np.pi*result.params['e2_phase'].stderr,
                                   'unit': 'deg'}
 
     result_str_dict['Lifetime 1'] = {'value': result.params['e1_lifetime'].value,
@@ -1587,16 +1587,16 @@ def make_sinetriple_fit(self, x_axis, data, estimator, units=None, add_params=No
                                                result.params[amp_string].stderr))*100,
                                      'unit': '%'}
 
-    result_str_dict['Phase 1'] = {'value': result.params['s1_phase'].value,
-                                  'error': result.params['s1_phase'].stderr,
+    result_str_dict['Phase 1'] = {'value': 180/np.pi*result.params['s1_phase'].value,
+                                  'error': 180/np.pi*result.params['s1_phase'].stderr,
                                   'unit': 'deg'}
 
-    result_str_dict['Phase 2'] = {'value': result.params['s2_phase'].value,
-                                  'error': result.params['s2_phase'].stderr,
+    result_str_dict['Phase 2'] = {'value': 180/np.pi*result.params['s2_phase'].value,
+                                  'error': 180/np.pi*result.params['s2_phase'].stderr,
                                   'unit': 'deg'}
 
-    result_str_dict['Phase 3'] = {'value': result.params['s3_phase'].value,
-                                  'error': result.params['s3_phase'].stderr,
+    result_str_dict['Phase 3'] = {'value': 180/np.pi*result.params['s3_phase'].value,
+                                  'error': 180/np.pi*result.params['s3_phase'].stderr,
                                   'unit': 'deg'}
 
     result_str_dict['Offset'] = {'value': result.params['offset'].value,
@@ -1782,16 +1782,16 @@ def make_sinetriplewithexpdecay_fit(self, x_axis, data, estimator, units=None, a
                                                result.params[amp_string].stderr))*100,
                                      'unit': '%'}
 
-    result_str_dict['Phase 1'] = {'value': result.params['s1_phase'].value,
-                                  'error': result.params['s1_phase'].stderr,
+    result_str_dict['Phase 1'] = {'value': 180/np.pi*result.params['s1_phase'].value,
+                                  'error': 180/np.pi*result.params['s1_phase'].stderr,
                                   'unit': 'deg'}
 
-    result_str_dict['Phase 2'] = {'value': result.params['s2_phase'].value,
-                                  'error': result.params['s2_phase'].stderr,
+    result_str_dict['Phase 2'] = {'value': 180/np.pi*result.params['s2_phase'].value,
+                                  'error': 180/np.pi*result.params['s2_phase'].stderr,
                                   'unit': 'deg'}
 
-    result_str_dict['Phase 3'] = {'value': result.params['s3_phase'].value,
-                                  'error': result.params['s3_phase'].stderr,
+    result_str_dict['Phase 3'] = {'value': 180/np.pi*result.params['s3_phase'].value,
+                                  'error': 180/np.pi*result.params['s3_phase'].stderr,
                                   'unit': 'deg'}
 
     result_str_dict['Lifetime'] = {'value': result.params['lifetime'].value,
@@ -1997,16 +1997,16 @@ def make_sinetriplewiththreeexpdecay_fit(self, x_axis, data, estimator, units=No
                                      'unit': '%'}
 
 
-    result_str_dict['Phase 1'] = {'value': result.params['e1_phase'].value,
-                                  'error': result.params['e1_phase'].stderr,
+    result_str_dict['Phase 1'] = {'value': 180/np.pi*result.params['e1_phase'].value,
+                                  'error': 180/np.pi*result.params['e1_phase'].stderr,
                                   'unit': 'deg'}
 
-    result_str_dict['Phase 2'] = {'value': result.params['e2_phase'].value,
-                                  'error': result.params['e2_phase'].stderr,
+    result_str_dict['Phase 2'] = {'value': 180/np.pi*result.params['e2_phase'].value,
+                                  'error': 180/np.pi*result.params['e2_phase'].stderr,
                                   'unit': 'deg'}
 
-    result_str_dict['Phase 3'] = {'value': result.params['e3_phase'].value,
-                                  'error': result.params['e3_phase'].stderr,
+    result_str_dict['Phase 3'] = {'value': 180/np.pi*result.params['e3_phase'].value,
+                                  'error': 180/np.pi*result.params['e3_phase'].stderr,
                                   'unit': 'deg'}
 
     result_str_dict['Lifetime 1'] = {'value': result.params['e1_lifetime'].value,

--- a/logic/fitmethods/sinemethods.py
+++ b/logic/fitmethods/sinemethods.py
@@ -570,7 +570,7 @@ def estimate_sinewithoutoffset(self, x_axis, data, params):
 # Sine #
 ########
 
-def make_sine_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_sine_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Perform a sine fit with a constant offset on the provided data.
 
     @param numpy.array x_axis: 1D axis values
@@ -594,9 +594,9 @@ def make_sine_fit(self, x_axis, data, estimator, units=None, add_params=None):
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = sine.fit(data, x=x_axis, params=params)
+        result = sine.fit(data, x=x_axis, params=params, **kwargs)
     except:
-        result = sine.fit(data, x=x_axis, params=params)
+        result = sine.fit(data, x=x_axis, params=params, **kwargs)
         self.log.error('The sine fit did not work.\n'
                        'Error message: {0}\n'.format(result.message))
 
@@ -680,7 +680,7 @@ def estimate_sine(self, x_axis, data, params):
 ##########################
 
 
-def make_sineexponentialdecay_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_sineexponentialdecay_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Perform a sine exponential decay fit on the provided data.
 
     @param numpy.array x_axis: 1D axis values
@@ -703,10 +703,10 @@ def make_sineexponentialdecay_fit(self, x_axis, data, estimator, units=None, add
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = sine_exp_decay_offset.fit(data, x=x_axis, params=params)
+        result = sine_exp_decay_offset.fit(data, x=x_axis, params=params, **kwargs)
     except:
 
-        result = sine_exp_decay_offset.fit(data, x=x_axis, params=params)
+        result = sine_exp_decay_offset.fit(data, x=x_axis, params=params, **kwargs)
         self.log.error('The sineexponentialdecayoffset fit did not work.\n'
                        'Error message: {0}'.format(result.message))
 
@@ -856,7 +856,7 @@ def estimate_sineexponentialdecay(self, x_axis, data, params=None):
 ###################################################
 
 
-def make_sinestretchedexponentialdecay_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_sinestretchedexponentialdecay_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Perform a sine stretched exponential decay fit on the provided data.
 
     @param numpy.array x_axis: 1D axis values
@@ -879,9 +879,9 @@ def make_sinestretchedexponentialdecay_fit(self, x_axis, data, estimator, units=
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = sine_stretched_exp_decay.fit(data, x=x_axis, params=params)
+        result = sine_stretched_exp_decay.fit(data, x=x_axis, params=params, **kwargs)
     except:
-        result = sine_stretched_exp_decay.fit(data, x=x_axis, params=params)
+        result = sine_stretched_exp_decay.fit(data, x=x_axis, params=params, **kwargs)
         self.log.error('The sineexponentialdecay fit did not work.\n'
                        'Error message: {0}'.format(result.message))
 
@@ -965,7 +965,7 @@ def estimate_sinestretchedexponentialdecay(self, x_axis, data, params):
 ###########################################
 
 
-def make_sinedouble_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_sinedouble_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Perform a two sine with offset fit on the provided data.
 
     @param numpy.array x_axis: 1D axis values
@@ -988,11 +988,11 @@ def make_sinedouble_fit(self, x_axis, data, estimator, units=None, add_params=No
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = two_sine_offset.fit(data, x=x_axis, params=params)
+        result = two_sine_offset.fit(data, x=x_axis, params=params, **kwargs)
     except:
         self.log.warning('The twosineexpdecayoffset fit did not work. '
                          'Error message: {}'.format(str(result.message)))
-        result = two_sine_offset.fit(data, x=x_axis, params=params)
+        result = two_sine_offset.fit(data, x=x_axis, params=params, **kwargs)
 
     if units is None:
         units = ['arb. unit', 'arb. unit']
@@ -1119,7 +1119,7 @@ def estimate_sinedouble(self, x_axis, data, params):
 ################################################################################
 
 
-def make_sinedoublewithexpdecay_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_sinedoublewithexpdecay_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Perform a two sine with one exponential decay offset fit on the provided
         data.
 
@@ -1143,11 +1143,11 @@ def make_sinedoublewithexpdecay_fit(self, x_axis, data, estimator, units=None, a
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = two_sine_exp_decay_offset.fit(data, x=x_axis, params=params)
+        result = two_sine_exp_decay_offset.fit(data, x=x_axis, params=params, **kwargs)
     except:
         self.log.warning('The sinedoublewithexpdecay fit did not work. '
                          'Error message: {}'.format(str(result.message)))
-        result = two_sine_exp_decay_offset.fit(data, x=x_axis, params=params)
+        result = two_sine_exp_decay_offset.fit(data, x=x_axis, params=params, **kwargs)
 
     if units is None:
         units = ['arb. unit', 'arb. unit']
@@ -1289,7 +1289,7 @@ def estimate_sinedoublewithexpdecay(self, x_axis, data, params):
 # Problem with stderr: x.stderr will always be 0 for this model!
 
 
-def make_sinedoublewithtwoexpdecay_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_sinedoublewithtwoexpdecay_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Perform a two sine with two exponential decay and offset fit on the
         provided data.
 
@@ -1313,11 +1313,11 @@ def make_sinedoublewithtwoexpdecay_fit(self, x_axis, data, estimator, units=None
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = two_sine_two_exp_decay_offset.fit(data, x=x_axis, params=params)
+        result = two_sine_two_exp_decay_offset.fit(data, x=x_axis, params=params, **kwargs)
     except:
         self.log.warning('The sinedoublewithtwoexpdecay fit did not work. '
                          'Error message: {}'.format(str(result.message)))
-        result = two_sine_two_exp_decay_offset.fit(data, x=x_axis, params=params)
+        result = two_sine_two_exp_decay_offset.fit(data, x=x_axis, params=params, **kwargs)
 
     if units is None:
         units = ['arb. unit', 'arb. unit']
@@ -1463,7 +1463,7 @@ def estimate_sinedoublewithtwoexpdecay(self, x_axis, data, params):
 #############################################
 
 
-def make_sinetriple_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_sinetriple_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Perform a three sine with offset fit on the provided data.
 
     @param numpy.array x_axis: 1D axis values
@@ -1486,11 +1486,11 @@ def make_sinetriple_fit(self, x_axis, data, estimator, units=None, add_params=No
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = two_sine_offset.fit(data, x=x_axis, params=params)
+        result = two_sine_offset.fit(data, x=x_axis, params=params, **kwargs)
     except:
         self.log.warning('The threesineexpdecayoffset fit did not work. '
                          'Error message: {}'.format(str(result.message)))
-        result = two_sine_offset.fit(data, x=x_axis, params=params)
+        result = two_sine_offset.fit(data, x=x_axis, params=params, **kwargs)
 
     if units is None:
         units = ['arb. unit', 'arb. unit']
@@ -1658,7 +1658,7 @@ def estimate_sinetriple(self, x_axis, data, params):
 ##########################################################################
 
 
-def make_sinetriplewithexpdecay_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_sinetriplewithexpdecay_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Perform a three sine with one exponential decay offset fit on the provided
         data.
 
@@ -1681,11 +1681,11 @@ def make_sinetriplewithexpdecay_fit(self, x_axis, data, estimator, units=None, a
 
     params = self._substitute_params(initial_params=params, update_params=add_params)
     try:
-        result = three_sine_exp_decay_offset.fit(data, x=x_axis, params=params)
+        result = three_sine_exp_decay_offset.fit(data, x=x_axis, params=params, **kwargs)
     except:
         self.log.warning('The sinetriplewithexpdecay fit did not work. '
                          'Error message: {}'.format(str(result.message)))
-        result = three_sine_exp_decay_offset.fit(data, x=x_axis, params=params)
+        result = three_sine_exp_decay_offset.fit(data, x=x_axis, params=params, **kwargs)
 
     if units is None:
         units = ['arb. unit', 'arb. unit']
@@ -1872,7 +1872,7 @@ def estimate_sinetriplewithexpdecay(self, x_axis, data, params):
 #########################################################################
 
 
-def make_sinetriplewiththreeexpdecay_fit(self, x_axis, data, estimator, units=None, add_params=None):
+def make_sinetriplewiththreeexpdecay_fit(self, x_axis, data, estimator, units=None, add_params=None, **kwargs):
     """ Perform a three sine with three exponential decay and offset fit on the
         provided data.
 
@@ -1896,11 +1896,11 @@ def make_sinetriplewiththreeexpdecay_fit(self, x_axis, data, estimator, units=No
     params = self._substitute_params(initial_params=params,
                                      update_params=add_params)
     try:
-        result = three_sine_three_exp_decay_offset.fit(data, x=x_axis, params=params)
+        result = three_sine_three_exp_decay_offset.fit(data, x=x_axis, params=params, **kwargs)
     except:
         self.log.warning('The twosinetwoexpdecayoffset fit did not work. '
                          'Error message: {}'.format(str(result.message)))
-        result = three_sine_three_exp_decay_offset.fit(data, x=x_axis, params=params)
+        result = three_sine_three_exp_decay_offset.fit(data, x=x_axis, params=params, **kwargs)
 
     if units is None:
         units = ['arb. unit', 'arb. unit']


### PR DESCRIPTION
Allows the passing of optional keyword arguments to the fit method of lmfit.
Useful if you want to give lmfit weights when it performs the fitting which can improve the fits somewhat. 

I haven't added it to the docstring of the methods

## Description
Added **kwargs to all fit methods and then passed that argument to the lmfit method fit.

## Motivation and Context
Helped improve some fits

## How Has This Been Tested?
Hasn't affected the setup that I have tried it on

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [ ] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
