### PR TITLE
Bugfix for gated fastcounter

### DIFF
--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -186,6 +186,9 @@ class PulsedMeasurementLogic(GenericLogic):
         if self.__fast_counter_record_length <= 0:
             self.__fast_counter_record_length = 3e-6
         self.fast_counter_off()
+        # Set default number of gates to a reasonable number for gated counters (>0 if gated)
+        if self.fastcounter().is_gated() and self.__fast_counter_gates < 1:
+            self.__fast_counter_gates = max(1, self._number_of_lasers)
         self.set_fast_counter_settings()
 
         # Check and configure external microwave


### PR DESCRIPTION
## Description
Bugfix in activation of `PulsedMeasurementLogic` when using gated fast counting.

## Motivation and Context
First time (no AppStatus) loading of `PulsedMeasurementLogic` with a gated fastcounter module caused an error because of a mismatch in number of gates in logic and hardware.
This has happened due to a unreasonable default value (0) for number of gates that the logic tries to set in the hardware module upon activation.
Usually the hardware module should return a reasonable value (>0) but most fast counter modules simply return the given parameters again without actually reading the set value from the device.

## How Has This Been Tested?
Win8.1 x64 dummy and on IQO setup 6

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
