### PR TITLE
Changed all channel config sets in pulser constraints to `frozenset` type

### DIFF
--- a/hardware/awg/keysight_M3202A.py
+++ b/hardware/awg/keysight_M3202A.py
@@ -146,7 +146,7 @@ class M3202A(Base, PulserInterface):
         constraints.sequence_steps.default = 1
 
         activation_config = OrderedDict()
-        activation_config['all'] = {'a_ch1', 'a_ch2', 'a_ch3', 'a_ch4'}
+        activation_config['all'] = frozenset({'a_ch1', 'a_ch2', 'a_ch3', 'a_ch4'})
         constraints.activation_config = activation_config
         # FIXME: additional constraint really necessary?
         constraints.dac_resolution = {'min': 14, 'max': 14, 'step': 1, 'unit': 'bit'}

--- a/hardware/awg/tektronix_awg5002c.py
+++ b/hardware/awg/tektronix_awg5002c.py
@@ -246,9 +246,10 @@ class AWG5002C(Base, PulserInterface):
         # channels. Here all possible channel configurations are stated, where only the generic
         # names should be used. The names for the different configurations can be customary chosen.
         activation_config = OrderedDict()
-        activation_config['config1'] = ['a_ch1', 'd_ch1', 'd_ch2', 'a_ch2', 'd_ch3', 'd_ch4']
-        activation_config['config2'] = ['a_ch1', 'd_ch1', 'd_ch2']
-        activation_config['config3'] = ['a_ch2', 'd_ch3', 'd_ch4']
+        activation_config['config1'] = frozenset(
+            {'a_ch1', 'd_ch1', 'd_ch2', 'a_ch2', 'd_ch3', 'd_ch4'})
+        activation_config['config2'] = frozenset({'a_ch1', 'd_ch1', 'd_ch2'})
+        activation_config['config3'] = frozenset({'a_ch2', 'd_ch3', 'd_ch4'})
         constraints.activation_config = activation_config
 
         return constraints

--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -233,33 +233,36 @@ class AWG70K(Base, PulserInterface):
         # names should be used. The names for the different configurations can be customary chosen.
         activation_config = OrderedDict()
         if self.awg_model == 'AWG70002A':
-            activation_config['all'] = {'a_ch1', 'd_ch1', 'd_ch2', 'a_ch2', 'd_ch3', 'd_ch4'}
+            activation_config['all'] = frozenset(
+                {'a_ch1', 'd_ch1', 'd_ch2', 'a_ch2', 'd_ch3', 'd_ch4'})
             # Usage of both channels but reduced markers (higher analog resolution)
-            activation_config['ch1_2mrk_ch2_1mrk'] = {'a_ch1', 'd_ch1', 'd_ch2', 'a_ch2', 'd_ch3'}
-            activation_config['ch1_2mrk_ch2_0mrk'] = {'a_ch1', 'd_ch1', 'd_ch2', 'a_ch2'}
-            activation_config['ch1_1mrk_ch2_2mrk'] = {'a_ch1', 'd_ch1', 'a_ch2', 'd_ch3', 'd_ch4'}
-            activation_config['ch1_0mrk_ch2_2mrk'] = {'a_ch1', 'a_ch2', 'd_ch3', 'd_ch4'}
-            activation_config['ch1_1mrk_ch2_1mrk'] = {'a_ch1', 'd_ch1', 'a_ch2', 'd_ch3'}
-            activation_config['ch1_0mrk_ch2_1mrk'] = {'a_ch1', 'a_ch2', 'd_ch3'}
-            activation_config['ch1_1mrk_ch2_0mrk'] = {'a_ch1', 'd_ch1', 'a_ch2'}
+            activation_config['ch1_2mrk_ch2_1mrk'] = frozenset(
+                {'a_ch1', 'd_ch1', 'd_ch2', 'a_ch2', 'd_ch3'})
+            activation_config['ch1_2mrk_ch2_0mrk'] = frozenset({'a_ch1', 'd_ch1', 'd_ch2', 'a_ch2'})
+            activation_config['ch1_1mrk_ch2_2mrk'] = frozenset(
+                {'a_ch1', 'd_ch1', 'a_ch2', 'd_ch3', 'd_ch4'})
+            activation_config['ch1_0mrk_ch2_2mrk'] = frozenset({'a_ch1', 'a_ch2', 'd_ch3', 'd_ch4'})
+            activation_config['ch1_1mrk_ch2_1mrk'] = frozenset({'a_ch1', 'd_ch1', 'a_ch2', 'd_ch3'})
+            activation_config['ch1_0mrk_ch2_1mrk'] = frozenset({'a_ch1', 'a_ch2', 'd_ch3'})
+            activation_config['ch1_1mrk_ch2_0mrk'] = frozenset({'a_ch1', 'd_ch1', 'a_ch2'})
             # Usage of channel 1 only:
