### PR TITLE
bug fix to forced sequence mode

### DIFF
--- a/hardware/pulser_dummy.py
+++ b/hardware/pulser_dummy.py
@@ -45,6 +45,7 @@ class PulserDummy(Base, PulserInterface):
     _modtype = 'hardware'
 
     activation_config = StatusVar(default=None)
+    force_sequence_option = ConfigOption('force_sequence_option', default=False)
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, **kwargs)
@@ -221,7 +222,7 @@ class PulserDummy(Base, PulserInterface):
         activation_config['config9'] = frozenset({'a_ch2', 'a_ch3'})
         constraints.activation_config = activation_config
 
-        constraints.sequence_option = SequenceOption.FORCED
+        constraints.sequence_option = SequenceOption.FORCED if self.force_sequence_option else SequenceOption.OPTIONAL
 
         return constraints
 

--- a/hardware/pulser_dummy.py
+++ b/hardware/pulser_dummy.py
@@ -221,7 +221,7 @@ class PulserDummy(Base, PulserInterface):
         activation_config['config9'] = frozenset({'a_ch2', 'a_ch3'})
         constraints.activation_config = activation_config
 
-        constraints.sequence_option = SequenceOption.OPTIONAL
+        constraints.sequence_option = SequenceOption.FORCED
 
         return constraints
 

--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1103,6 +1103,7 @@ class SequenceGeneratorLogic(GenericLogic):
                            ''.format(predefined_sequence_name))
             self.sigPredefinedSequenceGenerated.emit(None, False)
             raise
+
         # Save objects
         for block in blocks:
             self.save_block(block)
@@ -1111,9 +1112,11 @@ class SequenceGeneratorLogic(GenericLogic):
             self.save_ensemble(ensemble)
 
         if self.pulse_generator_constraints.sequence_option == SequenceOption.FORCED and len(sequences) < 1:
-            self.log.info('Adding default sequence for: {0:s}'.format(kwargs_dict.get('name')))
+            self.log.info('Adding default sequence for: {0:s}'.format(predefined_sequence_name))
             self._add_default_sequence(ensembles, sequences)
-            self.log.debug('New default PulseSequence is: {0:s} length {1:d}'.format(sequences[0].name, len(sequences)))
+            if len(sequences) > 0:
+                self.log.debug('New default PulseSequence is: {0:s} length {1:d}'
+                               ''.format(sequences[0].name, len(sequences)))
 
         for sequence in sequences:
             sequence.sampling_information = dict()


### PR DESCRIPTION
Small fix to only print a debug when the default sequence was successfully created. This bug was causing an additional error message, when the predefined function returned only empty lists.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
One can write predefined functions, that only return empty lists (so no waveforms at all). For these cases the load failed, because it assumed that the default sequence was successfully created. Now an if-clause catches this error.

As this is a bug fix to a new feature, I would leave it out of the changelog.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Linux 5.1.18-1-MANJARO on dummy config with different predefined functions not returning anything, some not even having a "name".

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
