### PR TITLE
Made natural_sort helper function more robust

### DIFF
--- a/core/util/helpers.py
+++ b/core/util/helpers.py
@@ -210,6 +210,10 @@ def natural_sort(iterable):
     @param str[] iterable: Iterable with str items to sort
     @return list: sorted list of strings
     """
+    # If first element of iterable is not a string, fall back to simple sorted()
+    if len(iterable) == 0 or not isinstance(iterable[0], str):
+        return sorted(iterable)
+
     def conv(s):
         return int(s) if s.isdigit() else s
     return sorted(iterable, key=lambda key: [conv(i) for i in re.split(r'(\d+)', key)])


### PR DESCRIPTION
## Description
Made `natural_sort` helper function more robust by type checking for non-str type and falling back to plain `sorted()` in that case.

## Motivation and Context
`natural_sort` failed when handing over an array of scalars.

## How Has This Been Tested?
On dummy

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
