### PR TITLE
StatusVar dumping robustness

### DIFF
--- a/core/module.py
+++ b/core/module.py
@@ -28,6 +28,7 @@ from qtpy import QtCore
 from .meta import ModuleMeta
 from .configoption import MissingOption
 from .connector import Connector
+from .statusvariable import StatusVar
 
 
 class ModuleStateMachine(QtCore.QObject, Fysom):
@@ -228,12 +229,12 @@ class BaseMixin(metaclass=ModuleMeta):
             # save status vars even if deactivation failed
             for vname, var in self._stat_vars.items():
                 if hasattr(self, var.var_name):
-                    if var.representer_function is None:
-                        self._statusVariables[var.name] = getattr(self, var.var_name)
-                    else:
-                        self._statusVariables[var.name] = var.representer_function(
-                                                            self,
-                                                            getattr(self, var.var_name))
+                    value = getattr(self, var.var_name)
+                    if not isinstance(value, StatusVar):
+                        if var.representer_function is None:
+                            self._statusVariables[var.name] = value
+                        else:
+                            self._statusVariables[var.name] = var.representer_function(self, value)
 
     @property
     def log(self):


### PR DESCRIPTION
## Description
In the strange edge-case of deleting a meta instance attribute (`StatusVar`) from an activated module at runtime, the deactivation raised an error.
Now the `StatusVar` is ignored if it can not be found.

## Motivation and Context
Fixes issue #595 

## How Has This Been Tested?
dummy configuration

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
