### PR TITLE
fixed: ramsey from list now accepts tau lists given as strings 

### DIFF
--- a/core/util/helpers.py
+++ b/core/util/helpers.py
@@ -275,3 +275,32 @@ def in_range(value, lower_limit, upper_limit):
     if value < l_limit:
         return lower_limit
     return value
+
+
+def csv_2_list(csv_string, str_2_val=None):
+    """
+    Parse a list literal (with or without square brackets) given as string containing
+    comma-separated int or float values to a python list.
+    (blanks before and after commas are handled)
+
+    @param str csv_string: scalar number literals as strings separated by a single comma and any number
+                       of blanks. (brackets are ignored)
+                       Example: '[1e-6,2.5e6, 42]' or '1e-6, 2e-6,   42'
+    @param function str_2_val: optional, function to use for casting substrings into single values.
+    @return list: list of float values. If optional str_2_val is given, type is invoked by this
+                  function.
+    """
+    if not isinstance(csv_string, str):
+        raise TypeError('string_2_list accepts only str type input.')
+
+    csv_string = csv_string.replace('[', '').replace(']', '')  # Remove square brackets
+    csv_string = csv_string.replace('(', '').replace(')', '')  # Remove round brackets
+    csv_string = csv_string.replace('{', '').replace('}', '')  # Remove curly brackets
+    csv_string = csv_string.strip().strip(',')  # Remove trailing/leading blanks and commas
+
+    # Cast each str value to float if no explicit cast function is given by parameter str_2_val.
+    if str_2_val is None:
+        csv_list = [float(val_str) for val_str in csv_string.split(',')]
+    else:
+        csv_list = [str_2_val(val_str.strip()) for val_str in csv_string.split(',')]
+    return csv_list

--- a/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
+++ b/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
@@ -335,17 +335,38 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         created_ensembles.append(block_ensemble)
         return created_blocks, created_ensembles, created_sequences
 
-    def generate_ramsey_from_list(self, name='ramsey', tau_list='[1e-6, 2e-6]', alternating = True):
+    def generate_ramsey_from_list(self, name='ramsey', tau_list='[1e-6, 2e-6]', alternating=True):
+        """
         """
 
-        """
+        def string_2_list(save_str):
+            """
+            Cast a list given as string to a python list.
+            Do nothing and return input unaltered, if not a string.
+            :param save_str: Eg. '[1e-6, 2e-6]'. Don't put evil strings from untrusted sources.
+            :return:
+            """
+            # ast is not completely safe (better than eval) and may crash the interpreter on malicious input
+            import ast
+
+            if type(save_str) is not str:
+                return save_str
+
+            val_list = ast.literal_eval(save_str)
+            # if list of strings, strip whitespaces
+            try:
+                val_list = [str.strip() for str in val_list]
+            except AttributeError:
+                pass
+
+            return val_list
 
         created_blocks = list()
         created_ensembles = list()
         created_sequences = list()
 
         # get tau array for measurement ticks
-        tau_array = [n.strip() for n in tau_list]
+        tau_array = string_2_list(tau_list)
 
         waiting_element = self._get_idle_element(length=self.wait_time,
                                                  increment=0)

--- a/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
+++ b/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
@@ -23,6 +23,7 @@ top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi
 import numpy as np
 from logic.pulsed.pulse_objects import PulseBlock, PulseBlockEnsemble, PulseSequence
 from logic.pulsed.pulse_objects import PredefinedGeneratorBase
+from core.util.helpers import csv_2_list
 
 """
 General Pulse Creation Procedure:
@@ -338,30 +339,13 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
     def generate_ramsey_from_list(self, name='ramsey', tau_list='[1e-6, 2e-6]', alternating=True):
         """
         """
-
-        def string_2_list(csv_string):
-            """
-            Cast a list given as string containing comma-separated float values to a python list.
-            (blanks before and after commas are handled)
-            :param csv_string: Eg. '[1e-6, 2e-6]'. Square brackets are optional.
-            :return: list of float values
-            """
-
-            if not isinstance(csv_string, str):
-                raise TypeError('string_2_list accepts only str type input.')
-            csv_string = csv_string.replace("[", "")
-            csv_string = csv_string.replace("]", "")
-            csv_string = csv_string.strip().strip(',')
-
-            return [float(num_str) for num_str in csv_string.split(',')]
-
         created_blocks = list()
         created_ensembles = list()
         created_sequences = list()
 
         # get tau array for measurement ticks
         try:
-            tau_array = string_2_list(tau_list)
+            tau_array = csv_2_list(tau_list)
         except TypeError:
             tau_array = tau_list
 

--- a/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
+++ b/logic/pulsed/predefined_generate_methods/basic_predefined_methods.py
@@ -339,34 +339,31 @@ class BasicPredefinedGenerator(PredefinedGeneratorBase):
         """
         """
 
-        def string_2_list(save_str):
+        def string_2_list(csv_string):
             """
-            Cast a list given as string to a python list.
-            Do nothing and return input unaltered, if not a string.
-            :param save_str: Eg. '[1e-6, 2e-6]'. Don't put evil strings from untrusted sources.
-            :return:
+            Cast a list given as string containing comma-separated float values to a python list.
+            (blanks before and after commas are handled)
+            :param csv_string: Eg. '[1e-6, 2e-6]'. Square brackets are optional.
+            :return: list of float values
             """
-            # ast is not completely safe (better than eval) and may crash the interpreter on malicious input
-            import ast
 
-            if type(save_str) is not str:
-                return save_str
+            if not isinstance(csv_string, str):
+                raise TypeError('string_2_list accepts only str type input.')
+            csv_string = csv_string.replace("[", "")
+            csv_string = csv_string.replace("]", "")
+            csv_string = csv_string.strip().strip(',')
 
-            val_list = ast.literal_eval(save_str)
-            # if list of strings, strip whitespaces
-            try:
-                val_list = [str.strip() for str in val_list]
-            except AttributeError:
-                pass
-
-            return val_list
+            return [float(num_str) for num_str in csv_string.split(',')]
 
         created_blocks = list()
         created_ensembles = list()
         created_sequences = list()
 
         # get tau array for measurement ticks
-        tau_array = string_2_list(tau_list)
+        try:
+            tau_array = string_2_list(tau_list)
+        except TypeError:
+            tau_array = tau_list
 
         waiting_element = self._get_idle_element(length=self.wait_time,
                                                  increment=0)


### PR DESCRIPTION
## Description
Fix generation error in Ramsey from list in the predefined methods.

## Motivation and Context
So far generation only worked when providing a real Python list, eg. from a jupyter notebook. Now it works also from gui. 

## How Has This Been Tested?
Sequence generation from gui. Works on setup3 & dummy.

## Screenshots (only if appropriate, delete if not):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
