### PR TITLE
Sample ensemble only if needed

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -10,7 +10,10 @@ image
 * Added an optional POI nametag to the POI manager. If you give this property a string value, all 
 new POIs will be named after this tag together with a consecutive integer index.
 * bug fix to how the flags are set for AWG70k
-* 
+* exposed the sequencegenerator-functions analyze_sequence and analyze_ensemble to be accessible via pulsedmaster
+* analyze functions can be called either with the appropriate objects or with the object name
+* while sampling a sequence, the ensembles are only sampled if they weren't already sampled before
+*
 
 Config changes:
 

--- a/logic/pulsed/pulsed_master_logic.py
+++ b/logic/pulsed/pulsed_master_logic.py
@@ -974,13 +974,89 @@ class PulsedMasterLogic(GenericLogic):
 
     def get_ensemble_info(self, ensemble):
         """
+        This helper method is just there for backwards compatibility. Essentially it will call the
+        method "analyze_block_ensemble".
+
+        Will return information like length in seconds and bins (with currently set sampling rate)
+        as well as number of laser pulses (with currently selected laser/gate channel)
+
+        @param PulseBlockEnsemble ensemble: The PulseBlockEnsemble instance to analyze
+        @return (float, int, int): length in seconds, length in bins, number of laser/gate pulses
         """
         return self.sequencegeneratorlogic().get_ensemble_info(ensemble=ensemble)
 
     def get_sequence_info(self, sequence):
         """
+        This helper method will analyze a PulseSequence and return information like length in
+        seconds and bins (with currently set sampling rate), number of laser pulses (with currently
+        selected laser/gate channel)
+
+        @param PulseSequence sequence: The PulseSequence instance to analyze
+        @return (float, int, int): length in seconds, length in bins, number of laser/gate pulses
         """
         return self.sequencegeneratorlogic().get_sequence_info(sequence=sequence)
+
+    def analyze_block_ensemble(self, ensemble):
+        """
+        This helper method runs through each element of a PulseBlockEnsemble object and extracts
+        important information about the Waveform that can be created out of this object.
+        Especially the discretization due to the set self.sample_rate is taken into account.
+        The positions in time (as integer time bins) of the PulseBlockElement transitions are
+        determined here (all the "rounding-to-best-match-value").
+        Additional information like the total number of samples, total number of PulseBlockElements
+        and the timebins for digital channel low-to-high transitions get returned as well.
+
+        This method assumes that sanity checking has been already performed on the
+        PulseBlockEnsemble (via _sampling_ensemble_sanity_check). Meaning it assumes that all
+        PulseBlocks are actually present in saved blocks and the channel activation matches the
+        current pulse settings.
+
+        @param ensemble: A PulseBlockEnsemble object (see logic.pulse_objects.py)
+        @return: number_of_samples (int): The total number of samples in a Waveform provided the
+                                              current sample_rate and PulseBlockEnsemble object.
+                 total_elements (int): The total number of PulseBlockElements (incl. repetitions) in
+                                       the provided PulseBlockEnsemble.
+                 elements_length_bins (1D numpy.ndarray[int]): Array of number of timebins for each
+                                                               PulseBlockElement in chronological
+                                                               order (incl. repetitions).
+                 digital_rising_bins (dict): Dictionary with keys being the digital channel
+                                             descriptor string and items being arrays of
+                                             chronological low-to-high transition positions
+                                             (in timebins; incl. repetitions) for each digital
+                                             channel.
+        """
+        return self.sequencegeneratorlogic().analyze_block_ensemble(ensemble=ensemble)
+
+    def analyze_sequence(self, sequence):
+        """
+        This helper method runs through each step of a PulseSequence object and extracts
+        important information about the Sequence that can be created out of this object.
+        Especially the discretization due to the set self.sample_rate is taken into account.
+        The positions in time (as integer time bins) of the PulseBlockElement transitions are
+        determined here (all the "rounding-to-best-match-value").
+        Additional information like the total number of samples, total number of PulseBlockElements
+        and the timebins for digital channel low-to-high transitions get returned as well.
+
+        This method assumes that sanity checking has been already performed on the
+        PulseSequence (via _sampling_ensemble_sanity_check). Meaning it assumes that all
+        PulseBlocks are actually present in saved blocks and the channel activation matches the
+        current pulse settings.
+
+        @param sequence: A PulseSequence object (see logic.pulse_objects.py)
+        @return: number_of_samples (int): The total number of samples in a Waveform provided the
+                                              current sample_rate and PulseBlockEnsemble object.
+                 total_elements (int): The total number of PulseBlockElements (incl. repetitions) in
+                                       the provided PulseBlockEnsemble.
+                 elements_length_bins (1D numpy.ndarray[int]): Array of number of timebins for each
+                                                               PulseBlockElement in chronological
+                                                               order (incl. repetitions).
+                 digital_rising_bins (dict): Dictionary with keys being the digital channel
+                                             descriptor string and items being arrays of
+                                             chronological low-to-high transition positions
+                                             (in timebins; incl. repetitions) for each digital
+                                             channel.
+        """
+        return self.sequencegeneratorlogic().analyze_sequence(sequence=sequence)
 
     #######################################################################
     ###             Helper  methods                                     ###

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1152,7 +1152,7 @@ class SequenceGeneratorLogic(GenericLogic):
         PulseBlocks are actually present in saved blocks and the channel activation matches the
         current pulse settings.
 
