### PR TITLE
Optimizer only working with first counter channel

### DIFF
--- a/logic/optimizer_logic.py
+++ b/logic/optimizer_logic.py
@@ -385,7 +385,7 @@ class OptimizerLogic(GenericLogic):
     def _set_optimized_xy_from_fit(self):
         """Fit the completed xy optimizer scan and set the optimized xy position."""
         fit_x, fit_y = np.meshgrid(self._X_values, self._Y_values)
-        xy_fit_data = self.xy_refocus_image[:, :, 3].ravel()
+        xy_fit_data = self.xy_refocus_image[:, :, 3+self.opt_channel].ravel()
         axes = np.empty((len(self._X_values) * len(self._Y_values), 2))
         axes = (fit_x.flatten(), fit_y.flatten())
         result_2D_gaus = self._fit_logic.make_twoDgaussian_fit(


### PR DESCRIPTION
Just a small bug causing the channel selection in the confocal gui optimizer settings to be ignored by the optimizer logic when fitting the xy image.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [ ] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
