### PR TITLE
Scaling of sampling functions

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -31,7 +31,8 @@ on an interpolated function
 * Changed ProcessInterface and ProcessControlInterface to use underscore case instead of CamelCase
 * Added an optional parameter to connectors so that dependencies can be optional
 * Made ODMR logic an optional dependency in SpectrumLogic
-*
+* Removed additional scaling from sampling functions. They now return samples as as expected. 
+The entire normalization to pulse generator analog voltage range (Vpp) is done during sampling.
 
 Config changes:
 

--- a/interface/pulser_interface.py
+++ b/interface/pulser_interface.py
@@ -428,7 +428,7 @@ class PulserInterface(metaclass=InterfaceMetaclass):
         @param str name: the name of the waveform to be created/append to
         @param dict analog_samples: keys are the generic analog channel names (i.e. 'a_ch1') and
                                     values are 1D numpy arrays of type float32 containing the
-                                    voltage samples.
+                                    voltage samples normalized to half Vpp (between -1 and 1).
         @param dict digital_samples: keys are the generic digital channel names (i.e. 'd_ch1') and
                                      values are 1D numpy arrays of type bool containing the marker
                                      states.

--- a/logic/pulsed/sampling_function_defs/basic_sampling_functions.py
+++ b/logic/pulsed/sampling_function_defs/basic_sampling_functions.py
@@ -93,9 +93,7 @@ class Sin(SamplingBase):
 
     def get_samples(self, time_array):
         phase_rad = np.pi * self.phase / 180
-        # conversion for AWG to actually output the specified voltage
-        amp_conv = 2 * self.amplitude
-        samples_arr = self._get_sine(time_array, amp_conv, self.frequency, phase_rad)
+        samples_arr = self._get_sine(time_array, self.amplitude, self.frequency, phase_rad)
         return samples_arr
 
 
@@ -149,15 +147,11 @@ class DoubleSinSum(SamplingBase):
     def get_samples(self, time_array):
         # First sine wave
         phase_rad = np.pi * self.phase_1 / 180
-        # conversion for AWG to actually output the specified voltage
-        amp_conv = 2 * self.amplitude_1
-        samples_arr = self._get_sine(time_array, amp_conv, self.frequency_1, phase_rad)
+        samples_arr = self._get_sine(time_array, self.amplitude_1, self.frequency_1, phase_rad)
 
         # Second sine wave (add on first sine)
         phase_rad = np.pi * self.phase_2 / 180
-        # conversion for AWG to actually output the specified voltage
-        amp_conv = 2 * self.amplitude_2
-        samples_arr += self._get_sine(time_array, amp_conv, self.frequency_2, phase_rad)
+        samples_arr += self._get_sine(time_array, self.amplitude_2, self.frequency_2, phase_rad)
         return samples_arr
 
 
@@ -211,15 +205,11 @@ class DoubleSinProduct(SamplingBase):
     def get_samples(self, time_array):
         # First sine wave
         phase_rad = np.pi * self.phase_1 / 180
-        # conversion for AWG to actually output the specified voltage
-        amp_conv = 2 * self.amplitude_1
-        samples_arr = self._get_sine(time_array, amp_conv, self.frequency_1, phase_rad)
+        samples_arr = self._get_sine(time_array, self.amplitude_1, self.frequency_1, phase_rad)
 
         # Second sine wave (add on first sine)
         phase_rad = np.pi * self.phase_2 / 180
-        # conversion for AWG to actually output the specified voltage
-        amp_conv = 2 * self.amplitude_2
-        samples_arr *= self._get_sine(time_array, amp_conv, self.frequency_2, phase_rad)
+        samples_arr *= self._get_sine(time_array, self.amplitude_2, self.frequency_2, phase_rad)
         return samples_arr
 
 
@@ -291,21 +281,15 @@ class TripleSinSum(SamplingBase):
     def get_samples(self, time_array):
         # First sine wave
         phase_rad = np.pi * self.phase_1 / 180
-        # conversion for AWG to actually output the specified voltage
-        amp_conv = 2 * self.amplitude_1
-        samples_arr = self._get_sine(time_array, amp_conv, self.frequency_1, phase_rad)
+        samples_arr = self._get_sine(time_array, self.amplitude_1, self.frequency_1, phase_rad)
 
         # Second sine wave (add on first sine)
         phase_rad = np.pi * self.phase_2 / 180