-            activation_config['ch1_2mrk'] = {'a_ch1', 'd_ch1', 'd_ch2'}
+            activation_config['ch1_2mrk'] = frozenset({'a_ch1', 'd_ch1', 'd_ch2'})
             # Usage of channel 2 only:
-            activation_config['ch2_2mrk'] = {'a_ch2', 'd_ch3', 'd_ch4'}
+            activation_config['ch2_2mrk'] = frozenset({'a_ch2', 'd_ch3', 'd_ch4'})
             # Usage of only channel 1 with one marker:
-            activation_config['ch1_1mrk'] = {'a_ch1', 'd_ch1'}
+            activation_config['ch1_1mrk'] = frozenset({'a_ch1', 'd_ch1'})
             # Usage of only channel 2 with one marker:
-            activation_config['ch2_1mrk'] = {'a_ch2', 'd_ch3'}
+            activation_config['ch2_1mrk'] = frozenset({'a_ch2', 'd_ch3'})
             # Usage of only channel 1 with no marker:
-            activation_config['ch1_0mrk'] = {'a_ch1'}
+            activation_config['ch1_0mrk'] = frozenset({'a_ch1'})
             # Usage of only channel 2 with no marker:
-            activation_config['ch2_0mrk'] = {'a_ch2'}
+            activation_config['ch2_0mrk'] = frozenset({'a_ch2'})
         elif self.awg_model == 'AWG70001A':
-            activation_config['all'] = {'a_ch1', 'd_ch1', 'd_ch2'}
+            activation_config['all'] = frozenset({'a_ch1', 'd_ch1', 'd_ch2'})
             # Usage of only channel 1 with one marker:
-            activation_config['ch1_1mrk'] = {'a_ch1', 'd_ch1'}
+            activation_config['ch1_1mrk'] = frozenset({'a_ch1', 'd_ch1'})
             # Usage of only channel 1 with no marker:
-            activation_config['ch1_0mrk'] = {'a_ch1'}
+            activation_config['ch1_0mrk'] = frozenset({'a_ch1'})
 
         constraints.activation_config = activation_config
 

--- a/hardware/awg/tektronix_awg7k.py
+++ b/hardware/awg/tektronix_awg7k.py
@@ -266,17 +266,17 @@ class AWG7k(Base, PulserInterface):
         # channels. Here all possible channel configurations are stated, where only the generic
         # names should be used. The names for the different configurations can be customary chosen.
         activation_config = OrderedDict()
-        activation_config['all'] = {'a_ch1', 'd_ch1', 'd_ch2', 'a_ch2', 'd_ch3', 'd_ch4'}
+        activation_config['all'] = frozenset({'a_ch1', 'd_ch1', 'd_ch2', 'a_ch2', 'd_ch3', 'd_ch4'})
         # Usage of channel 1 only:
-        activation_config['A1_M1_M2'] = {'a_ch1', 'd_ch1', 'd_ch2'}
+        activation_config['A1_M1_M2'] = frozenset({'a_ch1', 'd_ch1', 'd_ch2'})
         # Usage of channel 2 only:
-        activation_config['A2_M3_M4'] = {'a_ch2', 'd_ch3', 'd_ch4'}
+        activation_config['A2_M3_M4'] = frozenset({'a_ch2', 'd_ch3', 'd_ch4'})
         # Only both analog channels
