### PR TITLE
Fixed unintended constraints on ScienDSpinoxes

### DIFF
--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -2246,9 +2246,14 @@ class PulsedMeasurementGui(GUIBase):
         # set boundaries
         self._pa.ana_param_num_laser_pulse_SpinBox.setMinimum(1)
         self._pa.ana_param_record_length_DoubleSpinBox.setMinimum(0)
+        self._pa.ana_param_record_length_DoubleSpinBox.setMaximum(np.inf)
         self._pa.time_param_ana_periode_DoubleSpinBox.setMinimum(0)
         self._pa.time_param_ana_periode_DoubleSpinBox.setMinimalStep(1)
         self._pa.ext_control_mw_freq_DoubleSpinBox.setMinimum(0)
+        self._pa.ana_param_x_axis_start_ScienDSpinBox.setMaximum(np.inf)
+        self._pa.ana_param_x_axis_start_ScienDSpinBox.setMinimum(-np.inf)
+        self._pa.ana_param_x_axis_inc_ScienDSpinBox.setMaximum(np.inf)
+        self._pa.ana_param_x_axis_inc_ScienDSpinBox.setMinimum(-np.inf)
 
         # apply hardware constraints
         self._pa_apply_hardware_constraints()


### PR DESCRIPTION
## Description
Fixed unintended constraints on the ScienDSpinboxes in pulsed measurement GUI analysis tab.

## Motivation and Context
These constraints were imposed on the GUI by the qt designer

## How Has This Been Tested?
dummy win8.1 x64

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
