### PR TITLE
Saving a fit in alternative plot window of pulsedmeasurement, when mean of data is negative

### DIFF
--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -1385,7 +1385,7 @@ class PulsedMeasurementLogic(GenericLogic):
                                  label='data trace 2')
 
                 # Do not include fit curve if there is no fit calculated.
-                if self.signal_fit_data.size != 0 and np.sum(self.signal_fit_data[1]) > 0:
+                if self.signal_fit_data.size != 0 and np.sum(np.abs(self.signal_fit_data[1])) > 0:
                     x_axis_fit_scaled = self.signal_fit_data[0] / scaled_float.scale_val
                     ax1.plot(x_axis_fit_scaled, self.signal_fit_data[1],
                              color=colors[2], marker='None', linewidth=1.5,
@@ -1488,7 +1488,8 @@ class PulsedMeasurementLogic(GenericLogic):
                     ax2.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc=3, ncol=2,
                                mode="expand", borderaxespad=0.)
 
-                    if self.signal_fit_alt_data.size != 0 and np.sum(self.signal_fit_alt_data[1]) > 0:
+                    if (self.signal_fit_alt_data.size != 0
+                            and np.sum(np.abs(self.signal_fit_alt_data[1])) > 0):
                         x_axis_fit_scaled = self.signal_fit_alt_data[0] / scaled_float.scale_val
                         ax2.plot(x_axis_fit_scaled, self.signal_fit_alt_data[1],
                                  color=colors[2], marker='None', linewidth=1.5,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
## Description
When the mean of the fit data in the pulsedmeasurement is negative the fit is not saved. This PR solves this problem by simply adding an abs() around the data

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [ x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [x ] All changed Jupyter notebooks have been stripped of their output cells.
