### PR TITLE
Fixed a bug with missing 'name' argument in predefined methods.

### DIFF
--- a/logic/pulsed/sequence_generator_logic.py
+++ b/logic/pulsed/sequence_generator_logic.py
@@ -1088,6 +1088,12 @@ class SequenceGeneratorLogic(GenericLogic):
         """
         gen_method = self.generate_methods[predefined_sequence_name]
         gen_params = self.generate_method_params[predefined_sequence_name]
+        if 'name' not in gen_params:
+            self.log.error('Mandatory generation parameter "name" not found in generate method '
+                           '"{0}" arguments. Generation failed.'.format(predefined_sequence_name))
+            self.sigPredefinedSequenceGenerated.emit(None, False)
+            return
+
         # match parameters to method and throw out unwanted ones
         thrown_out_params = [param for param in kwargs_dict if param not in gen_params]
         for param in thrown_out_params:
@@ -1095,13 +1101,14 @@ class SequenceGeneratorLogic(GenericLogic):
         if thrown_out_params:
             self.log.debug('Unused params during predefined sequence generation "{0}":\n'
                            '{1}'.format(predefined_sequence_name, thrown_out_params))
+
         try:
             blocks, ensembles, sequences = gen_method(**kwargs_dict)
         except:
-            self.log.error('Generation of predefined sequence "{0}" failed.'
-                           ''.format(predefined_sequence_name))
+            self.log.exception('Generation of predefined sequence "{0}" failed with exception:'
+                               ''.format(predefined_sequence_name))
             self.sigPredefinedSequenceGenerated.emit(None, False)
-            raise
+            return
 
         # Save objects
         for block in blocks:
@@ -1120,7 +1127,9 @@ class SequenceGeneratorLogic(GenericLogic):
         for sequence in sequences:
             sequence.sampling_information = dict()
             self.save_sequence(sequence)
-        self.sigPredefinedSequenceGenerated.emit(kwargs_dict.get('name'), len(sequences) > 0)
+
+        created_name = gen_params.get('name') if 'name' not in kwargs_dict else kwargs_dict['name']
+        self.sigPredefinedSequenceGenerated.emit(created_name, len(sequences) > 0)
         return
 
     def _add_default_sequence(self, ensembles, sequences):


### PR DESCRIPTION
## Description
Fixed a bug with missing 'name' argument in predefined methods.

## Motivation and Context
Trying to generate a predefined method but not handing over the keyword argument "name" caused the generation to fail clean but silent without error or warning.

## How Has This Been Tested?
dummy

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
