### PR TITLE
Fix ImportError handling in qudikernel.py

### DIFF
--- a/core/qudikernel.py
+++ b/core/qudikernel.py
@@ -33,7 +33,7 @@ import config
 
 try:
     from .parentpoller import ParentPollerUnix, ParentPollerWindows
-except ModuleNotFoundError:
+except ImportError:
     from parentpoller import ParentPollerUnix, ParentPollerWindows
 
 rpyc.core.protocol.DEFAULT_CONFIG['allow_pickle'] = True

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -4,6 +4,7 @@
 
 Changes/New features:
 
+* Bug fix to qudikernel.py kernel installer for Python 3.7.6
 * Cleanup/Improvement/Debug of POI manager (logic and GUI)
 * New POI manager tool _POI selector_ which allows adding of new POIs by clicking inside the scan 
 image


### PR DESCRIPTION
Fix small bug in handling module import errors in qudikernel.py.
## Description
While installing a Jupyter kernel on one of our computers in Cambridge running Python 3.7.6 I had the following error:
```
qudi/core> python qudikernel.py install
Traceback (most recent call last):
File "qudikernel.py", line 35, in <module>
    from .parentpoller import ParentPollerUnix, ParentPollerWindows
ImportError: attempted relative import with no known parent package
```
This PR fixes the issue by handling ImportError instead of ModuleNotFoundError in qudikernel.py.
## Motivation and Context
In Python <3.7.4 the `from .parentpoller import ...` statement raises  `ModuleNotFoundError`, so the code in qudikernel.py works correctly. In Python 3.7.6 it only raises `ImportError`. Since `ModuleNotFoundError` inherits from `ImportError` anyway, this change is backwards-compatible.

## How Has This Been Tested?
On a Windows 10 PC with Python 3.7.6, run `python qudikernel.py install`
Kernel is installed correctly.
## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.