### PR TITLE
Natural string sorting

### DIFF
--- a/core/util/helpers.py
+++ b/core/util/helpers.py
@@ -25,6 +25,7 @@ Copyright:
 """
 
 import os
+import re
 import sys
 import atexit
 
@@ -199,3 +200,16 @@ def import_check():
         check_package(pkg_name, repo_name, version, True)
 
     return err_code
+
+
+def natural_sort(iterable):
+    """
+    Sort an iterable of str in an intuitive, natural way (human/natural sort).
+    Use this to sort alphanumeric strings containing integers.
+
+    @param str[] iterable: Iterable with str items to sort
+    @return list: sorted list of strings
+    """
+    def conv(s):
+        return int(s) if s.isdigit() else s
+    return sorted(iterable, key=lambda key: [conv(i) for i in re.split(r'(\d+)', key)])

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -10,7 +10,7 @@ image
 * Added an optional POI nametag to the POI manager. If you give this property a string value, all 
 new POIs will be named after this tag together with a consecutive integer index.
 * bug fix to how the flags are set for AWG70k
-* Add "natural_sort" utility function to `core.util.helpers`
+* Add `natural_sort` utility function to `core.util.helpers`
 
 Config changes:
 

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -10,7 +10,7 @@ image
 * Added an optional POI nametag to the POI manager. If you give this property a string value, all 
 new POIs will be named after this tag together with a consecutive integer index.
 * bug fix to how the flags are set for AWG70k
-* 
+* Add "natural_sort" utility function to `core.util.helpers`
 
 Config changes:
 

--- a/gui/poimanager/poimangui.py
+++ b/gui/poimanager/poimangui.py
@@ -27,6 +27,7 @@ import re
 
 from core.module import Connector
 from core.util.units import ScaledFloat
+from core.util.helpers import natural_sort
 from gui.guibase import GUIBase
 from gui.guiutils import ColorBar
 from gui.colordefs import ColorScaleInferno
@@ -633,7 +634,7 @@ class PoiManagerGui(GUIBase):
             text_active_poi = self._mw.active_poi_ComboBox.currentText()
             # sort POI names and repopulate ComboBoxes
             self._mw.active_poi_ComboBox.clear()
-            poi_names = sorted(self.poimanagerlogic().poi_names)
+            poi_names = natural_sort(self.poimanagerlogic().poi_names)
             self._mw.active_poi_ComboBox.addItems(poi_names)
             if text_active_poi == old_name:
                 self._mw.active_poi_ComboBox.setCurrentText(new_name)
@@ -834,7 +835,7 @@ class PoiManagerGui(GUIBase):
 
         self._mw.active_poi_ComboBox.clear()
 
-        poi_names = sorted(poi_dict)
+        poi_names = natural_sort(poi_dict)
         self._mw.active_poi_ComboBox.addItems(poi_names)
 
         # Get two list of POI names. One of those to delete and one of those to add

--- a/gui/pulsed/pulse_editors.py
+++ b/gui/pulsed/pulse_editors.py
@@ -21,6 +21,7 @@ top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi
 import numpy as np
 import copy
 
+from core.util.helpers import natural_sort
 from qtpy import QtCore, QtGui, QtWidgets
 from gui.pulsed.pulsed_item_delegates import ScienDSpinBoxItemDelegate, ComboBoxItemDelegate
 from gui.pulsed.pulsed_item_delegates import MultipleCheckboxItemDelegate, CheckBoxItemDelegate
@@ -183,10 +184,10 @@ class BlockEditorTableModel(QtCore.QAbstractTableModel):
         self.beginResetModel()
 
         self.activation_config = activation_config
-        self.digital_channels = sorted((chnl for chnl in activation_config if chnl.startswith('d')),
-                                       key=lambda chnl: int(chnl.split('ch')[-1]))
-        self.analog_channels = sorted((chnl for chnl in activation_config if chnl.startswith('a')),
-                                      key=lambda chnl: int(chnl.split('ch')[-1]))
+        self.digital_channels = natural_sort(
+            (chnl for chnl in activation_config if chnl.startswith('d')))
+        self.analog_channels = natural_sort(
+            (chnl for chnl in activation_config if chnl.startswith('a')))
 
         analog_shape = {chnl: SamplingFunctions.Idle() for chnl in self.analog_channels}
         digital_state = {chnl: False for chnl in self.digital_channels}

--- a/gui/pulsed/pulse_editors.py
+++ b/gui/pulsed/pulse_editors.py
@@ -494,7 +494,7 @@ class BlockEditor(QtWidgets.QTableView):
         # If any digital channels are present, set item delegate (custom multi-CheckBox widget)
         # for digital channels column.
         if len(self.model().digital_channels) > 0:
-            chnl_labels = sorted(chnl.split('d_ch')[1] for chnl in self.model().digital_channels)
+            chnl_labels = natural_sort(chnl.split('d_ch')[1] for chnl in self.model().digital_channels)
             self.setItemDelegateForColumn(
                 3, MultipleCheckboxItemDelegate(self, chnl_labels, self.model().digitalStateRole))
             offset_index = 4  # to indicate which column comes next.
@@ -507,7 +507,7 @@ class BlockEditor(QtWidgets.QTableView):
         for num, chnl in enumerate(self.model().analog_channels):
             self.setItemDelegateForColumn(
                 offset_index + 2 * num, ComboBoxItemDelegate(
-                    self, sorted(SamplingFunctions.parameters), self.model().analogShapeRole))
+                    self, natural_sort(SamplingFunctions.parameters), self.model().analogShapeRole))
             self.setItemDelegateForColumn(
                 offset_index + 2 * num + 1,
                 AnalogParametersItemDelegate(
@@ -675,7 +675,7 @@ class EnsembleEditorTableModel(QtCore.QAbstractTableModel):
 
         # Set default block
         if len(self.available_pulse_blocks) > 0:
-            self.__default_block = sorted(self.available_pulse_blocks)[0]
+            self.__default_block = natural_sort(self.available_pulse_blocks)[0]
         else:
             self.__default_block = ''
 
@@ -867,7 +867,7 @@ class EnsembleEditor(QtWidgets.QTableView):
         @return: int, error code (>=0: OK, <0: ERR)
         """
         if isinstance(blocks, (list, dict, set)):
