### PR TITLE
Additional path for fit methods as config option

### DIFF
--- a/config/example/default.cfg
+++ b/config/example/default.cfg
@@ -221,7 +221,7 @@ logic:
 
     fitlogic:
         module.Class: 'fit_logic.FitLogic'
-        #additional_predefined_methods_path: 'C:\\Custom_dir'  # optional, can also be lists on several folders
+        #additional_fit_methods_path: 'C:\\Custom_dir'  # optional, can also be lists on several folders
 
     tasklogic:
         module.Class: 'taskrunner.TaskRunner'

--- a/config/example/default.cfg
+++ b/config/example/default.cfg
@@ -221,6 +221,7 @@ logic:
 
     fitlogic:
         module.Class: 'fit_logic.FitLogic'
+        #additional_predefined_methods_path: 'C:\\Custom_dir'  # optional, can also be lists on several folders
 
     tasklogic:
         module.Class: 'taskrunner.TaskRunner'

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -53,8 +53,8 @@ The potential sequence_options are:
   * `OPTIONAL` (sequence mode possible)
   * `FORCED` (only output as sequence possible)
 * added the option to do a purely analog ODMR scan.
-*
-
+* added the option of an additional path for fit methods
+* 
 
 
 Config changes:
@@ -62,6 +62,7 @@ Config changes:
 * The parameters `additional_predefined_methods_path` and `additional_sampling_functions_path` 
 of the `SequenceGeneratorLogic` can now either be a string for a single path 
 or a list of strings for multiple paths.
+* There is an option for the fit logic, to give an additional path: `additional_fit_methods_path`  
 
 ## Release 0.10
 Released on 14 Mar 2019

--- a/logic/fit_logic.py
+++ b/logic/fit_logic.py
@@ -25,10 +25,8 @@ import inspect
 import lmfit
 from qtpy import QtCore
 import numpy as np
-from os import listdir
 import os
 import sys
-from os.path import isfile, join
 from collections import OrderedDict
 from distutils.version import LooseVersion
 
@@ -64,13 +62,14 @@ class FitLogic(GenericLogic):
 
         filenames = []
         # for path in directories:
-        path_list = [join(get_main_dir(), 'logic', 'fitmethods')]
+        path_list = [os.path.join(get_main_dir(), 'logic', 'fitmethods')]
         # adding additional path, to be defined in the config
 
-        if self._additional_methods_import_path is not None:
+        if self._additional_methods_import_path:
             if isinstance(self._additional_methods_import_path, str):
                 self._additional_methods_import_path = [self._additional_methods_import_path]
                 self.log.info('Adding fit methods path: {}'.format(self._additional_methods_import_path))
+
             if isinstance(self._additional_methods_import_path, (list, tuple, set)):
                 self.log.info('Adding fit methods path list: {}'.format(self._additional_methods_import_path))
                 for method_import_path in self._additional_methods_import_path:
@@ -82,13 +81,13 @@ class FitLogic(GenericLogic):
             else:
                 self.log.error('ConfigOption additional_predefined_methods_path needs to either be a string or '
                                'a list of strings.')
+
         for path in path_list:
-            for f in listdir(path):
-                if isfile(join(path, f)):
-                    if f[-3:] == '.py':
-                        filenames.append(f[:-3])
-                        if path not in sys.path:
-                            sys.path.append(path)
+            for f in os.listdir(path):
+                if os.path.isfile(os.path.join(path, f)) and f.endswith('.py'):
+                    filenames.append(f[:-3])
+                    if path not in sys.path:
+                        sys.path.append(path)
 
         # A dictionary containing all fit methods and their estimators.
         self.fit_list = OrderedDict()

--- a/logic/fit_logic.py
+++ b/logic/fit_logic.py
@@ -53,7 +53,7 @@ class FitLogic(GenericLogic):
     """
 
     # Optional additional paths to import from
-    _additional_methods_import_path = ConfigOption(name='additional_predefined_methods_path',
+    _additional_methods_import_path = ConfigOption(name='additional_fit_methods_path',
                                                    default=None,
                                                    missing='nothing')
 
@@ -70,11 +70,10 @@ class FitLogic(GenericLogic):
         if self._additional_methods_import_path is not None:
             if isinstance(self._additional_methods_import_path, str):
                 self._additional_methods_import_path = [self._additional_methods_import_path]
-                print('here1')
-
+                self.log.info('Adding fit methods path: {}'.format(self._additional_methods_import_path))
             if isinstance(self._additional_methods_import_path, (list, tuple, set)):
+                self.log.info('Adding fit methods path list: {}'.format(self._additional_methods_import_path))
                 for method_import_path in self._additional_methods_import_path:
-                    print('here2',method_import_path)
                     if not os.path.exists(method_import_path):
                         self.log.error('Specified path "{0}" for import of additional fit methods '
                                        'does not exist.'.format(method_import_path))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added config option "additional_methods_import_path", such that an external folder or a list of external folders can be given where fit methods can be stored. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Easier way to add fit functions. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested in dummy. 

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
