### PR TITLE
Underscore case in process interfaces

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -28,7 +28,8 @@ Purely for displaying purposes; raw data is not affected by this filter.
 * Updated powermeter PM100D module to add ProcessInterface and wavelength support
 * Added two interfuses for interfaces process value and process control to modify the values based
 on an interpolated function
-* 
+* Changed ProcessInterface and ProcessControlInterface to use underscore case instead of CamelCase
+*
 
 Config changes:
 

--- a/hardware/influx_data_client.py
+++ b/hardware/influx_data_client.py
@@ -69,13 +69,13 @@ class InfluxDataClient(Base, ProcessInterface):
         """ Connect to Influx database """
         self.conn = InfluxDBClient(self.host, self.port, self.user, self.pw, self.dbname)
 
-    def getProcessValue(self):
+    def get_process_value(self):
         """ Return a measured value """
         q = 'SELECT last({0}) FROM {1} WHERE (time > now() - 10m AND {2})'.format(self.field, self.series, self.cr)
         res = self.conn.query(q)
         return list(res[('{0}'.format(self.series), None)])[0]['last']
 
-    def getProcessUnit(self):
+    def get_process_unit(self):
         """ Return the unit that the value is measured in
 
             @return (str, str): a tuple of ('abreviation', 'full unit name')

--- a/hardware/pi_pwm.py
+++ b/hardware/pi_pwm.py
@@ -134,7 +134,7 @@ class PiPWM(Base, ProcessControlInterface):
             GPIO.output(self.inbpin, True)
         self.p.ChangeDutyCycle(abs(duty))
 
-    def setControlValue(self, value):
+    def set_control_value(self, value):
         """ Set control value for this controller.
 
             @param float value: control value, in this case duty cycle in percent
@@ -142,21 +142,21 @@ class PiPWM(Base, ProcessControlInterface):
         with self.threadlock:
             self.changeDutyCycle(value)
 
-    def getControlValue(self):
+    def get_control_value(self):
         """ Get control value for this controller.
 
             @return float: control value, in this case duty cycle in percent
         """
         return self.dutycycle
 
-    def getControlUnit(self):
+    def get_control_unit(self):
         """ Get unit for control value.
 
             @return tuple(str, str): short and text form of unit
         """
         return '%', 'percent'
 
-    def getControlLimits(self):
+    def get_control_limit(self):
         """ Get minimum and maxuimum value for control value.
 
             @return tuple(float, float): min and max control value
@@ -173,7 +173,7 @@ class PiPWMHalf(PiPWM):
         #locking for thread safety
         self.threadlock = Mutex()
 
-    def getControlLimits(self):
+    def get_control_limit(self):
         """ Get minimum and maxuimum value for control value.
 
             @return tuple(float, float): min and max control value

--- a/hardware/power_supply/Keysight_E3631A.py
+++ b/hardware/power_supply/Keysight_E3631A.py
@@ -80,32 +80,32 @@ class E3631A(Base, ProcessControlInterface):
         """ Function to query hardware"""
         return self._inst.query(cmd)
 
-    def setControlValue(self, value):
+    def set_control_value(self, value):
         """ Set control value, here heating power.
 
             @param flaot value: control value
         """
-        mini, maxi = self.getControlLimits()
+        mini, maxi = self.get_control_limit()
         if mini <= value <= maxi:
             self._write("VOLT {}".format(value))
         else:
             self.log.error('Voltage value {} out of range'.format(value))
 
-    def getControlValue(self):
+    def get_control_value(self):
         """ Get current control value, here heating power
 
             @return float: current control value
         """
         return float(self._query("VOLT?").split('\r')[0])
 
-    def getControlUnit(self):
+    def get_control_unit(self):
         """ Get unit of control value.
 
             @return tuple(str): short and text unit of control value
         """
         return 'V', 'Volt'
 
-    def getControlLimits(self):
+    def get_control_limit(self):
         """ Get minimum and maximum of control value.
 
             @return tuple(float, float): minimum and maximum of control value

--- a/hardware/powermeter/PM100D.py
+++ b/hardware/powermeter/PM100D.py
@@ -78,11 +78,11 @@ class PM100D(Base, SimpleDataInterface, ProcessInterface):
         """ Return the power read from the ThorlabsPM100 package """
         return self._power_meter.read
 
-    def getProcessValue(self):
+    def get_process_value(self):
         """ Return a measured value """
         return self.get_power()
 
-    def getProcessUnit(self):
+    def get_process_unit(self):
         """ Return the unit that hte value is measured in as a tuple of ('abreviation', 'full unit name') """
         return ('W', 'watt')
 

--- a/hardware/process_dummy.py
+++ b/hardware/process_dummy.py
@@ -53,42 +53,42 @@ class ProcessDummy(Base, ProcessInterface, ProcessControlInterface):
         """
         pass
 