-            blocks = sorted(blocks)
+            blocks = natural_sort(blocks)
         else:
             return -1
 
@@ -1026,7 +1026,7 @@ class SequenceEditorTableModel(QtCore.QAbstractTableModel):
 
         # Set default ensemble name
         if len(self.available_block_ensembles) > 0:
-            self.__default_ensemble = sorted(self.available_block_ensembles)[0]
+            self.__default_ensemble = natural_sort(self.available_block_ensembles)[0]
         else:
             self.__default_ensemble = ''
 
@@ -1292,7 +1292,7 @@ class SequenceEditor(QtWidgets.QTableView):
         err_code = self.model().set_available_block_ensembles(ensembles)
         if err_code >= 0:
             delegate = ComboBoxItemDelegate(
-                self, sorted(self.model().available_block_ensembles), self.model().ensembleNameRole)
+                self, natural_sort(self.model().available_block_ensembles), self.model().ensembleNameRole)
             self.setItemDelegateForColumn(0, delegate)
         return err_code
 

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -27,6 +27,7 @@ import datetime
 
 from core.module import Connector, StatusVar
 from core.util import units
+from core.util.helpers import natural_sort
 from gui.colordefs import QudiPalettePale as palette
 from gui.fitsettings import FitSettingsDialog
 from gui.guibase import GUIBase
@@ -950,7 +951,7 @@ class PulsedMeasurementGui(GUIBase):
         for cfg in self.pulsedmasterlogic().pulse_generator_constraints.activation_config.values():
             for ach in (chnl for chnl in cfg if chnl.startswith('a')):
                 analog_channels.add(ach)