-        activation_config['Two_Analog'] = {'a_ch1', 'a_ch2'}
+        activation_config['Two_Analog'] = frozenset({'a_ch1', 'a_ch2'})
         # Usage of one analog channel without digital channel
-        activation_config['Analog1'] = {'a_ch1'}
+        activation_config['Analog1'] = frozenset({'a_ch1'})
         # Usage of one analog channel without digital channel
-        activation_config['Analog2'] = {'a_ch2'}
+        activation_config['Analog2'] = frozenset({'a_ch2'})
         constraints.activation_config = activation_config
         return constraints
 

--- a/hardware/dtg/dtg5334.py
+++ b/hardware/dtg/dtg5334.py
@@ -204,15 +204,14 @@ class DTG5334(Base, PulserInterface):
         # channels. Here all possible channel configurations are stated, where only the generic
         # names should be used. The names for the different configurations can be customary chosen.
         activation_conf = OrderedDict()
-        activation_conf['A'] = {'d_ch1', 'd_ch2'}
-        activation_conf['B'] = {'d_ch3', 'd_ch4'}
-        activation_conf['C'] = {'d_ch5', 'd_ch6'}
-        activation_conf['D'] = {'d_ch7', 'd_ch8'}
-        activation_conf['AB'] = {'d_ch1', 'd_ch2', 'd_ch3', 'd_ch4'}
-        activation_conf['ABC'] = {'d_ch1', 'd_ch2', 'd_ch3', 'd_ch4', 'd_ch5', 'd_ch6'}
-        activation_conf['all'] = {
-            'd_ch1', 'd_ch2', 'd_ch3', 'd_ch4', 'd_ch5', 'd_ch6', 'd_ch7', 'd_ch8'
-        }
+        activation_conf['A'] = frozenset({'d_ch1', 'd_ch2'})
+        activation_conf['B'] = frozenset({'d_ch3', 'd_ch4'})
+        activation_conf['C'] = frozenset({'d_ch5', 'd_ch6'})
+        activation_conf['D'] = frozenset({'d_ch7', 'd_ch8'})
+        activation_conf['AB'] = frozenset({'d_ch1', 'd_ch2', 'd_ch3', 'd_ch4'})
+        activation_conf['ABC'] = frozenset({'d_ch1', 'd_ch2', 'd_ch3', 'd_ch4', 'd_ch5', 'd_ch6'})
+        activation_conf['all'] = frozenset(
+            {'d_ch1', 'd_ch2', 'd_ch3', 'd_ch4', 'd_ch5', 'd_ch6', 'd_ch7', 'd_ch8'})
         constraints.activation_config = activation_conf
         return constraints
 

--- a/hardware/fpga_pulser/ok_fpga_pulser.py
+++ b/hardware/fpga_pulser/ok_fpga_pulser.py
@@ -153,8 +153,8 @@ class OkFpgaPulser(Base, PulserInterface):
         # channels. Here all possible channel configurations are stated, where only the generic
         # names should be used. The names for the different configurations can be customary chosen.
         activation_config = OrderedDict()
-        activation_config['all'] = {'d_ch1', 'd_ch2', 'd_ch3', 'd_ch4',
-                                    'd_ch5', 'd_ch6', 'd_ch7', 'd_ch8'}
+        activation_config['all'] = frozenset(
+            {'d_ch1', 'd_ch2', 'd_ch3', 'd_ch4', 'd_ch5', 'd_ch6', 'd_ch7', 'd_ch8'})
         constraints.activation_config = activation_config
         return constraints
 

--- a/hardware/pulser_dummy.py
+++ b/hardware/pulser_dummy.py
@@ -200,23 +200,25 @@ class PulserDummy(Base, PulserInterface):
         # channels. Here all possible channel configurations are stated, where only the generic
         # names should be used. The names for the different configurations can be customary chosen.
         activation_config = OrderedDict()
-        activation_config['config0'] = {'a_ch1', 'd_ch1', 'd_ch2', 'a_ch2', 'd_ch3', 'd_ch4'}
-        activation_config['config1'] = {'a_ch2', 'd_ch1', 'd_ch2', 'a_ch3', 'd_ch3', 'd_ch4'}
+        activation_config['config0'] = frozenset(
+            {'a_ch1', 'd_ch1', 'd_ch2', 'a_ch2', 'd_ch3', 'd_ch4'})
+        activation_config['config1'] = frozenset(
+            {'a_ch2', 'd_ch1', 'd_ch2', 'a_ch3', 'd_ch3', 'd_ch4'})
         # Usage of channel 1 only:
