### PR TITLE
Bugfixes for core

### DIFF
--- a/core/connector.py
+++ b/core/connector.py
@@ -64,6 +64,25 @@ class Connector:
                     return attr[self.interface]
                 else:
                     return attr
+
+            def __setattr__(*args):
+                return setattr(self.obj, args[1], args[2])
+
+            def __delattr__(*args):
+                return delattr(self.obj, args[1])
+
+            def __repr__(*args):
+                return repr(self.obj)
+
+            def __str__(*args):
+                return str(self.obj)
+
+            def __dir__(*args):
+                return dir(self.obj)
+
+            def __sizeof__(*args):
+                return self.obj.__sizeof__()
+
         return ConnectedInterfaceProxy()
 
     @property

--- a/core/qudikernel.py
+++ b/core/qudikernel.py
@@ -31,7 +31,10 @@ import tempfile
 
 import config
 
-from .parentpoller import ParentPollerUnix, ParentPollerWindows
+try:
+    from .parentpoller import ParentPollerUnix, ParentPollerWindows
+except ModuleNotFoundError:
+    from parentpoller import ParentPollerUnix, ParentPollerWindows
 
 rpyc.core.protocol.DEFAULT_CONFIG['allow_pickle'] = True
 


### PR DESCRIPTION
## Description
- Fixed `ModuleNotFoundError` upon installing qudikernel
- Fixed `ConnectedInterfaceProxy` class to wrap more magic methods

## Motivation and Context
When trying to install qudikernel from a command line, there was an `ModuleNotFoundError` for the _parentpoller_ module. Fixed that by a try-except-wrapped import.

The new `ConnectedInterfaceProxy` class in `Connector` was missing a wrapper to `__setattr__` which prevented connected modules to directly edit attributes. 

## How Has This Been Tested?
dummy

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