-        analog_channels = sorted(analog_channels, key=lambda chnl: int(chnl.split('ch')[1]))
+        analog_channels = natural_sort(analog_channels)
 
         for i, chnl in enumerate(analog_channels, 1):
             self._analog_chnl_setting_widgets[chnl] = (
@@ -990,7 +991,7 @@ class PulsedMeasurementGui(GUIBase):
         for cfg in self.pulsedmasterlogic().pulse_generator_constraints.activation_config.values():
             for dch in (chnl for chnl in cfg if chnl.startswith('d')):
                 digital_channels.add(dch)
-        digital_channels = sorted(digital_channels, key=lambda chnl: int(chnl.split('ch')[1]))
+        digital_channels = natural_sort(digital_channels)
 
         for i, chnl in enumerate(digital_channels, 1):
             self._digital_chnl_setting_widgets[chnl] = (
@@ -1154,10 +1155,8 @@ class PulsedMeasurementGui(GUIBase):
                 widget.setObjectName('global_param_' + param)
                 widget.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
                 widget.addItem('')
-                widget.addItems(sorted(self.pulsedmasterlogic().digital_channels,
-                                       key=lambda chnl: int(chnl.split('ch')[-1])))
-                widget.addItems(sorted(self.pulsedmasterlogic().analog_channels,
-                                       key=lambda chnl: int(chnl.split('ch')[-1])))
+                widget.addItems(natural_sort(self.pulsedmasterlogic().digital_channels))
+                widget.addItems(natural_sort(self.pulsedmasterlogic().analog_channels))
                 index = widget.findText(value)
                 if index >= 0:
                     widget.setCurrentIndex(index)
@@ -1370,12 +1369,10 @@ class PulsedMeasurementGui(GUIBase):
             self._pgs.gen_sample_freq_DSpinBox.setValue(settings_dict['sample_rate'])
         if 'activation_config' in settings_dict:
             config_name = settings_dict['activation_config'][0]
-            digital_channels = sorted(
-                (ch for ch in settings_dict['activation_config'][1] if ch.startswith('d')),
-                key=lambda channel: int(channel.split('ch')[-1]))
-            analog_channels = sorted(
-                (ch for ch in settings_dict['activation_config'][1] if ch.startswith('a')),
-                key=lambda channel: int(channel.split('ch')[-1]))
+            digital_channels = natural_sort(
+                (ch for ch in settings_dict['activation_config'][1] if ch.startswith('d')))
+            analog_channels = natural_sort(
+                (ch for ch in settings_dict['activation_config'][1] if ch.startswith('a')))
             index = self._pgs.gen_activation_config_ComboBox.findText(config_name)
             self._pgs.gen_activation_config_ComboBox.setCurrentIndex(index)
             digital_str = str(digital_channels).strip('[]').replace('\'', '').replace(',', ' |')

--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -1063,7 +1063,7 @@ class PulsedMeasurementGui(GUIBase):
         editor.
         """
         # create all GUI elements and check all boxes listed in the methods to show
-        for method_name in sorted(self.pulsedmasterlogic().generate_methods):
+        for method_name in natural_sort(self.pulsedmasterlogic().generate_methods):
             # create checkboxes for the config dialogue
             name_checkbox = 'checkbox_' + method_name
             setattr(self._pm_cfg, name_checkbox, QtWidgets.QCheckBox(self._pm_cfg.scrollArea))
@@ -1234,7 +1234,7 @@ class PulsedMeasurementGui(GUIBase):
         self._pm.method_param_widgets = dict()
 
         method_params = self.pulsedmasterlogic().generate_method_params
-        for method_name in sorted(self.pulsedmasterlogic().generate_methods):
+        for method_name in natural_sort(self.pulsedmasterlogic().generate_methods):
             # Create the widgets for the predefined methods dialogue
             # Create GroupBox for the method to reside in
             groupBox = QtWidgets.QGroupBox(self._pm)
@@ -1771,7 +1771,7 @@ class PulsedMeasurementGui(GUIBase):
         @param block_dict:
         @return:
         """
-        block_names = sorted(block_dict)
+        block_names = natural_sort(block_dict)
         # Check if a block has been added. In that case set the current index to the new one.
         # In all other cases try to maintain the current item and if it was removed, set the first.
         text_to_set = None
@@ -1800,7 +1800,7 @@ class PulsedMeasurementGui(GUIBase):
         @param ensemble_dict:
         @return:
         """
-        ensemble_names = sorted(ensemble_dict)
+        ensemble_names = natural_sort(ensemble_dict)
         # Check if an ensemble has been added. In that case set the current index to the new one.
         # In all other cases try to maintain the current item and if it was removed, set the first.
         text_to_set = None
@@ -2085,7 +2085,7 @@ class PulsedMeasurementGui(GUIBase):
         @param sequence_dict:
         @return:
         """
-        sequence_names = sorted(sequence_dict)
+        sequence_names = natural_sort(sequence_dict)
         # Check if a sequence has been added. In that case set the current index to the new one.
         # In all other cases try to maintain the current item and if it was removed, set the first.
         text_to_set = None

--- a/hardware/awg/keysight_M3202A.py
+++ b/hardware/awg/keysight_M3202A.py
@@ -27,6 +27,7 @@ import os
 import datetime
 import numpy as np
 from collections import OrderedDict
+from core.util.helpers import natural_sort
 
 import sys
 
@@ -255,7 +256,7 @@ class M3202A(Base, PulserInterface):
 
         # Get all active channels
         chnl_activation = self.get_active_channels()
-        analog_channels = sorted(
+        analog_channels = natural_sort(
             chnl for chnl in chnl_activation if chnl.startswith('a') and chnl_activation[chnl])
 
         # Load waveforms into channels
@@ -482,7 +483,7 @@ class M3202A(Base, PulserInterface):
         # determine active channels
         activation_dict = self.get_active_channels()
         active_channels = {chnl for chnl in activation_dict if activation_dict[chnl]}
-        active_analog = sorted(chnl for chnl in active_channels if chnl.startswith('a'))
+        active_analog = natural_sort(chnl for chnl in active_channels if chnl.startswith('a'))
 
         # Sanity check of channel numbers
         if active_channels != set(analog_samples.keys()).union(set(digital_samples.keys())):
@@ -554,7 +555,7 @@ class M3202A(Base, PulserInterface):
                                'present in device memory.'.format(name, waveform_tuple))
                 return -1
 
-        active_analog = sorted(chnl for chnl in self.get_active_channels() if chnl.startswith('a'))
+        active_analog = natural_sort(chnl for chnl in self.get_active_channels() if chnl.startswith('a'))
         num_tracks = len(active_analog)
         num_steps = len(sequence_parameter_list)
 

--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -32,6 +32,7 @@ from lxml import etree as ET
 
 from core.module import Base, ConfigOption
 from core.util.modules import get_home_dir
+from core.util.helpers import natural_sort
 from interface.pulser_interface import PulserInterface, PulserConstraints
 
 
@@ -340,7 +341,7 @@ class AWG70K(Base, PulserInterface):
         # determine active channels
         activation_dict = self.get_active_channels()
         active_channels = {chnl for chnl in activation_dict if activation_dict[chnl]}
-        active_analog = sorted(chnl for chnl in active_channels if chnl.startswith('a'))
+        active_analog = natural_sort(chnl for chnl in active_channels if chnl.startswith('a'))
 
         # Sanity check of channel numbers
         if active_channels != set(analog_samples.keys()).union(set(digital_samples.keys())):
@@ -439,7 +440,7 @@ class AWG70K(Base, PulserInterface):
                                'present in device memory.'.format(name, waveform_tuple))
                 return -1
 
-        active_analog = sorted(chnl for chnl in self.get_active_channels() if chnl.startswith('a'))
+        active_analog = natural_sort(chnl for chnl in self.get_active_channels() if chnl.startswith('a'))
         num_tracks = len(active_analog)
         num_steps = len(sequence_parameter_list)
 
@@ -496,7 +497,7 @@ class AWG70K(Base, PulserInterface):
         except visa.VisaIOError:
             query_return = None
             self.log.error('Unable to read waveform list from device. VisaIOError occured.')
-        waveform_list = sorted(query_return.split(',')) if query_return else list()
+        waveform_list = natural_sort(query_return.split(',')) if query_return else list()
         return waveform_list
 
     def get_sequence_names(self):
@@ -584,7 +585,7 @@ class AWG70K(Base, PulserInterface):
 
         # Get all active channels
         chnl_activation = self.get_active_channels()
-        analog_channels = sorted(
+        analog_channels = natural_sort(
             chnl for chnl in chnl_activation if chnl.startswith('a') and chnl_activation[chnl])
 
         # Check if all channels to load to are active
@@ -626,7 +627,7 @@ class AWG70K(Base, PulserInterface):
 
         # Get all active channels
         chnl_activation = self.get_active_channels()
-        analog_channels = sorted(
+        analog_channels = natural_sort(
             chnl for chnl in chnl_activation if chnl.startswith('a') and chnl_activation[chnl])
 
         # Check if number of sequence tracks matches the number of analog channels
@@ -1461,7 +1462,7 @@ class AWG70K(Base, PulserInterface):
             for config in configs.values():
                 if len(largest_config) < len(config):
                     largest_config = config
-        return sorted(largest_config)
+        return natural_sort(largest_config)
 
     def _get_all_analog_channels(self):
         """

--- a/hardware/awg/tektronix_awg7k.py
+++ b/hardware/awg/tektronix_awg7k.py
@@ -29,6 +29,7 @@ from ftplib import FTP
 from collections import OrderedDict
 
 from core.util.modules import get_home_dir
+from core.util.helpers import natural_sort
 from core.module import Base, ConfigOption
 from interface.pulser_interface import PulserInterface, PulserConstraints
 
@@ -288,7 +289,7 @@ class AWG7k(Base, PulserInterface):
         """
         # Get all active channels
         chnl_activation = self.get_active_channels()
-        channel_numbers = sorted(int(chnl.split('_ch')[1]) for chnl in chnl_activation if
+        channel_numbers = natural_sort(int(chnl.split('_ch')[1]) for chnl in chnl_activation if
                                  chnl.startswith('a') and chnl_activation[chnl])
         # do nothing if AWG is already running
         if not self._is_output_on():
@@ -342,7 +343,7 @@ class AWG7k(Base, PulserInterface):
 
         # Get all active channels
         chnl_activation = self.get_active_channels()
-        analog_channels = sorted(
+        analog_channels = natural_sort(
             chnl for chnl in chnl_activation if chnl.startswith('a') and chnl_activation[chnl])
 
         # Check if all channels to load to are active
@@ -412,7 +413,7 @@ class AWG7k(Base, PulserInterface):
         """
         # Get all active channels
         chnl_activation = self.get_active_channels()
-        channel_numbers = sorted(int(chnl.split('_ch')[1]) for chnl in chnl_activation if
+        channel_numbers = natural_sort(int(chnl.split('_ch')[1]) for chnl in chnl_activation if
                                  chnl.startswith('a') and chnl_activation[chnl])
 
         # Get assets per channel
@@ -921,7 +922,7 @@ class AWG7k(Base, PulserInterface):
         # determine active channels
         activation_dict = self.get_active_channels()
         active_channels = {chnl for chnl in activation_dict if activation_dict[chnl]}
-        active_analog = sorted(chnl for chnl in active_channels if chnl.startswith('a'))
+        active_analog = natural_sort(chnl for chnl in active_channels if chnl.startswith('a'))
 
         # Sanity check of channel numbers
         if active_channels != set(analog_samples.keys()).union(set(digital_samples.keys())):
@@ -1009,7 +1010,7 @@ class AWG7k(Base, PulserInterface):
                                'present in device memory.'.format(name, waveform_tuple))
                 return -1
 
-        active_analog = sorted(chnl for chnl in self.get_active_channels() if chnl.startswith('a'))
+        active_analog = natural_sort(chnl for chnl in self.get_active_channels() if chnl.startswith('a'))
         num_tracks = len(active_analog)
         num_steps = len(sequence_parameter_list)
 
@@ -1056,7 +1057,7 @@ class AWG7k(Base, PulserInterface):
         wfm_list = list()
         for index in range(wfm_list_len):
             wfm_list.append(self.query('WLIS:NAME? {0:d}'.format(index)))
-        return sorted(wfm_list)
+        return natural_sort(wfm_list)
 
     def get_sequence_names(self):
         """ Retrieve the names of all uploaded sequence on the device.
@@ -1083,7 +1084,7 @@ class AWG7k(Base, PulserInterface):
             if waveform in avail_waveforms:
                 self.write('WLIS:WAV:DEL "{0}"'.format(waveform))
                 deleted_waveforms.append(waveform)
-        return sorted(deleted_waveforms)
+        return natural_sort(deleted_waveforms)
 
     def delete_sequence(self, sequence_name):
         """ Delete the sequence with name "sequence_name" from the device memory.
@@ -1313,7 +1314,7 @@ class AWG7k(Base, PulserInterface):
         avail_channels = ['a_ch1', 'd_ch1', 'd_ch2']
         if not self.get_interleave():
             avail_channels.extend(['a_ch2', 'd_ch3', 'd_ch4'])
-        return sorted(avail_channels)
+        return natural_sort(avail_channels)
 
     def _get_all_analog_channels(self):
         """
@@ -1322,7 +1323,7 @@ class AWG7k(Base, PulserInterface):
 
         @return list: Sorted list of analog channels
         """
-        return sorted(chnl for chnl in self._get_all_channels() if chnl.startswith('a'))
+        return natural_sort(chnl for chnl in self._get_all_channels() if chnl.startswith('a'))
 
     def _get_all_digital_channels(self):
         """
@@ -1331,7 +1332,7 @@ class AWG7k(Base, PulserInterface):
 
         @return list: Sorted list of digital channels
         """
-        return sorted(chnl for chnl in self._get_all_channels() if chnl.startswith('d'))
+        return natural_sort(chnl for chnl in self._get_all_channels() if chnl.startswith('d'))
 
     def _is_output_on(self):
         """

--- a/hardware/dtg/dtg5334.py
+++ b/hardware/dtg/dtg5334.py
@@ -26,6 +26,7 @@ import numpy as np
 import os
 import time
 import visa
+from core.util.helpers import natural_sort
 
 from interface.pulser_interface import PulserInterface, PulserConstraints
 from core.module import Base, ConfigOption
@@ -571,14 +572,14 @@ class DTG5334(Base, PulserInterface):
 
         @return list: List of all uploaded waveform name strings in the device workspace.
         """
-        return list(sorted(self.waveform_names))
+        return list(natural_sort(self.waveform_names))
 
     def get_sequence_names(self):
         """ Retrieve the names of all uploaded sequence on the device.
 
         @return list: List of all uploaded sequence name strings in the device workspace.
         """
-        return list(sorted(self.sequence_names))
+        return list(natural_sort(self.sequence_names))
 
     def delete_waveform(self, waveform_name):
         """ Delete the waveform with name "waveform_name" from the device memory.

--- a/hardware/pulser_dummy.py
+++ b/hardware/pulser_dummy.py
@@ -24,6 +24,7 @@ import time
 from collections import OrderedDict
 
 from core.module import Base, StatusVar, ConfigOption
+from core.util.helpers import natural_sort
 from interface.pulser_interface import PulserInterface, PulserConstraints
 
 
@@ -468,8 +469,8 @@ class PulserDummy(Base, PulserInterface):
             return self.get_loaded_assets()
 
         # Determine if the device is purely digital and get all active channels
-        analog_channels = sorted(chnl for chnl in self.activation_config if chnl.startswith('a'))
-        digital_channels = sorted(chnl for chnl in self.activation_config if chnl.startswith('d'))
+        analog_channels = natural_sort(chnl for chnl in self.activation_config if chnl.startswith('a'))
+        digital_channels = natural_sort(chnl for chnl in self.activation_config if chnl.startswith('d'))
         pure_digital = len(analog_channels) == 0
 
         if pure_digital and len(digital_channels) != self.sequence_dict[sequence_name]:

--- a/logic/pulsed/pulse_analyzer.py
+++ b/logic/pulsed/pulse_analyzer.py
@@ -25,6 +25,7 @@ import inspect
 import importlib
 
 from core.util.modules import get_main_dir
+from core.util.helpers import natural_sort
 
 
 class PulseAnalyzerBase:
@@ -110,7 +111,7 @@ class PulseAnalyzer(PulseAnalyzerBase):
         self.__populate_parameter_dict()
 
         # Set default analysis method
-        self._current_analysis_method = sorted(self._analysis_methods)[0]
+        self._current_analysis_method = natural_sort(self._analysis_methods)[0]
 
         # Update from parameter_dict if handed over
         if isinstance(pulsedmeasurementlogic.analysis_parameters, dict):

--- a/logic/pulsed/pulse_extractor.py
+++ b/logic/pulsed/pulse_extractor.py
@@ -25,6 +25,7 @@ import inspect
 import importlib
 
 from core.util.modules import get_main_dir
+from core.util.helpers import natural_sort
 
 
 class PulseExtractorBase:
@@ -112,9 +113,9 @@ class PulseExtractor(PulseExtractorBase):
 
         # Set default extraction method
         if self.is_gated:
-            self._current_extraction_method = sorted(self._gated_extraction_methods)[0]
+            self._current_extraction_method = natural_sort(self._gated_extraction_methods)[0]
         else:
-            self._current_extraction_method = sorted(self._ungated_extraction_methods)[0]
+            self._current_extraction_method = natural_sort(self._ungated_extraction_methods)[0]
 
         # Update from parameter_dict if handed over
         if isinstance(pulsedmeasurementlogic.extraction_parameters, dict):

--- a/logic/pulsed/pulse_objects.py
+++ b/logic/pulsed/pulse_objects.py
@@ -30,6 +30,7 @@ from collections import OrderedDict
 
 from logic.pulsed.sampling_functions import SamplingFunctions
 from core.util.modules import get_main_dir
+from core.util.helpers import natural_sort
 
 
 class PulseBlockElement(object):
@@ -172,8 +173,7 @@ class PulseBlock(object):
         return_str += 'initial length: {0}s\n\tlength increment: {1}s\n\t'.format(
             self.init_length_s, self.increment_s)
         return_str += 'active analog channels: {0}\n\tactive digital channels: {1}'.format(
-            sorted(self.analog_channels, key=lambda ch: int(ch.split('ch')[-1])),
-            sorted(self.digital_channels, key=lambda ch: int(ch.split('ch')[-1])))
+            natural_sort(self.analog_channels), natural_sort(self.digital_channels))
         return return_str
 
     def __len__(self):

--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -31,6 +31,7 @@ from core.module import Connector, ConfigOption, StatusVar
 from core.util.mutex import Mutex
 from core.util.network import netobtain
 from core.util import units
+from core.util.helpers import natural_sort
 from logic.generic_logic import GenericLogic
 from logic.pulsed.pulse_extractor import PulseExtractor
 from logic.pulsed.pulse_analyzer import PulseAnalyzer

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -737,7 +737,7 @@ class SequenceGeneratorLogic(GenericLogic):
         # Get all files in asset directory ending on ".block" and extract a sorted list of
         # PulseBlock names
         with os.scandir(self._assets_storage_dir) as scan:
-            names = sorted(f.name[:-6] for f in scan if f.is_file and f.name.endswith('.block'))
+            names = natural_sort(f.name[:-6] for f in scan if f.is_file and f.name.endswith('.block'))
 
         # Load all blocks from file
         for block_name in names:
@@ -840,7 +840,7 @@ class SequenceGeneratorLogic(GenericLogic):
         # Get all files in asset directory ending on ".ensemble" and extract a sorted list of
         # PulseBlockEnsemble names
         with os.scandir(self._assets_storage_dir) as scan:
-            names = sorted(f.name[:-9] for f in scan if f.is_file and f.name.endswith('.ensemble'))
+            names = natural_sort(f.name[:-9] for f in scan if f.is_file and f.name.endswith('.ensemble'))
 
         # Get all waveforms currently stored on pulser hardware in order to delete outdated
         # sampling_information dicts
@@ -1002,7 +1002,7 @@ class SequenceGeneratorLogic(GenericLogic):
         # Get all files in asset directory ending on ".sequence" and extract a sorted list of
         # PulseSequence names
         with os.scandir(self._assets_storage_dir) as scan:
-            names = sorted(f.name[:-9] for f in scan if f.is_file and f.name.endswith('.sequence'))
+            names = natural_sort(f.name[:-9] for f in scan if f.is_file and f.name.endswith('.sequence'))
 
         # Get all waveforms and sequences currently stored on pulser hardware in order to delete
         # outdated sampling_information dicts
@@ -1782,7 +1782,7 @@ class SequenceGeneratorLogic(GenericLogic):
             ensemble.sampling_information = dict()
             ensemble.sampling_information.update(ensemble_info)
             ensemble.sampling_information['pulse_generator_settings'] = self.pulse_generator_settings
-            ensemble.sampling_information['waveforms'] = sorted(written_waveforms)
+            ensemble.sampling_information['waveforms'] = natural_sort(written_waveforms)
             self.save_ensemble(ensemble)
 
         self.log.info('Time needed for sampling and writing PulseBlockEnsemble {0} to device: {1} sec'
@@ -1794,7 +1794,7 @@ class SequenceGeneratorLogic(GenericLogic):
             self.module_state.unlock()
         self.sigAvailableWaveformsUpdated.emit(self.sampled_waveforms)
         self.sigSampleEnsembleComplete.emit(ensemble)
-        return offset_bin, sorted(written_waveforms), ensemble_info
+        return offset_bin, natural_sort(written_waveforms), ensemble_info
 
     @QtCore.Slot(str)
     def sample_pulse_sequence(self, sequence):
@@ -1915,7 +1915,7 @@ class SequenceGeneratorLogic(GenericLogic):
         sequence.sampling_information.update(self.analyze_sequence(sequence))
         sequence.sampling_information['ensemble_info'] = generated_ensembles
         sequence.sampling_information['pulse_generator_settings'] = self.pulse_generator_settings
-        sequence.sampling_information['waveforms'] = sorted(written_waveforms)
+        sequence.sampling_information['waveforms'] = natural_sort(written_waveforms)
         sequence.sampling_information['step_waveform_list'] = [step[0] for step in
                                                                sequence_param_dict_list]
         self.save_sequence(sequence)

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -30,6 +30,7 @@ from qtpy import QtCore
 from collections import OrderedDict
 from core.module import StatusVar, Connector, ConfigOption
 from core.util.modules import get_main_dir, get_home_dir
+from core.util.helpers import natural_sort
 from logic.generic_logic import GenericLogic
 from logic.pulsed.pulse_objects import PulseBlock, PulseBlockEnsemble, PulseSequence
 from logic.pulsed.pulse_objects import PulseObjectGenerator, PulseBlockElement
@@ -357,8 +358,8 @@ class SequenceGeneratorLogic(GenericLogic):
                 # search the generation_parameters for channel specifiers and adjust them if they
                 # are no longer valid
                 changed_settings = dict()
-                ana_chnls = sorted(self.analog_channels, key=lambda ch: int(ch.split('ch')[-1]))
-                digi_chnls = sorted(self.digital_channels, key=lambda ch: int(ch.split('ch')[-1]))
+                ana_chnls = natural_sort(self.analog_channels)
+                digi_chnls = natural_sort(self.digital_channels)
                 for name in [setting for setting in self.generation_parameters if
                              setting.endswith('_channel')]:
                     channel = self.generation_parameters[name]

--- a/tools/config_gui/menu.py
+++ b/tools/config_gui/menu.py
@@ -18,6 +18,7 @@ Copyright (c) the Qudi Developers. See the COPYRIGHT.txt file at the
 top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi/>
 """
 import os
+from core.util.helpers import natural_sort
 from qtpy import QtCore, QtWidgets
 
 class MenuItem:
@@ -55,13 +56,13 @@ class ModMenu(QtWidgets.QMenu):
         self.logicmenuitems = MenuItem(self.logicmenu)
         self.guimenuitems = MenuItem(self.guimenu)
 
-        for module_path, module in sorted(modules['hardware'].items()):
+        for module_path, module in natural_sort(modules['hardware'].items()):
             self.build_submenu(self.hwmenuitems, module_path, module)
 
-        for module_path, module in sorted(modules['logic'].items()):
+        for module_path, module in natural_sort(modules['logic'].items()):
             self.build_submenu(self.logicmenuitems, module_path, module)
 
-        for module_path, module in sorted(modules['gui'].items()):
+        for module_path, module in natural_sort(modules['gui'].items()):
             self.build_submenu(self.guimenuitems, module_path, module)
 
     def build_submenu(self, menu_item, modpath, module) :


### PR DESCRIPTION
## Description
Introduced a new utility funtion `natural_sort` to `core.util.helpers` which can be used for natural/human sorting of string item iterables.

Made every module use the new sorting function where applicable. 

## Motivation and Context
If you want to sort alphanumeric strings, the python default `sorted()` will not sort these strings as a human would. 
If you have a list like:
```python
mylist = ['stuff10', 'stuff1', 'stuff5']
```
Python default
```python
sorted(mylist)
```
will yield
```python
['stuff1', 'stuff10', 'stuff5']
```
while
```python
core.util.helpers.natural_sort(mylist)
```
will yield
```python
['stuff1', 'stuff5', 'stuff10']
```

## How Has This Been Tested?
dummy Win8.1 x64

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
