### PR TITLE
Fix prints in notebooks from threads

### DIFF
--- a/logic/jupyterkernel/helpers.py
+++ b/logic/jupyterkernel/helpers.py
@@ -29,6 +29,11 @@ distributed as part of this software.
 import sys
 import builtins
 from base64 import encodebytes
+import threading
+
+
+class ThreadFixer(threading.Thread):
+    notebook_thread = True
 
 
 class ExecutionResult:

--- a/logic/jupyterkernel/redirect.py
+++ b/logic/jupyterkernel/redirect.py
@@ -9,19 +9,30 @@ class _RedirectStream:
     """ A base class for a context manager to redirect streams from the sys module."""
     _stream = None
 
-    def __init__(self, new_target):
+    def __init__(self, new_target=None):
         self._new_target = new_target
         # We use a list of old targets to make this CM re-entrant
         self._old_targets = []
 
-    def __enter__(self):
+    def open(self, new_target):
+        self._new_target = new_target
         self._old_targets.append(getattr(sys, self._stream))
         setattr(sys, self._stream, self._new_target)
         return self._new_target
 
+    def close(self):
+        if len(self._old_targets) > 0:
+            setattr(sys, self._stream, self._old_targets.pop())
+            self._new_target.close()
+        return getattr(sys, self._stream)
+
+    def __enter__(self):
+        if self._new_target is None:
+            return getattr(sys, self._stream)
+        return self.open(self._new_target)
+
     def __exit__(self, exctype, excinst, exctb):
-        setattr(sys, self._stream, self._old_targets.pop())
-        self._new_target.close()
+        self.close()
 
 
 class RedirectedStdOut(_RedirectStream):


### PR DESCRIPTION
The redirect of the output generated by the cells of a jupyther is now global for the kernel and not local to the cell. The redirect therefore also catches any output generated by threads started in a notebook cell, even after the cell has long finished.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The redirect is set up at the start of the kernel and only cleaned up together with the kernel at deactivation. By default **all** output is redirected to a StringIO which then checks, if the output is coming from inside the notebook or from somewhere else. The notebook output is send back to the browser, while the rest is send on to the normal stdout (same for stderr).
To recognize the output from a notebook, the imported Thread class was extended by a marker, so that any Thread created inside a notebook will have this marker. This marker is than only added to the notebook scripts.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Creative people (me included) started using the jupyter notebooks for everything and created Threads inside notebooks. The prints of these could go missing, if the cell was already finished with the started thread still running (sometimes the output of these threads appeared in stdout instead of the notebook).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
running test notebooks with threads and fast prints on dummy config: Linux 5.1.8-1-MANJARO

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
