### PR TITLE
Optional connectors

### DIFF
--- a/config/example/default.cfg
+++ b/config/example/default.cfg
@@ -267,7 +267,7 @@ logic:
         connect:
             spectrometer: 'myspectrometer'
             savelogic: 'savelogic'
-            odmrlogic: 'odmrlogic'
+            odmrlogic: 'odmrlogic' # optional
             fitlogic: 'fitlogic'
 
     magnet_logic:

--- a/core/manager.py
+++ b/core/manager.py
@@ -731,7 +731,7 @@ class Manager(QtCore.QObject):
         # check that all connectors are connected
         for c, v in self.tree['loaded'][base][mkey].connectors.items():
             # new-style connector
-            if isinstance(v, Connector) and v.obj is None:
+            if isinstance(v, Connector) and v.obj is None and not v.optional:
                 logger.error('Connector {0} of module {1}.{2} is not '
                              'connected. Connection not complete.'.format(
                                  c, base, mkey))

--- a/core/manager.py
+++ b/core/manager.py
@@ -731,7 +731,7 @@ class Manager(QtCore.QObject):
         # check that all connectors are connected
         for c, v in self.tree['loaded'][base][mkey].connectors.items():
             # new-style connector
-            if isinstance(v, Connector) and v.obj is None and not v.optional:
+            if isinstance(v, Connector) and not v.is_connected and not v.optional:
                 logger.error('Connector {0} of module {1}.{2} is not '
                              'connected. Connection not complete.'.format(
                                  c, base, mkey))

--- a/core/module.py
+++ b/core/module.py
@@ -188,6 +188,10 @@ class Connector:
                 'Connector {0} (interface {1}) is not connected.'
                 ''.format(self.name, self.interface))
         return self.obj
+    
+    @property
+    def is_connected(self):
+        return self.obj is not None
 
     def connect(self, target):
         """ Check if target is connectable this connector and connect."""

--- a/core/module.py
+++ b/core/module.py
@@ -170,18 +170,20 @@ class ConfigOption:
 class Connector:
     """ A connector where another module can be connected """
 
-    def __init__(self, *, name=None, interface=None):
+    def __init__(self, *, name=None, interface=None, optional=False):
         """
             @param name: name of the connector
             @param interface: interface class or name of the interface for this connector
+            @param (bool) optional: the optionality of the connector
         """
         self.name = name
         self.interface = interface
         self.obj = None
+        self.optional = optional
 
     def __call__(self):
         """ Return reference to the module that this connector is connected to. """
-        if self.obj is None:
+        if self.obj is None and not self.optional:
             raise Exception(
                 'Connector {0} (interface {1}) is not connected.'
                 ''.format(self.name, self.interface))
@@ -208,7 +210,8 @@ class Connector:
 
     def copy(self, **kwargs):
         """ Create a new instance of Connector with copied values and update """
-        newargs = {'name': copy.copy(self.name), 'interface': copy.copy(self.interface)}
+        newargs = {'name': copy.copy(self.name), 'interface': copy.copy(self.interface),
+                   'optional': copy.copy(self.optional)}
         newargs.update(kwargs)
         return Connector(**newargs)
 

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -29,6 +29,7 @@ Purely for displaying purposes; raw data is not affected by this filter.
 * Added two interfuses for interfaces process value and process control to modify the values based
 on an interpolated function
 * Changed ProcessInterface and ProcessControlInterface to use underscore case instead of CamelCase
+* Added an optional parameter to connectors so that dependencies can be optional
 *
 
 Config changes:

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -30,6 +30,7 @@ Purely for displaying purposes; raw data is not affected by this filter.
 on an interpolated function
 * Changed ProcessInterface and ProcessControlInterface to use underscore case instead of CamelCase
 * Added an optional parameter to connectors so that dependencies can be optional
+* Made ODMR logic an optional dependency in SpectrumLogic
 *
 
 Config changes:

--- a/documentation/how_to_use_config_file.md
+++ b/documentation/how_to_use_config_file.md
@@ -116,10 +116,10 @@ mention it
     <optional_module> = Connector(interface='<InterfaceForTheOptionalConnector>', optional=True)
 ```
 
-The logic module can then test if the module is specified by checking whether the reference is *None*
+The logic module can then test if the module is connected by checking the is_connected property
 
 ```python
-if self.<optional_module>() is not None:
+if self.<optional_module>.is_connected:
     self.<optional_module>().do_stuff()
 ```
 

--- a/documentation/how_to_use_config_file.md
+++ b/documentation/how_to_use_config_file.md
@@ -105,3 +105,21 @@ A reference to the connected module can then be obtained at runtime by just call
 <antother connected module> = self.<another connector name>()
 ```
 
+### Optional connectors
+
+A connector can be made optional so that no error is created if the configuration file does not 
+mention it
+
+```python
+    <mandatory_module> = Connector(interface='<InterfaceForThisConnector>')
+    <another mandatory_module> = Connector(interface='<InterfaceForTheOtherConnector>', optional=False)
+    <optional_module> = Connector(interface='<InterfaceForTheOptionalConnector>', optional=True)
+```
+
+The logic module can then test if the module is specified by checking whether the reference is *None*
+
+```python
+if self.<optional_module>() is not None:
+    self.<optional_module>().do_stuff()
+```
+

--- a/logic/spectrum.py
+++ b/logic/spectrum.py
@@ -40,7 +40,7 @@ class SpectrumLogic(GenericLogic):
 
     # declare connectors
     spectrometer = Connector(interface='SpectrometerInterface')
-    odmrlogic = Connector(interface='ODMRLogic')
+    odmrlogic = Connector(interface='ODMRLogic', optional=True)
     savelogic = Connector(interface='SaveLogic')
     fitlogic = Connector(interface='FitLogic')
 
@@ -247,7 +247,8 @@ class SpectrumLogic(GenericLogic):
     def toggle_modulation(self, on):
         """ Toggle the modulation.
         """
-
+        if self._odmr_logic is None:
+            return
         if on:
             self._odmr_logic.mw_cw_on()
         elif not on:

--- a/logic/spectrum.py
+++ b/logic/spectrum.py
@@ -33,6 +33,16 @@ from logic.generic_logic import GenericLogic
 class SpectrumLogic(GenericLogic):
 
     """This logic module gathers data from the spectrometer.
+
+    Demo config:
+
+    spectrumlogic:
+        module.Class: 'spectrum.SpectrumLogic'
+        connect:
+            spectrometer: 'myspectrometer'
+            savelogic: 'savelogic'
+            odmrlogic: 'odmrlogic' # optional
+            fitlogic: 'fitlogic'
     """
 
     _modclass = 'spectrumlogic'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I've added an optional feature to the Connector object so that some logic module may support optional dependencies.
I've shown an example by using in on the ODMRLogic dependency of the SpectrumLogic module.

## Motivation and Context
Some Qudi logic modules ask for other modules, sometime only for very particular features. This creates a need for adding a lot  of dummy modules in the configuration file, just to be able to use the basic functionalities.
For example the SpectrumLogic require and ODMRLogic connector. This connector is useful because it adds some nice features to the spectrum logic, but if one only want to use the spectrum feature, one has to add the odmrlogic and all its specific dependencies : odmrcounter, microwave1, taskrunner, etc.
With an optional parameter, the logic (and even GUI) can be smart and use (show) the feature that are relevant in the user's config.

## How Has This Been Tested?
I've played with it for 5 minutes.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