-        activation_config['config2'] = {'a_ch2', 'd_ch1', 'd_ch2'}
+        activation_config['config2'] = frozenset({'a_ch2', 'd_ch1', 'd_ch2'})
         # Usage of channel 2 only:
-        activation_config['config3'] = {'a_ch3', 'd_ch3', 'd_ch4'}
+        activation_config['config3'] = frozenset({'a_ch3', 'd_ch3', 'd_ch4'})
         # Usage of Interleave mode:
-        activation_config['config4'] = {'a_ch1', 'd_ch1', 'd_ch2'}
+        activation_config['config4'] = frozenset({'a_ch1', 'd_ch1', 'd_ch2'})
         # Usage of only digital channels:
-        activation_config['config5'] = {'d_ch1', 'd_ch2', 'd_ch3', 'd_ch4', 'd_ch5', 'd_ch6',
-                                        'd_ch7', 'd_ch8'}
+        activation_config['config5'] = frozenset(
+            {'d_ch1', 'd_ch2', 'd_ch3', 'd_ch4', 'd_ch5', 'd_ch6', 'd_ch7', 'd_ch8'})
         # Usage of only one analog channel:
-        activation_config['config6'] = {'a_ch1'}
-        activation_config['config7'] = {'a_ch2'}
-        activation_config['config8'] = {'a_ch3'}
+        activation_config['config6'] = frozenset({'a_ch1'})
+        activation_config['config7'] = frozenset({'a_ch2'})
+        activation_config['config8'] = frozenset({'a_ch3'})
         # Usage of only the analog channels:
-        activation_config['config9'] = {'a_ch2', 'a_ch3'}
+        activation_config['config9'] = frozenset({'a_ch2', 'a_ch3'})
         constraints.activation_config = activation_config
 
         return constraints

--- a/hardware/spincore/pulse_blaster_esrpro.py
+++ b/hardware/spincore/pulse_blaster_esrpro.py
@@ -1284,10 +1284,10 @@ class PulseBlasterESRPRO(Base, SwitchInterface, PulserInterface):
         # the different configurations can be customary chosen.
 
         activation_conf = OrderedDict()