-    def getProcessValue(self):
+    def get_process_value(self):
         """ Process value, here temperature.
 
             @return float: process value
         """
         return self.temperature
 
-    def getProcessUnit(self):
+    def get_process_unit(self):
         """ Process unit, here kelvin.
 
             @return float: process unit
         """
         return 'K', 'kelvin'
 
-    def setControlValue(self, value):
+    def set_control_value(self, value):
         """ Set control value, here heating power.
 
             @param flaot value: control value
         """
         self.pwmpower = value
 
-    def getControlValue(self):
+    def get_control_value(self):
         """ Get current control value, here heating power
 
             @return float: current control value
         """
         return self.pwmpower
 
-    def getControlUnit(self):
+    def get_control_unit(self):
         """ Get unit of control value.
 
             @return tuple(str): short and text unit of control value
         """
         return '%', 'percent'
 
-    def getControlLimits(self):
+    def get_control_limit(self):
         """ Get minimum and maximum of control value.
 
             @return tuple(float, float): minimum and maximum of control value

--- a/hardware/tsys01_spi.py
+++ b/hardware/tsys01_spi.py
@@ -154,7 +154,7 @@ class TSYS01SPI(Base, ProcessInterface):
         """
         return 273.15 + self.temperatureCelsius(adcValue)
 
-    def getProcessValue(self):
+    def get_process_value(self):
         """ Read ADC and return emperature in Kelvin.
 
             @return float: current temperature in Kelvin
@@ -163,7 +163,7 @@ class TSYS01SPI(Base, ProcessInterface):
             self.startADC()
             return self.temperatureKelvin(self.readADC())
 
-    def getProcessUnit(self):
+    def get_process_unit(self):
         """ Return Process unit, here Kelvin.
 
             @return tuple(str, str): short and text form of process unit

--- a/interface/process_control_interface.py
+++ b/interface/process_control_interface.py
@@ -33,22 +33,22 @@ class ProcessControlInterface(metaclass=InterfaceMetaclass):
     _modclass = 'interface'
 
     @abc.abstractmethod
-    def setControlValue(self, value):
+    def set_control_value(self, value):
         """ Set the value of the controlled process variable """
         pass
 
     @abc.abstractmethod
-    def getControlValue(self):
+    def get_control_value(self):
         """ Get the value of the controlled process variable """
         pass
 
     @abc.abstractmethod
-    def getControlUnit(self):
+    def get_control_unit(self):
         """ Return the unit that the value is set in as a tuple of ('abreviation', 'full unit name') """
         pass
 
     @abc.abstractmethod
-    def getControlLimits(self):
+    def get_control_limit(self):
         """ Return limits within which the controlled value can be set as a tuple of (low limit, high limit)
         """
         pass

--- a/interface/process_interface.py
+++ b/interface/process_interface.py
@@ -33,11 +33,11 @@ class ProcessInterface(metaclass=InterfaceMetaclass):
     _modclass = 'interface'
 
     @abc.abstractmethod
-    def getProcessValue(self):
+    def get_process_value(self):
         """ Return a measured value """
         pass
 
     @abc.abstractmethod
-    def getProcessUnit(self):
+    def get_process_unit(self):
         """ Return the unit that hte value is measured in as a tuple of ('abreviation', 'full unit name') """
         pass

--- a/logic/interfuse/process_control_modifier.py
+++ b/logic/interfuse/process_control_modifier.py
@@ -93,41 +93,41 @@ class ProcessControlModifier(GenericLogic, ProcessControlInterface):
             self._interpolated_function = interp1d(self._calibration[:, 0], self._calibration[:, 1])
             self._interpolated_function_reversed = interp1d(self._calibration[:, 1], self._calibration[:, 0])
         if self._last_control_value is not None:
-            self.setControlValue(self._last_control_value)
+            self.set_control_value(self._last_control_value)
 
     def reset_to_identity(self):
         """ Reset the calibration data to use identity """
         self._calibration = None
         self.update_calibration()
 
-    def getControlValue(self):
+    def get_control_value(self):
         """ Return the original control value
         """
         if self._interpolated_function_reversed is not None:
-            return self._interpolated_function_reversed(self._hardware.getControlValue())
+            return self._interpolated_function_reversed(self._hardware.get_control_value())
         else:
             self.log.error('No calibration was found, please set the control value modifier data first.')
 
-    def setControlValue(self, value):
+    def set_control_value(self, value):
         """ Set the control value modified
         """
         if self._interpolated_function is not None:
-            self._hardware.setControlValue(self._interpolated_function(value))
+            self._hardware.set_control_value(self._interpolated_function(value))
         else:
             self.log.error('No calibration was found, please set the control value modifier data first.')
 
