### PR TITLE
Sequence channel flank detection

### DIFF
--- a/logic/pulsed/pulse_extraction_methods/basic_extraction_methods.py
+++ b/logic/pulsed/pulse_extraction_methods/basic_extraction_methods.py
@@ -354,6 +354,20 @@ class BasicPulseExtractor(PulseExtractorBase):
         # get laser rising and falling bins
         laser_rising_bins = self.sampling_information['laser_rising_bins']
         laser_falling_bins = self.sampling_information['laser_falling_bins']
+
+        # Sort out trailing or leading incomplete laser pulse
+        while len(laser_rising_bins) != len(laser_falling_bins):
+            if len(laser_rising_bins) > len(laser_falling_bins):
+                if laser_rising_bins[-1] >= laser_falling_bins[-1]:
+                    laser_rising_bins = laser_rising_bins[:-1]
+                else:
+                    laser_rising_bins = laser_rising_bins[1:]
+            else:
+                if laser_rising_bins[0] >= laser_falling_bins[0]:
+                    laser_falling_bins = laser_falling_bins[1:]
+                else:
+                    laser_falling_bins = laser_falling_bins[:-1]
+
         # convert to bins of fastcounter
         laser_rising_bins = np.rint(laser_rising_bins / sample_rate / fc_binwidth).astype('int64')
         laser_falling_bins = np.rint(laser_falling_bins / sample_rate / fc_binwidth).astype('int64')

--- a/logic/pulsed/pulse_extraction_methods/basic_extraction_methods.py
+++ b/logic/pulsed/pulse_extraction_methods/basic_extraction_methods.py
@@ -352,23 +352,25 @@ class BasicPulseExtractor(PulseExtractorBase):
         # get the fastcounter binwidth
         fc_binwidth = self.fast_counter_settings['bin_width']
         # get laser rising and falling bins
-        laser_bins = self.sampling_information['laser_bins']
+        laser_rising_bins = self.sampling_information['laser_rising_bins']
+        laser_falling_bins = self.sampling_information['laser_falling_bins']
         # convert to bins of fastcounter
-        laser_bins = np.rint(laser_bins / sample_rate / fc_binwidth).astype('int64')
+        laser_rising_bins = np.rint(laser_rising_bins / sample_rate / fc_binwidth).astype('int64')
+        laser_falling_bins = np.rint(laser_falling_bins / sample_rate / fc_binwidth).astype('int64')
         # convert to fastcounter bins
         safety_bins = round(safety / fc_binwidth)
         delay_bins = round(delay / fc_binwidth)
         # dimensions of laser pulse array
-        num_rows = len(laser_bins)
-        max_laser_length = max(laser_bins[:, 1] - laser_bins[:, 0])
+        num_rows = len(laser_rising_bins)
+        max_laser_length = max(laser_falling_bins - laser_rising_bins)
         num_col = max_laser_length + 2 * safety_bins
         # compute from laser_start_indices and laser length the respective position of the laser
         # pulses
         laser_pulses = np.empty((num_rows, num_col))
         for ii in range(num_rows):
             laser_pulses[ii][:] = count_data[
-                np.arange(laser_bins[ii, 0] + delay_bins - safety_bins,
-                          laser_bins[ii, 0] + delay_bins + safety_bins + max_laser_length)]
+                np.arange(laser_rising_bins[ii] + delay_bins - safety_bins,
+                          laser_rising_bins[ii] + delay_bins + safety_bins + max_laser_length)]
         # use the gated extraction method
         return_dict = self.gated_conv_deriv(laser_pulses, conv_std_dev)
         return return_dict

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1312,6 +1312,9 @@ class SequenceGeneratorLogic(GenericLogic):
         # Determine channel activation and the channel states of the very first and last element
         digital_channels = set()
         analog_channels = set()
+        last_digital_channel_state = {chnl: False for chnl in digital_channels}
+        last_laser_on_state = False
+
         if len(sequence) > 0:
             ensemble = self.get_ensemble(sequence[0].ensemble)
             if len(ensemble) > 0:
@@ -1400,7 +1403,7 @@ class SequenceGeneratorLogic(GenericLogic):
 
                 # Append laser_bins arrays with bin offsets for each repetition analogous to the
                 # digital channels above.
-                if laser_channel.startswith('d'):
+                if not laser_channel.startswith('d'):
                     for iteration in range(reps):
                         bin_offset = iteration * ens_bins + starting_bin
                         rising_bins = info_dict['laser_rising_bins'] + bin_offset

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1323,9 +1323,6 @@ class SequenceGeneratorLogic(GenericLogic):
                 block = self.get_block(ensemble[0][0])
                 digital_channels = block.digital_channels
                 analog_channels = block.analog_channels
-                if len(block) > 0:
-                    first_digital_channel_state = block[0].digital_high.copy()
-                    first_laser_on_state = block[0].laser_on
             ensemble = self.get_ensemble(sequence[-1].ensemble)
             if len(ensemble) > 0:
                 block = self.get_block(ensemble[-1][0])
@@ -1346,11 +1343,9 @@ class SequenceGeneratorLogic(GenericLogic):
         digital_rising_bins = {chnl: list() for chnl in digital_channels}
         digital_falling_bins = {chnl: list() for chnl in digital_channels}
         ensemble_name_set = set()
-        prev_step_digital_state = last_digital_channel_state
-        prev_step_laser_on_state = last_laser_on_state
-        step_first_digital_state = dict()
+        # Initialize the last channel state of the first sequence step as last channel state in the
+        # entire sequence.
         step_last_digital_state = last_digital_channel_state
-        step_first_laser_on_state = False
         step_last_laser_on_state = last_laser_on_state
 
         for step_no, seq_step in enumerate(sequence):
@@ -1363,6 +1358,7 @@ class SequenceGeneratorLogic(GenericLogic):
             ensemble_name_set.add(ensemble.name)
             reps = seq_step.repetitions + 1
             ens_bins = info_dict['number_of_samples']
+            # Keep track of channel states at sequence step boundaries
             prev_step_digital_state = step_last_digital_state.copy()
             prev_step_laser_on_state = step_last_laser_on_state
             tmp_block = self.get_block(ensemble[0][0])


### PR DESCRIPTION
## Description
Improved `SequenceGeneratorLogic.analyze_block_ensemble` and `SequenceGeneratorLogic.analyze_sequence` to be more efficient and most importantly handled special cases of laser_on flag / digital channel rising/falling flank detection in sequences.

## Motivation and Context
The recently introduced expansion of the `analyze_sequence` return dict was incomplete. Special cases of the digital flank detection when transitioning waveforms in sequences were ignored and are now properly handled. 

## How Has This Been Tested?
On dummy Win8.1 x64
Tested using a notebook that was creating random pulse sequences and compared the "brute force" approach (walking each `PulseBlockElement` as it would be played) result to the now introduced `analyze_sequence` return values.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