-        activation_conf['yourconf'] = {'a_ch1', 'd_ch1', 'd_ch2', 'a_ch2',
-                                       'd_ch3', 'd_ch4'}
-        activation_conf['different_conf'] = {'a_ch1', 'd_ch1', 'd_ch2'}
-        activation_conf['something_else'] = {'a_ch2', 'd_ch3', 'd_ch4'}
+        activation_conf['yourconf'] = frozenset(
+            {'a_ch1', 'd_ch1', 'd_ch2', 'a_ch2', 'd_ch3', 'd_ch4'})
+        activation_conf['different_conf'] = frozenset({'a_ch1', 'd_ch1', 'd_ch2'})
+        activation_conf['something_else'] = frozenset({'a_ch2', 'd_ch3', 'd_ch4'})
         constraints.activation_config = activation_conf
         """
         constraints = PulserConstraints()
@@ -1317,13 +1317,13 @@ class PulseBlasterESRPRO(Base, SwitchInterface, PulserInterface):
         constraints.waveform_length.default = 128
 
         activation_config = OrderedDict()
-        activation_config['4_ch'] = {'d_ch1', 'd_ch2', 'd_ch3', 'd_ch4'}
-        activation_config['all'] = {'d_ch1', 'd_ch2', 'd_ch3', 'd_ch4',
-                                    'd_ch5', 'd_ch6', 'd_ch7', 'd_ch8',
-                                    'd_ch9', 'd_ch10', 'd_ch11', 'd_ch12',
-                                    'd_ch13', 'd_ch14', 'd_ch15', 'd_ch16',
-                                    'd_ch17', 'd_ch18', 'd_ch19', 'd_ch20',
-                                    'd_ch21'}
+        activation_config['4_ch'] = frozenset({'d_ch1', 'd_ch2', 'd_ch3', 'd_ch4'})
+        activation_config['all'] = frozenset({'d_ch1', 'd_ch2', 'd_ch3', 'd_ch4',
+                                              'd_ch5', 'd_ch6', 'd_ch7', 'd_ch8',
+                                              'd_ch9', 'd_ch10', 'd_ch11', 'd_ch12',
+                                              'd_ch13', 'd_ch14', 'd_ch15', 'd_ch16',
+                                              'd_ch17', 'd_ch18', 'd_ch19', 'd_ch20',
+                                              'd_ch21'})
 
         constraints.activation_config = activation_config
 

--- a/interface/pulser_interface.py
+++ b/interface/pulser_interface.py
@@ -127,10 +127,12 @@ class PulserInterface(metaclass=InterfaceMetaclass):
         # the name a_ch<num> and d_ch<num> are generic names, which describe UNAMBIGUOUSLY the
         # channels. Here all possible channel configurations are stated, where only the generic
         # names should be used. The names for the different configurations can be customary chosen.
+        # IMPORTANT: Active channel sets must be of type frozenset to properly work as remote module
         activation_conf = OrderedDict()
-        activation_conf['yourconf'] = {'a_ch1', 'd_ch1', 'd_ch2', 'a_ch2', 'd_ch3', 'd_ch4'}
-        activation_conf['different_conf'] = {'a_ch1', 'd_ch1', 'd_ch2'}
-        activation_conf['something_else'] = {'a_ch2', 'd_ch3', 'd_ch4'}
+        activation_conf['yourconf'] = frozenset(
+            {'a_ch1', 'd_ch1', 'd_ch2', 'a_ch2', 'd_ch3', 'd_ch4'})
+        activation_conf['different_conf'] = frozenset({'a_ch1', 'd_ch1', 'd_ch2'})
+        activation_conf['something_else'] = frozenset({'a_ch2', 'd_ch3', 'd_ch4'})
         constraints.activation_config = activation_conf
         """
         pass
@@ -561,6 +563,5 @@ class PulserConstraints:
         self.repetitions = ScalarConstraint(unit='#')
         self.event_triggers = list()
         self.flags = list()
-
 
         self.activation_config = dict()

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -31,6 +31,7 @@ from collections import OrderedDict
 from core.module import StatusVar, Connector, ConfigOption
 from core.util.modules import get_main_dir, get_home_dir
 from core.util.helpers import natural_sort
+from core.util.network import netobtain
 from logic.generic_logic import GenericLogic
 from logic.pulsed.pulse_objects import PulseBlock, PulseBlockEnsemble, PulseSequence
 from logic.pulsed.pulse_objects import PulseObjectGenerator, PulseBlockElement
@@ -264,11 +265,11 @@ class SequenceGeneratorLogic(GenericLogic):
 
     @property
     def sampled_waveforms(self):
-        return self.pulsegenerator().get_waveform_names()
+        return netobtain(self.pulsegenerator().get_waveform_names())
 
     @property
     def sampled_sequences(self):
-        return self.pulsegenerator().get_sequence_names()
+        return netobtain(self.pulsegenerator().get_sequence_names())
 
     @property
     def analog_channels(self):


### PR DESCRIPTION
## Description
This resolves a bug when checking local and netref (rpyc) sets for equality.
Updated the interface documentation and dummy module as well.
Does not break in case of non-remote access if standard sets are used.

## Motivation and Context
Comparing a local set `a` with an rpyc netref set `b` by using `a == b` (or `b == a`) returns `False` even if the contents are the same (same hashes in both sets but iterator yields different ordering).
This happens despite the fact that `a.issubset(b) and a.issuperset(b)` or `b.issubset(a) and b.issuperset(a)` both return `True` (equality).
Since the only difference is the element order when iterating over both sets I assume this is a bug in the implementation of the equality operator in cpython. 
rpyc does not overwrite any equality checks but just creates a weakref to the corresponding methods.

## How Has This Been Tested?
Dummy Win8.1 x64
Experimental Setup Win8.1 x64 with Keysight AWG

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
