### PR TITLE
Add current poi to savelogic

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -9,6 +9,8 @@ Changes/New features:
 image
 * Added an optional POI nametag to the POI manager. If you give this property a string value, all 
 new POIs will be named after this tag together with a consecutive integer index.
+* If using the POI manager, the currently selected active POI name will be added to savelogic as 
+global parameter. All saved data files will include this POI name in the header.
 * bug fix to how the flags are set for AWG70k
 * Add `natural_sort` utility function to `core.util.helpers`
 

--- a/logic/poi_manager_logic.py
+++ b/logic/poi_manager_logic.py
@@ -967,9 +967,9 @@ class PoiManagerLogic(GenericLogic):
 
     def update_poi_tag_in_savelogic(self):
         if not self._active_poi:
-            self.savelogic().remove_additional_parameter('active POI')
+            self.savelogic().remove_additional_parameter('Active POI')
         else:
-            self.savelogic().update_additional_parameters({'active POI': self._active_poi})
+            self.savelogic().update_additional_parameters({'Active POI': self._active_poi})
 
     def save_roi(self):
         """

--- a/logic/poi_manager_logic.py
+++ b/logic/poi_manager_logic.py
@@ -418,6 +418,7 @@ class PoiManagerLogic(GenericLogic):
                                  'scan_image': self.roi_scan_image,
                                  'scan_image_extent': self.roi_scan_image_extent})
         self.sigActivePoiUpdated.emit('' if self.active_poi is None else self.active_poi)
+        self.update_poi_tag_in_savelogic()
         return
 
     def on_deactivate(self):
@@ -965,8 +966,10 @@ class PoiManagerLogic(GenericLogic):
         return
 
     def update_poi_tag_in_savelogic(self):
-        # TODO: Implement this once there is a way to include global parameters in the savelogic.
-        pass
+        if not self._active_poi:
+            self.savelogic().remove_additional_parameter('active POI')
+        else:
+            self.savelogic().update_additional_parameters({'active POI': self._active_poi})
 
     def save_roi(self):
         """

--- a/logic/save_logic.py
+++ b/logic/save_logic.py
@@ -644,14 +644,27 @@ class SaveLogic(GenericLogic):
         """ Method that return the additional parameters dictionary securely """
         return self._additional_parameters.copy()
 
-    def update_additional_parameters(self, **new_pairs):
-        """ Method to update one or multiple additional parameters """
-        dic = {}
-        for key in new_pairs.keys():
-            dic[key] = netobtain(new_pairs[key])
-        self._additional_parameters = {**self._additional_parameters, **dic}
+    def update_additional_parameters(self, __pdict=None, **new_params):
+        """
+        Method to update one or multiple additional parameters
+
+        @param dict __pdict: Optional single positional argument holding parameters in a dict to
+                             update additional parameters from.
+        @param kwargs new_params: Optional keyword arguments to be added to additional parameters
+        """
+        if not (__pdict is None or isinstance(__pdict, dict)):
+            raise TypeError('update_additional_parameters: optional positional argument must be '
+                            'None or dict type.')
+
+        param_dict = dict() if __pdict is None else netobtain(__pdict)
+
+        for key in new_params.keys():
+            param_dict[key] = netobtain(new_params[key])
+        self._additional_parameters.update(param_dict)
+        return
 
     def remove_additional_parameter(self, key):
         """ remove a parameter from additional parameters """
         self._additional_parameters.pop(key, None)
+        return
 

--- a/logic/save_logic.py
+++ b/logic/save_logic.py
@@ -644,27 +644,35 @@ class SaveLogic(GenericLogic):
         """ Method that return the additional parameters dictionary securely """
         return self._additional_parameters.copy()
 
-    def update_additional_parameters(self, __pdict=None, **new_params):
+    def update_additional_parameters(self, *args, **kwargs):
         """
         Method to update one or multiple additional parameters
 
-        @param dict __pdict: Optional single positional argument holding parameters in a dict to
-                             update additional parameters from.
-        @param kwargs new_params: Optional keyword arguments to be added to additional parameters
+        @param dict args: Optional single positional argument holding parameters in a dict to
+                          update additional parameters from.
+        @param kwargs: Optional keyword arguments to be added to additional parameters
         """
-        if not (__pdict is None or isinstance(__pdict, dict)):
-            raise TypeError('update_additional_parameters: optional positional argument must be '
-                            'None or dict type.')
+        if len(args) == 0:
+            param_dict = dict()
+        elif len(args) == 1 and isinstance(args[0], dict):
+            param_dict = args[0]
+        else:
+            raise TypeError('"update_additional_parameters" takes exactly 0 or 1 positional '
+                            'argument of type dict.')
 
-        param_dict = dict() if __pdict is None else netobtain(__pdict)
+        param_dict.update(kwargs)
 
-        for key in new_params.keys():
-            param_dict[key] = netobtain(new_params[key])
+        for key in param_dict.keys():
+            param_dict[key] = netobtain(param_dict[key])
         self._additional_parameters.update(param_dict)
         return
 
     def remove_additional_parameter(self, key):
-        """ remove a parameter from additional parameters """
+        """
+        remove parameter from additional parameters
+
+        @param str key: The additional parameters key/name to delete
+        """
         self._additional_parameters.pop(key, None)
         return
 

--- a/logic/save_logic.py
+++ b/logic/save_logic.py
@@ -653,14 +653,12 @@ class SaveLogic(GenericLogic):
         @param kwargs: Optional keyword arguments to be added to additional parameters
         """
         if len(args) == 0:
-            param_dict = dict()
+            param_dict = kwargs
         elif len(args) == 1 and isinstance(args[0], dict):
-            param_dict = args[0]
+            param_dict = args[0].update(kwargs)
         else:
             raise TypeError('"update_additional_parameters" takes exactly 0 or 1 positional '
                             'argument of type dict.')
-
-        param_dict.update(kwargs)
 
         for key in param_dict.keys():
             param_dict[key] = netobtain(param_dict[key])


### PR DESCRIPTION
## Description
`PoiManagerLogic` will now update the global additional_parameters dict in `SaveLogic` with the currently selected active POI name. This active POI name will as such be included in all data headers saved with `SaveLogic`.

Also improved method `SaveLogic.update_poi_tag_in_savelogic` to accept a single optional positional argument. This argument can be used to directly pass a dict to update additional parameters from.
This has the advantage that the parameter key/name can be any string and not only python keyword-conform descriptors (i.e. you can add blanks and such).

## How Has This Been Tested?
Dummy Win8.1 x64

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
