### PR TITLE
Multi interface fix

### DIFF
--- a/core/interface.py
+++ b/core/interface.py
@@ -48,6 +48,7 @@ class InterfaceMethod:
 
     def __init__(self, default_callable, is_abstractmethod=False):
         self._obj = None
+        self._name = default_callable.__name__
         if is_abstractmethod:
             self._default_callable = abstractmethod(default_callable)
         else:
@@ -100,7 +101,7 @@ class InterfaceMethod:
         def decorator(func):
             self.registered[interface] = func
             self.__isabstractmethod__ = False
-            InterfaceMethod._latest_unregistered_instances.pop(func.__name__, None)
+            InterfaceMethod._latest_unregistered_instances.pop(self._name, None)
             return func
         return decorator
 

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -69,6 +69,7 @@ The potential sequence_options are:
 * Adding hardware file of HydraHarp 400 from Pico Quant, basing on the 3.0.0.2 version of function library and user manual.
 * reworked the QDPlotter to now contain fits and a scalable number of plots. Attention: custom notebooks might break by this change.
 * Set proper minimum wavelength value in constraints of Tektronix AWG7k series HW module
+* Fixed bug affecting interface overloading of Qudi modules
 
 
 Config changes:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I've corrected a bug in the class InterfaceMethod for overloading hardware methods for multiple interfaces.

Once a module using the register for get_constraints was loaded, any new module declaring a get_constraints method would mess up the first one. This is because every InterfaceMethod share a common _latest_unregistered_instances dictionary.
When cleaning it,  func.__name__ was the name of the interface specific method (ex : some_arbitrary_name1) instead of the name of the overloaded method (my_overloaded_method).

## Motivation and Context
This solve an active bug making the overloading of interfaces quite difficult.  The bug was reported in issue #552 .
The bug is hard to track as it might depend on the loading order of the modules. For example, loading pulsed_measurement_logic activate both the fastcounter and the pulser in a non deterministic order.

## How Has This Been Tested?
I've tested this on a dummy file implementing SlowCounter and FastCounter. 

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
