### PR TITLE
fixed SSL authentication of module server

### DIFF
--- a/core/manager.py
+++ b/core/manager.py
@@ -155,8 +155,18 @@ class Manager(QtCore.QObject):
                                 'port', 12345)
                             certfile = self.tree['global']['module_server'].get(
                                 'certfile', None)
+                            if (certfile is not None) and not os.path.isabs(certfile):
+                                certfile = os.path.abspath(os.path.join(self.configDir, certfile))
                             keyfile = self.tree['global']['module_server'].get('keyfile', None)
-                            self.rm.createServer(server_address, server_port, certfile, keyfile)
+                            if (keyfile is not None) and not os.path.isabs(keyfile):
+                                keyfile = os.path.abspath(os.path.join(self.configDir, keyfile))
+                            cacertfile = self.tree['global']['module_server'].get('cacertfile',
+                                                                                  None)
+                            if (cacertfile is not None) and not os.path.isabs(cacertfile):
+                                cacertfile = os.path.abspath(os.path.join(self.configDir,
+                                                                          cacertfile))
+                            self.rm.createServer(server_address, server_port, certfile, keyfile,
+                                                 cacertfile)
                             # successfully started remote server
                             logger.info('Started server rpyc://{0}:{1}'.format(server_address,
                                                                                server_port))
@@ -166,27 +176,6 @@ class Manager(QtCore.QObject):
                 elif 'serveraddress' in self.tree['global']:
                     logger.warning('Deprecated remote server settings. Please update to new '
                                    'style. See documentation.')
-                    server_address = self.tree['global']['serveraddress']
-                    try:
-                        if 'serverport' in self.tree['global']:
-                            remote_port = self.tree['global']['serverport']
-                            logger.info('Remote port is configured to {0}'.format(remote_port))
-                        else:
-                            remote_port = 12345
-                            logger.info('Remote port is the standard {0}'.format(remote_port))
-                        if 'certfile' in self.tree['global']:
-                            certfile = self.tree['global']['certfile']
-                        else:
-                            certfile = None
-                        if 'keyfile' in self.tree['global']:
-                            keyfile = self.tree['global']['keyfile']
-                        else:
-                            keyfile = None
-                        self.rm.createServer(server_address, remote_port, certfile, keyfile)
-                        # successfully started remote server
-                        self.remote_server = True
-                    except:
-                        logger.exception('Remote server could not be started.')
 
             logger.info('Qudi started.')
 
@@ -765,10 +754,12 @@ class Manager(QtCore.QObject):
                 try:
                     certfile = defined_module.get('certfile', None)
                     keyfile = defined_module.get('keyfile', None)
+                    cacertsfile = defined_module.get('cacerts', None)
                     instance = self.rm.getRemoteModuleUrl(
                         defined_module['remote'],
                         certfile=certfile,
-                        keyfile=keyfile)
+                        keyfile=keyfile,
+                        cacertsfile=cacertsfile)
                     logger.info('Remote module {0} loaded as {1}.{2}.'
                                 ''.format(defined_module['remote'], base, key))
                     with self.lock:

--- a/core/remote.py
+++ b/core/remote.py
@@ -29,8 +29,33 @@ import ssl
 from .util.models import DictTableModel, ListTableModel
 import rpyc
 from rpyc.utils.server import ThreadedServer
-from rpyc.utils.authenticators import SSLAuthenticator
 rpyc.core.protocol.DEFAULT_CONFIG['allow_pickle'] = True
+import os
+import sys
+
+
+class SSLAuthenticator:
+    """
+    An SSL authenticator using an SSLContext as preferred since python 3.4
+    """
+    def __init__(self, server_key_file, server_cert_file, ca_certs=None):
+        self.server_key_file = str(server_key_file)
+        self.server_cert_file = str(server_cert_file)
+        self.ca_certs = str(ca_certs) if ca_certs else None
+
+    def __call__(self, sock):
+        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        context.verify_mode = ssl.CERT_REQUIRED
+        context.load_cert_chain(certfile=self.server_cert_file, keyfile=self.server_key_file)
+        if self.ca_certs is not None:
+            context.load_verify_locations(cafile=self.ca_certs)
+
+        try:
+            conn = context.wrap_socket(sock, server_side=True)
+        except ssl.SSLError:
+            ex = sys.exc_info()[1]
+            raise Exception(str(ex))
+        return conn, conn.getpeercert()
 
 
 class RemoteObjectManager(QObject):