-        @param ensemble: A PulseBlockEnsemble object (see logic.pulse_objects.py)
+        @param ensemble: A PulseBlockEnsemble object (see logic.pulse_objects.py) or the name of one
         @return: number_of_samples (int): The total number of samples in a Waveform provided the
                                               current sample_rate and PulseBlockEnsemble object.
                  total_elements (int): The total number of PulseBlockElements (incl. repetitions) in
@@ -1166,6 +1166,14 @@ class SequenceGeneratorLogic(GenericLogic):
                                              (in timebins; incl. repetitions) for each digital
                                              channel.
         """
+
+        if isinstance(ensemble, str):
+            ensemble = self.get_ensemble(ensemble)
+        elif not isinstance(ensemble, PulseBlockEnsemble):
+            self.log.error('Ensemble to analyze must either be of type PulseBlockEnsemble or the name of the ensemble.'
+                           'Returning empty dict')
+            return {}
+
         # Determine the right laser channel to choose. For gated counting it should be the gate
         # channel instead of the laser trigger.
         laser_channel = self.generation_parameters['gate_channel'] if self.generation_parameters[
@@ -1290,7 +1298,7 @@ class SequenceGeneratorLogic(GenericLogic):
         PulseBlocks are actually present in saved blocks and the channel activation matches the
         current pulse settings.
 
-        @param sequence: A PulseSequence object (see logic.pulse_objects.py)
+        @param sequence: A PulseSequence object (see logic.pulse_objects.py) or the name of one
         @return: number_of_samples (int): The total number of samples in a Waveform provided the
                                               current sample_rate and PulseBlockEnsemble object.
                  total_elements (int): The total number of PulseBlockElements (incl. repetitions) in
@@ -1304,6 +1312,14 @@ class SequenceGeneratorLogic(GenericLogic):
                                              (in timebins; incl. repetitions) for each digital
                                              channel.
         """
