### PR TITLE
improve loading StatusVar for dicts

### DIFF
--- a/core/module.py
+++ b/core/module.py
@@ -205,7 +205,11 @@ class BaseMixin(metaclass=ModuleMeta):
         # add status vars
         for vname, var in self._stat_vars.items():
             sv = self._statusVariables
-            svar = sv[var.name] if var.name in sv else var.default
+            if isinstance(var.default, (OrderedDict, dict)) and var.name in sv:
+                svar = var.default
+                svar.update(sv[var.name])
+            else:
+                svar = sv[var.name] if var.name in sv else var.default
 
             if var.constructor_function is None:
                 setattr(self, var.var_name, svar)

--- a/core/module.py
+++ b/core/module.py
@@ -19,6 +19,7 @@ Copyright (c) the Qudi Developers. See the COPYRIGHT.txt file at the
 top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi/>
 """
 
+import copy
 import logging
 import warnings
 from fysom import Fysom  # provides a final state machine
@@ -203,13 +204,14 @@ class BaseMixin(metaclass=ModuleMeta):
             @param e: Fysom event
         """
         # add status vars
+        sv = self._statusVariables
         for vname, var in self._stat_vars.items():
-            sv = self._statusVariables
-            if isinstance(var.default, (OrderedDict, dict)) and var.name in sv:
-                svar = var.default
+
+            if isinstance(var.default, dict) and var.name in sv:
+                svar = copy.deepcopy(var.default)
                 svar.update(sv[var.name])
             else:
-                svar = sv[var.name] if var.name in sv else var.default
+                svar = sv[var.name] if var.name in sv else copy.deepcopy(var.default)
 
             if var.constructor_function is None:
                 setattr(self, var.var_name, svar)


### PR DESCRIPTION
Optimizing the loading of StatusVars

## Description
If the Status Vars tries to load a dict type item, it will now load the default values for every key, if the key is missing, and not only if the entire dictionary is missing.

## Motivation and Context
If someone adds a key to an exisiting dict, this key with its value will only be loaded, if the StatusVar is newly loaded. One example would be adding a channel to the channel list at the pulsed logic. If I add a new channel for a new trigger output, the corresponding channel option will only appear after I delete the StatusVar save file or the entry.

## How Has This Been Tested?
tested on a confocal setup and dummy. 

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