@@ -43,6 +68,7 @@ class RemoteObjectManager(QObject):
         super().__init__(**kwargs)
         self.tm = manager.tm
         self.manager = manager
+        self.server = None
         self.remoteModules = ListTableModel()
         self.remoteModules.headers[0] = 'Remote Modules'
         self.sharedModules = DictTableModel()
@@ -57,8 +83,8 @@ class RemoteObjectManager(QObject):
             modules = self.sharedModules
             _manager = self.manager
 
-            @staticmethod
-            def get_service_name():
+            @classmethod
+            def get_service_name(cls):
                 return 'RemoteModule'
 
             def on_connect(self, conn):
@@ -86,18 +112,18 @@ class RemoteObjectManager(QObject):
                 else:
                     for base in ['hardware', 'logic', 'gui']:
                         logger.info('remotesearch: {0}'.format(name))
-                        if name in self._manager.tree['defined'][base] and 'remoteaccess' in self._manager.tree['defined'][base][name]:
+                        if name in self._manager.tree['defined'][base] and \
+                                'remoteaccess' in self._manager.tree['defined'][base][name]:
                             self._manager.startModule(base, name)
                             logger.info('remoteload: {0}{1}'.format(base, name))
                     if name in self.modules.storage:
                         return self.modules.storage[name]
                     else:
-                        logger.error('Client requested a module that is not '
-                                'shared.')
+                        logger.error('Client requested a module that is not shared.')
                         return None
         return RemoteModuleService
 
-    def createServer(self, hostname, port, certfile=None, keyfile=None):
+    def createServer(self, hostname, port, certfile=None, keyfile=None, cacertfile=None):
         """ Start the rpyc modules server on a given port.
 
           @param int port: port where the server should be running
@@ -109,7 +135,8 @@ class RemoteObjectManager(QObject):
                 hostname,
                 port,
                 keyfile=keyfile,
-                certfile=certfile)
+                certfile=certfile,
+                cacertsfile=cacertfile)
         else:
             if hostname != 'localhost':
                 logger.warning('Remote connection not secured! Use a certificate!')
@@ -123,8 +150,9 @@ class RemoteObjectManager(QObject):
     def stopServer(self):
         """ Stop the remote module server.
         """
-        if hasattr(self, 'server'):
+        if self.server is not None:
             self.server.close()
+            self.server = None
 
     def shareModule(self, name, obj):
         """ Add a module to the list of modules that can be accessed remotely.
@@ -146,20 +174,22 @@ class RemoteObjectManager(QObject):
             logger.error('Module {0} was not shared.'.format(name))
         self.sharedModules.pop(name)
 
-    def getRemoteModuleUrl(self, url, certfile=None, keyfile=None):
+    def getRemoteModuleUrl(self, url, certfile=None, keyfile=None, cacertsfile=None):
         """ Get a remote module via its URL.
 
           @param str url: URL pointing to a module hosted b a remote server
           @param str certfile: filename of certificate or None if SSL is not used
           @param str keyfile: filename of key or None if SSL is not used
+          @param str cacertsfile: filename of cacerts of None if SSL is not used
 
           @return object: remote module
         """
         parsed = urlparse(url)
         name = parsed.path.replace('/', '')
-        return self.getRemoteModule(parsed.hostname, parsed.port, name)
+        return self.getRemoteModule(parsed.hostname, parsed.port, name, certfile, keyfile,
+                                    cacertsfile)
 
-    def getRemoteModule(self, host, port, name, certfile=None, keyfile=None):
+    def getRemoteModule(self, host, port, name, certfile=None, keyfile=None, cacertsfile=None):
         """ Get a remote module via its host, port and name.
 
           @param str host: host that the remote module server is running on
@@ -167,10 +197,12 @@ class RemoteObjectManager(QObject):
           @param str name: unique name of the remote module
           @param str certfile: filename of certificate or None if SSL is not used
           @param str keyfile: filename of key or None if SSL is not used
+          @param str cacertsfile: filename of cacerts of None if SSL is not used
 
           @return object: remote module
         """
