### PR TITLE
Also allow colormaps for negative values in Confocal and ODMR

### DIFF
--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -838,7 +838,7 @@ class ConfocalGui(GUIBase):
         """ Determines the cb_min and cb_max values for the xy scan image
         """
         # If "Manual" is checked, or the image data is empty (all zeros), then take manual cb range.
-        if self._mw.xy_cb_manual_RadioButton.isChecked() or np.max(self.xy_image.image) == 0.0:
+        if self._mw.xy_cb_manual_RadioButton.isChecked() or np.count_nonzero(self.xy_image.image) < 1:
             cb_min = self._mw.xy_cb_min_DoubleSpinBox.value()
             cb_max = self._mw.xy_cb_max_DoubleSpinBox.value()
 
@@ -862,7 +862,7 @@ class ConfocalGui(GUIBase):
         """ Determines the cb_min and cb_max values for the xy scan image
         """
         # If "Manual" is checked, or the image data is empty (all zeros), then take manual cb range.
-        if self._mw.depth_cb_manual_RadioButton.isChecked() or np.max(self.depth_image.image) == 0.0:
+        if self._mw.depth_cb_manual_RadioButton.isChecked() or np.count_nonzero(self.depth_image.image) < 1:
             cb_min = self._mw.depth_cb_min_DoubleSpinBox.value()
             cb_max = self._mw.depth_cb_max_DoubleSpinBox.value()
 
@@ -1608,7 +1608,7 @@ class ConfocalGui(GUIBase):
         xy_optimizer_image = self._optimizer_logic.xy_refocus_image[:, :, 3 + self._optimizer_logic.opt_channel]
 
         # If the Z scan is done first, then the XY image has only zeros and there is nothing to draw.
-        if np.max(xy_optimizer_image) != 0:
+        if np.count_nonzero(xy_optimizer_image) > 0:
             colorscale_min = np.min(xy_optimizer_image[np.nonzero(xy_optimizer_image)])
             colorscale_max = np.max(xy_optimizer_image[np.nonzero(xy_optimizer_image)])
 

--- a/gui/odmr/odmrgui.py
+++ b/gui/odmr/odmrgui.py
@@ -570,7 +570,7 @@ class ODMRGui(GUIBase):
 
         # If "Manual" is checked or the image is empty (all zeros), then take manual cb range.
         # Otherwise, calculate cb range from percentiles.
-        if self._mw.odmr_cb_manual_RadioButton.isChecked() or np.max(matrix_image) < 0.1:
+        if self._mw.odmr_cb_manual_RadioButton.isChecked() or np.count_nonzero(matrix_image) < 1:
             cb_min = self._mw.odmr_cb_min_DoubleSpinBox.value()
             cb_max = self._mw.odmr_cb_max_DoubleSpinBox.value()
         else:


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using analog inputs for Confocal and ODMR, the colormap does not work with negative values.
This patch changes the comparison to the maximum value to searching for nonzero entries when determining whether to update the colormap.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on a setup at NVision with analog ODMR.
Tested with dummy to see if Confocal breaks in normal operation.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