-        # conversion for AWG to actually output the specified voltage
-        amp_conv = 2 * self.amplitude_2
-        samples_arr += self._get_sine(time_array, amp_conv, self.frequency_2, phase_rad)
+        samples_arr += self._get_sine(time_array, self.amplitude_2, self.frequency_2, phase_rad)
 
         # Second sine wave (add on sum of first and second)
         phase_rad = np.pi * self.phase_3 / 180
-        # conversion for AWG to actually output the specified voltage
-        amp_conv = 2 * self.amplitude_3
-        samples_arr += self._get_sine(time_array, amp_conv, self.frequency_3, phase_rad)
+        samples_arr += self._get_sine(time_array, self.amplitude_3, self.frequency_3, phase_rad)
         return samples_arr
 
 
@@ -377,21 +361,15 @@ class TripleSinProduct(SamplingBase):
     def get_samples(self, time_array):
         # First sine wave
         phase_rad = np.pi * self.phase_1 / 180
-        # conversion for AWG to actually output the specified voltage
-        amp_conv = 2 * self.amplitude_1
-        samples_arr = self._get_sine(time_array, amp_conv, self.frequency_1, phase_rad)
+        samples_arr = self._get_sine(time_array, self.amplitude_1, self.frequency_1, phase_rad)
 
         # Second sine wave (add on first sine)
         phase_rad = np.pi * self.phase_2 / 180
-        # conversion for AWG to actually output the specified voltage
-        amp_conv = 2 * self.amplitude_2
-        samples_arr *= self._get_sine(time_array, amp_conv, self.frequency_2, phase_rad)
+        samples_arr *= self._get_sine(time_array, self.amplitude_2, self.frequency_2, phase_rad)
 
         # Second sine wave (add on sum of first and second)
         phase_rad = np.pi * self.phase_3 / 180
-        # conversion for AWG to actually output the specified voltage
-        amp_conv = 2 * self.amplitude_3
-        samples_arr *= self._get_sine(time_array, amp_conv, self.frequency_3, phase_rad)
+        samples_arr *= self._get_sine(time_array, self.amplitude_3, self.frequency_3, phase_rad)
         return samples_arr
 
 
@@ -430,9 +408,7 @@ class Chirp(SamplingBase):
         phase_rad = np.deg2rad(self.phase)
         freq_diff = self.stop_freq - self.start_freq
         time_diff = time_array[-1] - time_array[0]
-        # conversion for AWG to actually output the specified voltage
-        amp_conv = 2 * self.amplitude
-        samples_arr = amp_conv * np.sin(2 * np.pi * time_array * (
+        samples_arr = self.amplitude * np.sin(2 * np.pi * time_array * (
                     self.start_freq + freq_diff * (
                         time_array - time_array[0]) / time_diff / 2) + phase_rad)
         return samples_arr

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1735,7 +1735,7 @@ class SequenceGeneratorLogic(GenericLogic):
                         for chnl in pulse_function:
                             analog_samples[chnl][array_write_index:array_write_index + samples_to_add] = pulse_function[
                                                                                                              chnl].get_samples(
-                                time_arr) / self.__analog_levels[0][chnl]
+                                time_arr) / (self.__analog_levels[0][chnl] / 2)
 
                         # Free memory
                         if pulse_function:


### PR DESCRIPTION
## Description
Normalization of the waveform sample data is now only performed in `sample_pulse_block_ensemble` just before feeding the data to the pulser hardware module.

All sampling functions return mathematically correct values now (as you would expect) and not something already scaled for AWGs.

## Motivation and Context
In the current master branch the values returned by sampling functions (Sine, DC, etc.) `get_samples` method were already scaled to twice the specified amplitude. This behavior is very counter intuitive since you expect e.g. to get a sine wave with the specified amplitude and not twice the amplitude.
Afterwards these values were divided by the pulser analog peak-to-peak amplitude in `sample_pulse_block_ensemble` to obtain values between -1 and 1 normalized to the peak-to-peak amplitude.

This normalization should only be performed at one centralized spot where you need it (namely `sample_pulse_block_ensemble`) and so this scaling was removed from `basic_sampling_functions.py`.
Instead of dividing by _Vpp_, the sampling function now divides by _Vpp_/2 instead.

This whole issue was a relic from a very early version of qudi and somehow slipped past "pulsed 3.0" revision unnoticed.

This PR will break custom sampling functions since they will now be scaled to half the amplitude than before. I would notify all users via the mailing list.
 
## How Has This Been Tested?
IQO Setup9 with _Tektronix AWG70002A_ on Win8.1 x64 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