-        module = RemoteModule(host, port, name, certfile=certfile, keyfile=keyfile)
+        module = RemoteModule(host, port, name, certfile=certfile, keyfile=keyfile,
+                              cacertsfile=cacertsfile)
         self.remoteModules.append(module)
         return module.module
 
@@ -178,7 +210,7 @@ class RemoteObjectManager(QObject):
 class RPyCServer(QObject):
     """ Contains a RPyC server that serves modules to remote computers. Runs in a QThread.
     """
-    def __init__(self, serviceClass, host, port, certfile=None, keyfile=None):
+    def __init__(self, serviceClass, host, port, certfile=None, keyfile=None, cacertsfile=None):
         """
           @param class serviceClass: class that represents an RPyC service
           @param int port: port that hte RPyC server should listen on
@@ -189,21 +221,28 @@ class RPyCServer(QObject):
         self.port = port
         self.certfile = certfile
         self.keyfile = keyfile
+        self.cacertsfile = cacertsfile
 
     def run(self):
         """ Start the RPyC server
         """
         if self.certfile is not None and self.keyfile is not None:
-            authenticator = SSLAuthenticator(self.certfile, self.keyfile)
+            if not os.path.exists(self.certfile):
+                raise Exception('SSL certificate {0} does not exist.'.format(self.certfile))
+            if not os.path.exists(self.keyfile):
+                raise Exception('SSL private key file {0} does not exist.'.format(self.keyfile))
+            if (self.cacertsfile is not None) and (not os.path.exists(self.cacertsfile)):
+                logger.warning('SSL CA certificates file {0} does not exist.'.format(
+                    self.cacertsfile))
+            authenticator = SSLAuthenticator(server_key_file=self.keyfile,
+                                             server_cert_file=self.certfile,
+                                             ca_certs=self.cacertsfile)
             self.server = ThreadedServer(
                 self.serviceClass,
                 hostname=self.host,
                 port=self.port,
                 protocol_config={'allow_all_attrs': True},
-                authenticator=authenticator,
-                cert_reqs=ssl.CERT_REQUIRED,
-                ciphers='EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH',
-                ssl_version=ssl.PROTOCOL_TLSv1_2)
+                authenticator=authenticator)
         else:
             self.server = ThreadedServer(
                 self.serviceClass,
@@ -216,14 +255,22 @@ class RPyCServer(QObject):
 class RemoteModule:
     """ This class represents a module on a remote computer and holds a reference to it.
     """
-    def __init__(self, host, port, name, certfile=None, keyfile=None):
+    def __init__(self, host, port, name, certfile=None, keyfile=None, cacertsfile=None):
         if certfile is not None and keyfile is not None:
+            if not os.path.exists(certfile):
+                raise Exception('SSL certificate {0} does not exist.'.format(certfile))
+            if not os.path.exists(keyfile):
+                raise Exception('SSL private key file {0} does not exist.'.format(keyfile))
+            if (cacertsfile is not None) and (not os.path.exists(cacertsfile)):
+                logger.warning('SSL CA certificates file {0} does not exist.'.format(cacertsfile))
             self.connection = rpyc.ssl_connect(
                 host,
                 port=port,
                 config={'allow_all_attrs': True},
                 certfile=certfile,
-                keyfile=keyfile)
+                keyfile=keyfile,
+                ca_certs=cacertsfile,
+                cert_reqs=ssl.CERT_REQUIRED)
         else:
             self.connection = rpyc.connect(host, port, config={'allow_all_attrs': True})
         self.module = self.connection.root.getModule(name)

--- a/core/util/helpers.py
+++ b/core/util/helpers.py
@@ -128,7 +128,7 @@ def import_check():
     # encode like: (python-package-name, repository-name, version)
     vital_pkg = [('ruamel.yaml', 'ruamel.yaml', None),
                  ('fysom', 'fysom', '2.1.4')]
-    opt_pkg = [('rpyc', 'rpyc', None),
+    opt_pkg = [('rpyc', 'rpyc', '4.1.0'),
                ('pyqtgraph', 'pyqtgraph', None),
                ('git', 'gitpython', None)]
 
@@ -167,6 +167,9 @@ def import_check():
                                'attribute. Ignoring version check!'.format(
                                    check_pkg_name))
                 return 0
+            # if version number is a tuple, convert to string
+            if isinstance(module_version, tuple):
+                module_version = '.'.join([str(v) for v in module_version])
             # compare version number
             if parse_version(module_version) < parse_version(check_version):
                 logger.error(

--- a/core/util/helpers.py
+++ b/core/util/helpers.py
@@ -128,7 +128,7 @@ def import_check():
     # encode like: (python-package-name, repository-name, version)
     vital_pkg = [('ruamel.yaml', 'ruamel.yaml', None),
                  ('fysom', 'fysom', '2.1.4')]
-    opt_pkg = [('rpyc', 'rpyc', '4.1.0'),
+    opt_pkg = [('rpyc', 'rpyc', '4.0.2'),
                ('pyqtgraph', 'pyqtgraph', None),
                ('git', 'gitpython', None)]
 

--- a/documentation/remote_modules.md
+++ b/documentation/remote_modules.md
@@ -4,7 +4,7 @@ Using rpyc Qudi modules can be accessed from a remote computer like they were lo
 
 ## Requirements
 
-* rpyc in at least version 4.1.0 has to be installed.
+* rpyc in version 4.0.2 has to be installed.
 
 ## Server Configuration
 

--- a/documentation/remote_modules.md
+++ b/documentation/remote_modules.md
@@ -4,7 +4,7 @@ Using rpyc Qudi modules can be accessed from a remote computer like they were lo
 
 ## Requirements
 
-* rpyc in at least version 4.0.2 has to be installed.
+* rpyc in at least version 4.1.0 has to be installed.
 
 ## Server Configuration
 
@@ -14,11 +14,12 @@ In the configuration file:
 
 ```
 [global]
-  remote_server:
+  module_server:
     - address: ''
     - port: 12345
     - certfile: 'path/to/ssl/certificate'
     - keyfile: 'path/to/ssl/key'
+    - cacerts: 'path/to/ssl/cacerts'
 ```
 
 To activate access to individual modules, add
@@ -39,8 +40,25 @@ Specify a module in the configuration file as usual, but add the following optio
 remote: 'rpyc://servername:port/module_name'
 certfile: 'path/to/ssl/certificate'
 keyfile: 'path/to/ssl/key'
+cacerts: 'path/to/ssl/cacerts'
 ```
 
 ## Important Notes
 
 * If `certfile` and `keyfile` are not specified, the connection is unencrypted and not authenticated.
+
+## Certificate generation
+
+To generate the server certificate use
+
+```openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout server.key -out server.crt```
+
+To generate the client certificate use
+
+```openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout client.key -out client.crt```
+
+### Notes
+* You do not have the setup your own CA to sign certificates. Simply use the client certificate as `cacerts` on
+  server side and the server certificate on client side. That way you obtain simple two way authentication between the
+  server and one client.
+* For `cacerts` you can concatenate multiple client certificates into a single file to authenticate multiple clients.

--- a/tools/conda-env-win10-64bit-qt5.yml
+++ b/tools/conda-env-win10-64bit-qt5.yml
@@ -109,7 +109,7 @@ dependencies:
     - pyvisa==1.9.0
     - pyyaml==3.12
     - qtpy==1.4.2
-    - rpyc==4.0.2
+    - rpyc==4.1.4
     - ruamel.yaml==0.15.40
     - scipy==1.1.0
     - serial==0.0.66

--- a/tools/conda-env-win10-64bit-qt5.yml
+++ b/tools/conda-env-win10-64bit-qt5.yml
@@ -109,7 +109,7 @@ dependencies:
     - pyvisa==1.9.0
     - pyyaml==3.12
     - qtpy==1.4.2
-    - rpyc==4.1.4
+    - rpyc==4.0.2
     - ruamel.yaml==0.15.40
     - scipy==1.1.0
     - serial==0.0.66


### PR DESCRIPTION
The SSL authentication of the module server was completely broken and potentially never worked. This pull request fixes it.

## Description
Now SSL can be used for authentication.

## Motivation and Context
Unencrypted and not authenticated connections shouldn't be used. But Qudi's implementation of SSL authentication was broken.

## How Has This Been Tested?
Qudi module server <-> manual rpyc connection on two Windows 10 machines.

## Screenshots (only if appropriate, delete if not):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