+
+        if isinstance(sequence, str):
+            sequence = self.get_sequence(sequence)
+        elif not isinstance(sequence, PulseSequence):
+            self.log.error('Sequence to analyze must either be of type PulseSequence or the name of the sequence.'
+                           'Returning empty dict')
+            return {}
+
         # Determine the right laser channel to choose. For gated counting it should be the gate
         # channel instead of the laser trigger.
         laser_channel = self.generation_parameters['gate_channel'] if self.generation_parameters[

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1167,13 +1167,16 @@ class SequenceGeneratorLogic(GenericLogic):
                                              (in timebins; incl. repetitions) for each digital
                                              channel.
         """
-
         if isinstance(ensemble, str):
+            if ensemble not in self._saved_pulse_block_ensembles:
+                self.log.error('No saved PulseBlockEnsemble instance by the name "{0}" found. '
+                               'Returning empty dict.'.format(ensemble))
+                return dict()
             ensemble = self.get_ensemble(ensemble)
         elif not isinstance(ensemble, PulseBlockEnsemble):
-            self.log.error('Ensemble to analyze must either be of type PulseBlockEnsemble or the name of the ensemble.'
-                           'Returning empty dict')
-            return {}
+            self.log.error('Ensemble to analyze must either be of type PulseBlockEnsemble or the '
+                           'name of the ensemble. Returning empty dict')
+            return dict()
 
         # Determine the right laser channel to choose. For gated counting it should be the gate
         # channel instead of the laser trigger.
@@ -1313,13 +1316,16 @@ class SequenceGeneratorLogic(GenericLogic):
                                              (in timebins; incl. repetitions) for each digital
                                              channel.
         """
-
         if isinstance(sequence, str):
+            if sequence not in self._saved_pulse_sequences:
+                self.log.error('No saved PulseSequence instance by the name "{0}" found. '
+                               'Returning empty dict.'.format(sequence))
+                return dict()
             sequence = self.get_sequence(sequence)
         elif not isinstance(sequence, PulseSequence):
-            self.log.error('Sequence to analyze must either be of type PulseSequence or the name of the sequence.'
-                           'Returning empty dict')
-            return {}
+            self.log.error('Sequence to analyze must either be of type PulseSequence or the name '
+                           'of the sequence. Returning empty dict')
+            return dict()
 
         # Determine the right laser channel to choose. For gated counting it should be the gate
         # channel instead of the laser trigger.

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1874,7 +1874,10 @@ class SequenceGeneratorLogic(GenericLogic):
                 offset_bin = 0  # Keep the offset at 0
 
             # Only sample ensembles if they have not already been sampled
-            if sequence.rotating_frame or seq_step.ensemble not in generated_ensembles:
+            if sequence.rotating_frame \
+                    or name_tag not in self._saved_pulse_block_ensembles.keys() \
+                    or 'number_of_samples' not in self.get_ensemble(name_tag).sampling_information:
+
                 offset_bin, waveform_list, ensemble_info = self.sample_pulse_block_ensemble(
                     ensemble=seq_step.ensemble,
                     offset_bin=offset_bin,
@@ -1895,6 +1898,11 @@ class SequenceGeneratorLogic(GenericLogic):
 
                 # Add created waveform names to the set
                 written_waveforms.update(waveform_list)
+            else:
+                self.log.debug('Waveform already sampled: {0}'.format(name_tag))
+                ensemble_info = self.get_ensemble(name_tag).sampling_information.copy()
+                generated_ensembles[name_tag] = ensemble_info
+                written_waveforms.update(ensemble_info['waveforms'])
 
             # Append written sequence step to sequence_param_dict_list
             sequence_param_dict_list.append(

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1897,7 +1897,9 @@ class SequenceGeneratorLogic(GenericLogic):
                 offset_bin = 0  # Keep the offset at 0
 
             # Only sample ensembles if they have not already been sampled
-            if sequence.rotating_frame or not self.get_ensemble(name_tag).sampling_information:
+            if sequence.rotating_frame or \
+                    not self.get_ensemble(name_tag).sampling_information or \
+                    self.get_ensemble(name_tag).sampling_information['pulse_generator_settings'] != self.pulse_generator_settings:
 
                 offset_bin, waveform_list, ensemble_info = self.sample_pulse_block_ensemble(
                     ensemble=seq_step.ensemble,
@@ -1922,7 +1924,10 @@ class SequenceGeneratorLogic(GenericLogic):
             else:
                 self.log.debug('Waveform already sampled: {0}'.format(name_tag))
                 ensemble_info = self.get_ensemble(name_tag).sampling_information.copy()
+                del(ensemble_info['pulse_generator_settings'])
                 generated_ensembles[name_tag] = ensemble_info
+
+                # Add created waveform names to the set
                 written_waveforms.update(ensemble_info['waveforms'])
 
             # Append written sequence step to sequence_param_dict_list

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1890,9 +1890,7 @@ class SequenceGeneratorLogic(GenericLogic):
                 offset_bin = 0  # Keep the offset at 0
 
             # Only sample ensembles if they have not already been sampled
-            if sequence.rotating_frame \
-                    or name_tag not in self._saved_pulse_block_ensembles.keys() \
-                    or 'number_of_samples' not in self.get_ensemble(name_tag).sampling_information:
+            if sequence.rotating_frame or not self.get_ensemble(name_tag).sampling_information:
 
                 offset_bin, waveform_list, ensemble_info = self.sample_pulse_block_ensemble(
                     ensemble=seq_step.ensemble,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
So far all the ensembles needed in a sequence were first deleted and then sampled anew.
Now first a check is performed, if the ensemble already was sample before and it is only sampled if needed (so always when rotating wave is active).

## Description
<!--- Describe your changes in detail -->
Ensembles are only sampled if needed.
The analyze_sequence and analyze_ensemble functions are now available through pulsedmaster.
The aforementioned analyze functions can either be called with the appropriate objects directly or by the object's name.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When an ensemble is created or changed, this ensemble should be newly sampled. But if the same ensemble is used by multiple sequences they should not be overwritten but rather all sequences should use the same ensembles.
This saves time on the one hand and several sequences can be pre-sampled and then just loaded to run experiments.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on LP1 with AWG70k and Win 8.1.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
