### PR TITLE
Thorlabs filter wheel FW102C

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -77,6 +77,7 @@ please use _ni_x_series_in_streamer.py_ as hardware module.
 * Set proper minimum wavelength value in constraints of Tektronix AWG7k series HW module
 * Added a hardware file for fibered optical switch Thorlabs OSW12/22 via SwitchInterface
 * Fixed bug affecting interface overloading of Qudi modules
+* Added a hardware file to interface Thorlabs filter wheels via scripts
 *
 
 

--- a/hardware/wheels/thorlabs.py
+++ b/hardware/wheels/thorlabs.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""
+Qudi is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Qudi is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Qudi. If not, see <http://www.gnu.org/licenses/>.
+
+Copyright (c) the Qudi Developers. See the COPYRIGHT.txt file at the
+top-level directory of this distribution and at <https://github.com/Ulm-IQO/qudi/>
+"""
+
+import visa
+from core.module import Base
+from core.configoption import ConfigOption
+
+
+class Main(Base):
+    """ This class is implements communication with Thorlabs Motorized Filter Wheels
+
+    Example config for copy-paste:
+
+    thorlabs_wheel:
+        module.Class: 'wheels.thorlabs.Main'
+        interface: 'COM6'
+
+    Description of the hardware provided by Thorlabs:
+        These stepper-motor-driven filter wheels are designed for use in a host of automated applications including
+        color CCD photography, fluorescence microscopy, and photometry. Each unit consists of a motorized housing
+        and a preinstalled filter wheel with either 6 positions for Ø1" (Ø25 mm) optics or 12 positions
+        for Ø1/2" (Ø12.5 mm) optics. Filter wheels of either type can also be purchased separately and installed
+        by the user.
+    """
+
+    interface = ConfigOption('interface', 'COM3', missing='error')
+
+    _rm = None
+    _inst = None
+
+    def on_activate(self):
+        """ Module activation method """
+        self._rm = visa.ResourceManager()
+        try:
+            self._inst = self._rm.open_resource(self.interface, baud_rate=115200, write_termination='\r',
+                                                read_termination='\r')
+            idn = self._query('*idn?')
+            self.log.debug('Connected to : {}'.format(idn))
+        except visa.VisaIOError:
+            self.log.error('Could not connect to device')
+
+    def on_deactivate(self):
+        """ Disconnect from hardware on deactivation. """
+        self._inst.close()
+        self._rm.close()
+
+    def _query(self, text):
+        """ Send query, get and return answer """
+        echo = self._write(text)
+        answer = self._inst.read()
+        return answer
+
+    def _write(self, text):
+        """ Write command, do not expect answer """
+        self._inst.write(text)
+        echo = self._inst.read()
+        return echo
+
+    def get_position(self):
+        """ Get the current position, from 1 to 6 (or 12) """
+        position = self._query('pos?')
+        return int(position)
+
+    def set_position(self, value):
+        """ Set the position to a given value
+
+        The wheel will take the shorter path. If upward or downward are equivalent, the wheel take the upward path.
+        """
+        res = self._write("pos={}".format(int(value)))

--- a/hardware/wheels/thorlabs_motorized_filter_wheel.py
+++ b/hardware/wheels/thorlabs_motorized_filter_wheel.py
@@ -22,13 +22,13 @@ from core.module import Base
 from core.configoption import ConfigOption
 
 
-class Main(Base):
+class ThorlabsMotorizedFilterWheel(Base):
     """ This class is implements communication with Thorlabs Motorized Filter Wheels
 
     Example config for copy-paste:
 
     thorlabs_wheel:
-        module.Class: 'wheels.thorlabs.Main'
+        module.Class: 'wheels.thorlabs_motorized_filter_wheel.ThorlabsMotorizedFilterWheel'
         interface: 'COM6'
 
     Description of the hardware provided by Thorlabs:
@@ -41,8 +41,10 @@ class Main(Base):
 
     interface = ConfigOption('interface', 'COM3', missing='error')
 
-    _rm = None
-    _inst = None
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._rm = None
+        self._inst = None
 
     def on_activate(self):
         """ Module activation method """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds support of the FW102C filter wheels from Thorlabs as a hardware module.

## Motivation and Context
Thorlabs filter wheels are generally interfaced by their dedicated software. For some application, it's necessary to operate them from a Qudi script. This PR adds this possibility.
As there is no appropriate interface for this hardware, it does not have any.  This means this module is only compatible with scripts for now.

## How Has This Been Tested?
This has been tested with a FW102C and a six position wheel on a windows 10 PC.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