-    def getControlUnit(self):
+    def get_control_unit(self):
         """ Return the process unit
         """
         if self._new_unit is not None:
             return self._new_unit
         else:
-            return self._hardware.getControlUnit()
+            return self._hardware.get_control_unit()
 
-    def getControlLimits(self):
+    def get_control_limit(self):
         """ Return limits within which the controlled value can be set as a tuple of (low limit, high limit)
         """
-        mini, maxi = self._hardware.getControlLimits()
+        mini, maxi = self._hardware.get_control_limit()
         mini = float(self._interpolated_function_reversed(mini))
         maxi = float(self._interpolated_function_reversed(maxi))
         return mini, maxi

--- a/logic/interfuse/process_value_modifier.py
+++ b/logic/interfuse/process_value_modifier.py
@@ -98,20 +98,20 @@ class ProcessValueModifier(GenericLogic, ProcessInterface):
         self._calibration = None
         self.update_calibration()
 
-    def getProcessValue(self):
+    def get_process_value(self):
         """ Return the process value modified
         """
         if self._interpolated_function is not None:
-            return float(self._interpolated_function(self._hardware.getProcessValue()))
+            return float(self._interpolated_function(self._hardware.get_process_value()))
         else:
             self.log.error('No calibration was found, please set the process value modifier data first.')
             return 0
 
-    def getProcessUnit(self):
+    def get_process_unit(self):
         """ Return the process unit
         """
         if self._new_unit is not None:
             return self._new_unit
         else:
-            return self._hardware.getProcessUnit()
+            return self._hardware.get_process_unit()
 

--- a/logic/software_pid_controller.py
+++ b/logic/software_pid_controller.py
@@ -71,14 +71,14 @@ class SoftPIDController(GenericLogic, PIDControllerInterface):
         self._control = self.control()
 
         self.previousdelta = 0
-        self.cv = self._control.getControlValue()
+        self.cv = self._control.get_control_value()
 
         self.timer = QtCore.QTimer()
         self.timer.setSingleShot(True)
         self.timer.setInterval(self.timestep)
 
         self.timer.timeout.connect(self._calcNextStep, QtCore.Qt.QueuedConnection)
-        self.sigNewValue.connect(self._control.setControlValue)
+        self.sigNewValue.connect(self._control.set_control_value)
 
         self.history = np.zeros([3, 5])
         self.savingState = False
@@ -100,7 +100,7 @@ class SoftPIDController(GenericLogic, PIDControllerInterface):
              The D term is NOT low-pass filtered.
              This function should be called once every TS seconds.
         """
-        self.pv = self._process.getProcessValue()
+        self.pv = self._process.get_process_value()
 
         if self.countdown > 0:
             self.countdown -= 1
@@ -123,7 +123,7 @@ class SoftPIDController(GenericLogic, PIDControllerInterface):
             self.previousdelta = delta
 
             ## limit contol output to maximum permissible limits
-            limits = self._control.getControlLimits()
+            limits = self._control.get_control_limit()
             if self.cv > limits[1]:
                 self.cv = limits[1]
             if self.cv < limits[0]:
@@ -136,7 +136,7 @@ class SoftPIDController(GenericLogic, PIDControllerInterface):
             self.sigNewValue.emit(self.cv)
         else:
             self.cv = self.manualvalue
-            limits = self._control.getControlLimits()
+            limits = self._control.get_control_limit()
             if self.cv > limits[1]:
                 self.cv = limits[1]
             if self.cv < limits[0]:
@@ -244,7 +244,7 @@ class SoftPIDController(GenericLogic, PIDControllerInterface):
             @param float manualvalue: control value for manual mode of controller
         """
         self.manualvalue = manualvalue
-        limits = self._control.getControlLimits()
+        limits = self._control.get_control_limit()
         if self.manualvalue > limits[1]:
             self.manualvalue = limits[1]
         if self.manualvalue < limits[0]:
@@ -272,7 +272,7 @@ class SoftPIDController(GenericLogic, PIDControllerInterface):
 
             @return list(float): (minimum, maximum) values of the control actuator
         """
-        return self._control.getControlLimits()
+        return self._control.get_control_limit()
 
     def set_control_limits(self, limits):
         """ Set the minimum and maximum value of the control actuator.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I've use CTRL+R to change all the function from ProcessInterface and ProcessControlInterface from CamelCase to Qudi's principal convention

## Motivation and Context
As mention in PR #519, this change needed to be done to respect Qudi's convention. 
Few modules actually use this interface so it's still a minor change. Maybe an announcement is still required ? I let the maintainers decide how to proceed.

## How Has This Been Tested?
I've checked that the Load all module is not screaming at me. (it is but not because of this change)

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
