### PR TITLE
Added missing metadata to raw pulsed file

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -77,6 +77,7 @@ please use _ni_x_series_in_streamer.py_ as hardware module.
 * Set proper minimum wavelength value in constraints of Tektronix AWG7k series HW module
 * Added a hardware file for fibered optical switch Thorlabs OSW12/22 via SwitchInterface
 * Fixed bug affecting interface overloading of Qudi modules
+* Added missing metadata in saved raw data file of PulsedMeasurement module
 *
 
 

--- a/logic/pulsed/pulsed_measurement_logic.py
+++ b/logic/pulsed/pulsed_measurement_logic.py
@@ -1581,6 +1581,8 @@ class PulsedMeasurementLogic(GenericLogic):
         parameters['Number of laser pulses'] = self._number_of_lasers
         parameters['alternating'] = self._alternating
         parameters['Controlled variable'] = list(self.signal_data[0])
+        parameters['Approx. measurement time (s)'] = self.__elapsed_time
+        parameters['Measurement sweeps'] = self.__elapsed_sweeps
 
         self.savelogic().save_data(data, timestamp=timestamp,
                                    parameters=parameters, fmt='%d',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The title sums it up, it's a short PR.
The metadata are : 'Approx. measurement time (s)' and 'Measurement sweeps'.

## Motivation and Context
The added metadata were missing from the raw file, the only file that is kept in some applications.

## How Has This Been Tested?
I checked on dummy it works as expected.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
