### PR TITLE
Time trace streamer fixes

### DIFF
--- a/gui/time_series/time_series_gui.py
+++ b/gui/time_series/time_series_gui.py
@@ -25,6 +25,7 @@ import pyqtgraph as pg
 
 from core.connector import Connector
 from core.configoption import ConfigOption
+from core.statusvariable import StatusVar
 from gui.colordefs import QudiPalettePale as palette
 from gui.guibase import GUIBase
 from qtpy import QtCore
@@ -78,6 +79,9 @@ class TimeSeriesGui(GUIBase):
 
     # declare ConfigOptions
     _use_antialias = ConfigOption('use_antialias', default=True)
+
+    # declare StatusVars
+    _current_value_channel = StatusVar(name='current_value_channel', default=None)
 
     sigStartCounter = QtCore.Signal()
     sigStopCounter = QtCore.Signal()
@@ -380,16 +384,22 @@ class TimeSeriesGui(GUIBase):
         av_channels = tuple(ch for ch, w in self._csd_widgets.items() if
                             w['checkbox2'].isChecked() and ch in channels)
         # Update combobox
-        old_value = self._mw.curr_value_comboBox.currentText()
+        self._mw.curr_value_comboBox.blockSignals(True)
         self._mw.curr_value_comboBox.clear()
         self._mw.curr_value_comboBox.addItem('None')
         self._mw.curr_value_comboBox.addItems(['average {0}'.format(ch) for ch in av_channels])
         self._mw.curr_value_comboBox.addItems(channels)
-        index = self._mw.curr_value_comboBox.findText(old_value)
-        if index < 0:
+        if self._current_value_channel is None:
             self._mw.curr_value_comboBox.setCurrentIndex(0)
         else:
-            self._mw.curr_value_comboBox.setCurrentIndex(index)
+            index = self._mw.curr_value_comboBox.findText(self._current_value_channel)
+            if index < 0:
+                self._mw.curr_value_comboBox.setCurrentIndex(0)
+                self._current_value_channel = None
+            else:
+                self._mw.curr_value_comboBox.setCurrentIndex(index)
+        self._mw.curr_value_comboBox.blockSignals(False)
+        self.current_value_channel_changed()
 
         # Update plot widget axes
         ch_list = self._time_series_logic.active_channels
@@ -572,7 +582,8 @@ class TimeSeriesGui(GUIBase):
         """
         """
         val = self._mw.curr_value_comboBox.currentText()
-        self._mw.curr_value_Label.setVisible(val != 'None')
+        self._current_value_channel = None if val == 'None' else val
+        self._mw.curr_value_Label.setVisible(self._current_value_channel is not None)
 
     @QtCore.Slot()
     def restore_default_view(self):

--- a/gui/time_series/time_series_gui.py
+++ b/gui/time_series/time_series_gui.py
@@ -440,7 +440,7 @@ class TimeSeriesGui(GUIBase):
         """
         """
         curr_channels = self._time_series_logic.active_channel_names
-        curr_av_channels = self._time_series_logic.averaged_channels
+        curr_av_channels = self._time_series_logic.averaged_channel_names
         for chnl, widgets in self._csd_widgets.items():
             widgets['checkbox1'].setChecked(chnl in curr_channels)
             widgets['checkbox2'].setChecked(chnl in curr_av_channels)

--- a/logic/time_series_reader_logic.py
+++ b/logic/time_series_reader_logic.py
@@ -681,7 +681,7 @@ class TimeSeriesReaderLogic(GenericLogic):
             return np.empty(0), dict()
 
         saving_stop_time = self._record_start_time + dt.timedelta(
-            seconds=data_arr.shape[1] * self.data_rate)
+            seconds=data_arr.shape[1] / self.data_rate)
 
         # write the parameters:
         parameters = dict()

--- a/logic/time_series_reader_logic.py
+++ b/logic/time_series_reader_logic.py
@@ -599,7 +599,7 @@ class TimeSeriesReaderLogic(GenericLogic):
 
         # Append data to save if necessary
         if self._data_recording_active:
-            self._recorded_data.append(data)
+            self._recorded_data.append(data.copy())
 
         data = data[:, -self._trace_data.shape[1]:]
         new_samples = data.shape[1]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fixes a nasty bug stemming from numpy not creating implicit copies that caused data corruption when saving time traces from the new "slow counter".
- Also the stop time was calculated and saved in a wrong way.
- `TimeSeriesGui` will now remember the data channel to show the value between qudi sessions.

## Motivation and Context
bugfixing and cosmetic improvement

## How Has This Been Tested?
IQO Setup 9 in an actual experiment (laser saturation measurement)

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
