### PR TITLE
Awg 7k constraint fix

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -64,7 +64,7 @@ The potential sequence_options are:
 * Saving data in confocal GUI no longer freezes other GUI modules
 * Added save_pdf and save_png config options for save_logic
 * Adding hardware file of HydraHarp 400 from Pico Quant, basing on the 3.0.0.2 version of function library and user manual.
-
+* Set proper minimum wavelength value in constraints of Tektronix AWG7k series HW module
 
 
 Config changes:

--- a/hardware/awg/tektronix_awg7k.py
+++ b/hardware/awg/tektronix_awg7k.py
@@ -202,7 +202,7 @@ class AWG7k(Base, PulserInterface):
         elif self.model == 'AWG7052':
             constraints.sample_rate.min = 10.0e6
             constraints.sample_rate.max = 5.0e9
-            constraints.sample_rate.step = 10.0e6
+            constraints.sample_rate.step = 10.0e6 # <=== not sure
             constraints.sample_rate.default = 5.0e9
 
         if '02' in self.installed_options or self._has_interleave():
@@ -1627,4 +1627,10 @@ class AWG7k(Base, PulserInterface):
         return has_error
 
     def _has_sequence_mode(self):
-        return '08' in self.installed_options
+        if self.model == 'AWG7052':
+            # the Tek AWG model 7052 does support sequencing even without the option '08'
+            # from measurement results it looks kind of "fast" too
+            # can be used for T1 and correlation spectroscopy
+            return True
+        else:
+            return '08' in self.installed_options

--- a/hardware/awg/tektronix_awg7k.py
+++ b/hardware/awg/tektronix_awg7k.py
@@ -223,9 +223,9 @@ class AWG7k(Base, PulserInterface):
         constraints.d_ch_high.step = 0.01
         constraints.d_ch_high.default = 1.4
 
-        constraints.waveform_length.min = 1
+        constraints.waveform_length.min = 960
         constraints.waveform_length.step = 4
-        constraints.waveform_length.default = 80
+        constraints.waveform_length.default = 960
         if '01' in self.installed_options:
             constraints.waveform_length.max = 64800000
         else:

--- a/hardware/awg/tektronix_awg7k.py
+++ b/hardware/awg/tektronix_awg7k.py
@@ -230,9 +230,9 @@ class AWG7k(Base, PulserInterface):
         constraints.d_ch_high.default = 1.4
         
         if self.model == 'AWG7052':
-            constraints.waveform_length.min = 64
+            constraints.waveform_length.min = 960
             constraints.waveform_length.step = 64
-            constraints.waveform_length.default = 64
+            constraints.waveform_length.default = 960
         else:
             if self.get_interleave():
                 constraints.waveform_length.min = 1920

--- a/hardware/awg/tektronix_awg7k.py
+++ b/hardware/awg/tektronix_awg7k.py
@@ -199,6 +199,12 @@ class AWG7k(Base, PulserInterface):
                 constraints.sample_rate.step = 10.0e6
                 constraints.sample_rate.default = 8.0e9
 
+        elif self.model == 'AWG7052':
+            constraints.sample_rate.min = 10.0e6
+            constraints.sample_rate.max = 5.0e9
+            constraints.sample_rate.step = 10.0e6
+            constraints.sample_rate.default = 5.0e9
+
         if '02' in self.installed_options or self._has_interleave():
             constraints.a_ch_amplitude.max = 1.0
             constraints.a_ch_amplitude.step = 0.001
@@ -222,24 +228,37 @@ class AWG7k(Base, PulserInterface):
         constraints.d_ch_high.max = 1.4
         constraints.d_ch_high.step = 0.01
         constraints.d_ch_high.default = 1.4
-
-        if self.get_interleave():
-            constraints.waveform_length.min = 1920
-            constraints.waveform_length.step = 8
+        
+        if self.model == 'AWG7052':
+            constraints.waveform_length.min = 64
+            constraints.waveform_length.step = 64
+            constraints.waveform_length.default = 64
         else:
-            constraints.waveform_length.min = 960
-            constraints.waveform_length.step = 4
-        constraints.waveform_length.default = 1920
+            if self.get_interleave():
+                constraints.waveform_length.min = 1920
+                constraints.waveform_length.step = 8
+            else:
+                constraints.waveform_length.min = 960
+                constraints.waveform_length.step = 4
+            constraints.waveform_length.default = 1920
+
         if '01' in self.installed_options:
             constraints.waveform_length.max = 64800000
         else:
             constraints.waveform_length.max = 32400000
 
-        constraints.waveform_num.min = 1
-        constraints.waveform_num.max = 32000
-        constraints.waveform_num.step = 1
-        constraints.waveform_num.default = 1
+        if self.model == 'AWG7052':
+            constraints.waveform_num.min = 1
+            constraints.waveform_num.max = 16000
+            constraints.waveform_num.step = 1
+            constraints.waveform_num.default = 1
+        else:
+            constraints.waveform_num.min = 1
+            constraints.waveform_num.max = 32000
+            constraints.waveform_num.step = 1
+            constraints.waveform_num.default = 1
 
+        # there doesn't seem to be something like number of sequences according to the technical reference
         constraints.sequence_num.min = 1
         constraints.sequence_num.max = 16000
         constraints.sequence_num.step = 1
@@ -252,7 +271,7 @@ class AWG7k(Base, PulserInterface):
 
         # If sequencer mode is available then these should be specified
         constraints.repetitions.min = 0
-        constraints.repetitions.max = 65539
+        constraints.repetitions.max = 65536
         constraints.repetitions.step = 1
         constraints.repetitions.default = 0
 
@@ -260,10 +279,16 @@ class AWG7k(Base, PulserInterface):
         constraints.event_triggers = ['ON']
         constraints.flags = list()
 
-        constraints.sequence_steps.min = 0
-        constraints.sequence_steps.max = 8000
-        constraints.sequence_steps.step = 1
-        constraints.sequence_steps.default = 0
+        if self.model == 'AWG7052':
+            constraints.sequence_steps.min = 0
+            constraints.sequence_steps.max = 4000
+            constraints.sequence_steps.step = 1
+            constraints.sequence_steps.default = 0
+        else:
+            constraints.sequence_steps.min = 0
+            constraints.sequence_steps.max = 8000
+            constraints.sequence_steps.step = 1
+            constraints.sequence_steps.default = 0
 
         # the name a_ch<num> and d_ch<num> are generic names, which describe UNAMBIGUOUSLY the
         # channels. Here all possible channel configurations are stated, where only the generic

--- a/hardware/awg/tektronix_awg7k.py
+++ b/hardware/awg/tektronix_awg7k.py
@@ -223,9 +223,13 @@ class AWG7k(Base, PulserInterface):
         constraints.d_ch_high.step = 0.01
         constraints.d_ch_high.default = 1.4
 
-        constraints.waveform_length.min = 960
-        constraints.waveform_length.step = 4
-        constraints.waveform_length.default = 960
+        if self.get_interleave():
+            constraints.waveform_length.min = 1920
+            constraints.waveform_length.step = 8
+        else:
+            constraints.waveform_length.min = 960
+            constraints.waveform_length.step = 4
+        constraints.waveform_length.default = 1920
         if '01' in self.installed_options:
             constraints.waveform_length.max = 64800000
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The number for minimum wavelength was set to 1 instead of the real value (960) for Tektronix AWG 7k. Fixed that

## How Has This Been Tested?
Ask @NeumannP 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
