### PR TITLE
Core bug fixes

### DIFF
--- a/core/manager.py
+++ b/core/manager.py
@@ -1372,6 +1372,7 @@ class Manager(QtCore.QObject):
             self.realQuit()
 
     @QtCore.Slot()
+    @QtCore.Slot(bool)
     def realQuit(self, restart=False):
         """ Stop all modules, no questions asked. """
         deps = self.getAllRecursiveModuleDependencies(self.tree['loaded'])

--- a/core/manager.py
+++ b/core/manager.py
@@ -1149,30 +1149,6 @@ class Manager(QtCore.QObject):
             If the module is an active GUI module, show its window.
         """
 
-        print(base,
-              key,
-              'not equal' if QtCore.QThread.currentThread() is not self.thread() else 'equal',
-              QtCore.QThread.currentThread(),
-              self.thread())
-        if QtCore.QThread.currentThread() is not self.thread():
-            print('invoke')
-            QtCore.QMetaObject.invokeMethod(
-                self,
-                'startModule',
-                QtCore.Qt.QueuedConnection,
-                QtCore.Q_ARG(str, str(base)),
-                QtCore.Q_ARG(str, str(key))
-            )
-            QtCore.QCoreApplication.instance().processEvents()
-            start_time = time.time()
-            while time.time() - start_time < 3:
-                if key in self.tree['loaded'].get(base, dict):
-                    return self.tree['loaded'][base][key].module_state() == 'deactivated'
-                else:
-                    time.sleep(0.1)
-            print('return because of timeout')
-            return -2
-
         deps = self.getRecursiveModuleDependencies(base, key)
         sorteddeps = toposort(deps)
         if len(sorteddeps) == 0:

--- a/core/manager.py
+++ b/core/manager.py
@@ -1149,15 +1149,29 @@ class Manager(QtCore.QObject):
             If the module is an active GUI module, show its window.
         """
 
+        print(base,
+              key,
+              'not equal' if QtCore.QThread.currentThread() is not self.thread() else 'equal',
+              QtCore.QThread.currentThread(),
+              self.thread())
         if QtCore.QThread.currentThread() is not self.thread():
+            print('invoke')
             QtCore.QMetaObject.invokeMethod(
                 self,
                 'startModule',
-                QtCore.Qt.BlockingQueuedConnection,
+                QtCore.Qt.QueuedConnection,
                 QtCore.Q_ARG(str, str(base)),
                 QtCore.Q_ARG(str, str(key))
             )
-            return self.tree['loaded'][base][key].module_state() == 'deactivated'
+            QtCore.QCoreApplication.instance().processEvents()
+            start_time = time.time()
+            while time.time() - start_time < 3:
+                if key in self.tree['loaded'].get(base, dict):
+                    return self.tree['loaded'][base][key].module_state() == 'deactivated'
+                else:
+                    time.sleep(0.1)
+            print('return because of timeout')
+            return -2
 
         deps = self.getRecursiveModuleDependencies(base, key)
         sorteddeps = toposort(deps)

--- a/core/manager.py
+++ b/core/manager.py
@@ -1157,6 +1157,17 @@ class Manager(QtCore.QObject):
             If the module is already loaded, just activate it.
             If the module is an active GUI module, show its window.
         """
+
+        if QtCore.QThread.currentThread() is not self.thread():
+            QtCore.QMetaObject.invokeMethod(
+                self,
+                'startModule',
+                QtCore.Qt.BlockingQueuedConnection,
+                QtCore.Q_ARG(str, str(base)),
+                QtCore.Q_ARG(str, str(key))
+            )
+            return self.tree['loaded'][base][key].module_state() == 'deactivated'
+
         deps = self.getRecursiveModuleDependencies(base, key)
         sorteddeps = toposort(deps)
         if len(sorteddeps) == 0:

--- a/core/manager.py
+++ b/core/manager.py
@@ -24,6 +24,7 @@ Originally distributed under MIT/X11 license. See documentation/MITLicense.txt f
 """
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 import os
@@ -35,11 +36,12 @@ import importlib
 from qtpy import QtCore
 from . import config
 
-from .util.mutex import Mutex   # Mutex provides access serialization between threads
+from .util.mutex import Mutex  # Mutex provides access serialization between threads
 from .util.modules import toposort, is_base
 from collections import OrderedDict
 from .logger import register_exception_handler
 from .threadmanager import ThreadManager
+
 # try to import RemoteObjectManager. Might fail if rpyc is not installed.
 try:
     from .remote import RemoteObjectManager
@@ -250,7 +252,7 @@ class Manager(QtCore.QObject):
                     else:
                         logger.critical('Couldn\'t find config file '
                                         'specified in load.cfg: {0}'.format(
-                                            confDict['configfile']))
+                            confDict['configfile']))
             except Exception:
                 logger.exception('Error while handling load.cfg.')
         # try config/example/custom.cfg next
@@ -394,7 +396,7 @@ class Manager(QtCore.QObject):
                                 # add directory to search path
                                 logger.debug('Adding extension path: {0}'
                                              ''.format(path))
-                                sys.path.insert(1+ii, path)
+                                sys.path.insert(1 + ii, path)
                         elif m == 'startup':
                             self.tree['global']['startup'] = cfg[
                                 'global']['startup']
@@ -506,7 +508,7 @@ class Manager(QtCore.QObject):
                     '^' + re.escape(configdir),
                     '',
                     filename)
-                )
+            )
         loadData = {'configfile': filename}
         config.save(loadFile, loadData)
         logger.info('Set loaded configuration to {0}'.format(filename))
@@ -588,7 +590,7 @@ class Manager(QtCore.QObject):
             configuration = {}
 
         # get class from module by name
-        #print(moduleObject, className)
+        # print(moduleObject, className)
         modclass = getattr(moduleObject, className)
 
         # FIXME: Check if the class we just obtained has the right inheritance
@@ -618,7 +620,7 @@ class Manager(QtCore.QObject):
         if not self.isModuleLoaded(base, mkey):
             logger.error('Loading of {0} module {1} as {2} was not '
                          'successful, not connecting it.'.format(
-                             base, thismodule['module.Class'], mkey))
+                base, thismodule['module.Class'], mkey))
             return -1
         loaded_module = self.tree['loaded'][base][mkey]
         if 'connect' not in thismodule:
@@ -630,7 +632,7 @@ class Manager(QtCore.QObject):
         if 'module.Class' not in thismodule:
             logger.error('Connection configuration of module {0}.{1} '
                          'is broken: no module defined.'.format(
-                             base, mkey))
+                base, mkey))
             return -1
         if not isinstance(thismodule['connect'], OrderedDict):
             logger.error('Connection configuration of module {0}.{1} '
@@ -654,26 +656,26 @@ class Manager(QtCore.QObject):
             elif isinstance(connectors[c], OrderedDict):
                 if 'class' not in connectors[c]:
                     logger.error('{0}.{1}.{2}: No class key in connection declaration.'
-                        ''.format(c, base, mkey))
+                                 ''.format(c, base, mkey))
                     continue
                 if not isinstance(connectors[c]['class'], str):
                     logger.error('{0}.{1}.{2}: Value {3} for class key is not a string.'
-                        ''.format(c, base, mkey, connectors[c]['class']))
+                                 ''.format(c, base, mkey, connectors[c]['class']))
                     continue
                 if 'object' not in connectors[c]:
                     logger.error('{0}.{1}.{2}: No object key in connection declaration.'
-                        ''.format(c, base, mkey))
+                                 ''.format(c, base, mkey))
                     continue
                 if connectors[c]['object'] is not None:
                     logger.warning('Connector {0}.{1}.{2} is already connected.'
-                        ''.format(c, base, mkey))
+                                   ''.format(c, base, mkey))
                     continue
                 logger.warning('Connector {0} in {1}.{2} is a legacy connector.\n'
-                    'Use core.module.Connector to declare connectors.'
-                    ''.format(c, base, mkey))
+                               'Use core.module.Connector to declare connectors.'
+                               ''.format(c, base, mkey))
             else:
                 logger.error('{0}.{1}.{2}: Connector is no dictionary or Connector.'
-                    ''.format(c, base, mkey))
+                             ''.format(c, base, mkey))
                 continue
             if not isinstance(connections[c], str):
                 logger.error('Connector configuration {0}.{1}.{2} '
@@ -685,7 +687,7 @@ class Manager(QtCore.QObject):
                                'legacy format since it contains a dot.'
                                ''.format(base, mkey, c))
                 logger.error('{0}.{1}.{2}: Connector is no dictionary.'
-                    ''.format(c, base, mkey))
+                             ''.format(c, base, mkey))
                 continue
                 destmod = connections[c].split('.')[0]
             else:
@@ -697,7 +699,7 @@ class Manager(QtCore.QObject):
                     destmod not in self.tree['loaded']['logic']):
                 logger.error('Cannot connect {0}.{1}.{2} to module {3}. '
                              'Module does not exist.'.format(
-                             base, mkey, c, destmod))
+                    base, mkey, c, destmod))
                 continue
             # check that module exists only once
             if not ((destmod in self.tree['loaded']['gui']) ^
@@ -705,7 +707,7 @@ class Manager(QtCore.QObject):
                     (destmod in self.tree['loaded']['logic'])):
                 logger.error('Cannot connect {0}.{1}.{2} to module {3}. '
                              'Module exists more than once.'.format(
-                                 base, mkey, c, destmod))
+                    base, mkey, c, destmod))
                 continue
 
             # find category of module that should be connected to
@@ -736,13 +738,13 @@ class Manager(QtCore.QObject):
             if isinstance(v, Connector) and not v.is_connected and not v.optional:
                 logger.error('Connector {0} of module {1}.{2} is not '
                              'connected. Connection not complete.'.format(
-                                 c, base, mkey))
+                    c, base, mkey))
                 return -1
             # legacy connector
             elif isinstance(v, dict) and v['object'] is None:
                 logger.error('Connector {0} of module {1}.{2} is not '
                              'connected. Connection not complete.'.format(
-                                 c, base, mkey))
+                    c, base, mkey))
                 return -1
         return 0
 
@@ -859,7 +861,7 @@ class Manager(QtCore.QObject):
             except:
                 logger.exception('Error while loading {0} module: {1}'.format(base, key))
         elif (key in self.tree['loaded'][base]
-                and 'module.Class' in defined_module):
+              and 'module.Class' in defined_module):
             try:
                 # state machine: deactivate
                 if self.isModuleActive(base, key):
@@ -900,10 +902,10 @@ class Manager(QtCore.QObject):
           @return bool: module is present in definition
         """
         return (
-            is_base(base)
-            and base in self.tree['defined']
-            and name in self.tree['defined'][base]
-            )
+                is_base(base)
+                and base in self.tree['defined']
+                and name in self.tree['defined'][base]
+        )
 
     def isModuleLoaded(self, base, name):
         """Check if module was loaded.
@@ -912,10 +914,10 @@ class Manager(QtCore.QObject):
           @return bool: module is loaded
         """
         return (
-            is_base(base)
-            and base in self.tree['loaded']
-            and name in self.tree['loaded'][base]
-            )
+                is_base(base)
+                and base in self.tree['loaded']
+                and name in self.tree['loaded'][base]
+        )
 
     def isModuleActive(self, base, name):
         """Returns whether a given module is active.
@@ -973,7 +975,7 @@ class Manager(QtCore.QObject):
                     QtCore.Q_RETURN_ARG(bool),
                     QtCore.Q_ARG(str, 'activate'))
             else:
-                success = module.module_state.activate() # runs on_activate in main thread
+                success = module.module_state.activate()  # runs on_activate in main thread
             logger.debug('Activation success: {}'.format(success))
         except:
             logger.exception(
@@ -1021,7 +1023,7 @@ class Manager(QtCore.QObject):
                 self.tm.quitThread('mod-{0}-{1}'.format(base, name))
                 self.tm.joinThread('mod-{0}-{1}'.format(base, name))
             else:
-                success = module.module_state.deactivate() # runs on_deactivate in main thread
+                success = module.module_state.deactivate()  # runs on_deactivate in main thread
 
             self.saveStatusVariables(base, name, module.getStatusVariables())
             logger.debug('Deactivation success: {}'.format(success))
@@ -1058,9 +1060,9 @@ class Manager(QtCore.QObject):
                     if '.' in connection:
                         conn = connection.split('.')[0]
                         logger.warning(
-                           '{0}.{1}: connection {2}: {3} has legacy '
-                           ' format for connection target'
-                           ''.format(bname, mname, cname, connection))
+                            '{0}.{1}: connection {2}: {3} has legacy '
+                            ' format for connection target'
+                            ''.format(bname, mname, cname, connection))
                     if conn == module:
                         deplist.add(mname)
         if len(deplist) > 0:
@@ -1087,7 +1089,7 @@ class Manager(QtCore.QObject):
         if not self.isModuleDefined(base, key):
             logger.error('{0} module {1}: no such module defined'.format(base, key))
             return None
-        defined_module =  self.tree['defined'][base][key]
+        defined_module = self.tree['defined'][base][key]
         if 'connect' not in defined_module:
             return dict()
         if not isinstance(defined_module['connect'], OrderedDict):
@@ -1102,7 +1104,7 @@ class Manager(QtCore.QObject):
             if '.' in connections[c]:
                 logger.warning('{0}.{1}: connection {2}: {3} has legacy '
                                ' format for connection target'.format(
-                                   base, key, c, connections[c]))
+                    base, key, c, connections[c]))
                 destmod = connections[c].split('.')[0]
             else:
                 destmod = connections[c]
@@ -1228,7 +1230,7 @@ class Manager(QtCore.QObject):
                 success = self.reloadConfigureModule(mbase, mkey)
                 if success < 0:
                     logger.warning('Stopping loading module {0}.{1} after '
-                        'loading error'.format(mbase, mkey))
+                                   'loading error'.format(mbase, mkey))
                     return -1
                 unloaded_mods.append(mkey)
 
@@ -1294,12 +1296,12 @@ class Manager(QtCore.QObject):
                 statusdir = self.getStatusDir()
                 classname = self.tree['loaded'][base][module].__class__.__name__
                 filename = os.path.join(statusdir,
-                    'status-{0}_{1}_{2}.cfg'.format(classname, base, module))
+                                        'status-{0}_{1}_{2}.cfg'.format(classname, base, module))
                 config.save(filename, variables)
             except:
                 print(variables)
                 logger.exception('Failed to save status variables of module '
-                        '{0}.{1}:\n{2}'.format(base, module, repr(variables)))
+                                 '{0}.{1}:\n{2}'.format(base, module, repr(variables)))
 
     def loadStatusVariables(self, base, module):
         """ If a status variable file exists for a module, load it into a dictionary.
@@ -1403,4 +1405,3 @@ class Manager(QtCore.QObject):
                 logger.error('You tried to remove the task runner but none was registered.')
             else:
                 logger.warning('Replacing task runner.')
-

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -77,6 +77,7 @@ please use _ni_x_series_in_streamer.py_ as hardware module.
 * Set proper minimum wavelength value in constraints of Tektronix AWG7k series HW module
 * Added a hardware file for fibered optical switch Thorlabs OSW12/22 via SwitchInterface
 * Fixed bug affecting interface overloading of Qudi modules
+* Bug fixes to core: made error messages sticky, respecting dependencies when restarting, startModule now uses invokeMethod when called from somewhere else but the main thread.
 *
 
 

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -85,7 +85,7 @@ please use _ni_x_series_in_streamer.py_ as hardware module.
 * Added missing metadata in saved raw data file of PulsedMeasurement module
 * Update hardware module controlling the cryocon temperature regulator
 * Added a hardware file to interface Thorlabs filter wheels via scripts
-* Bug fixes to core: made error messages sticky, respecting dependencies when restarting, startModule now uses invokeMethod when called from somewhere else but the main thread.
+* Bug fixes to core: made error messages sticky, respecting dependencies when restarting.
 *
 
 

--- a/gui/manager/errordialog.py
+++ b/gui/manager/errordialog.py
@@ -41,7 +41,7 @@ class ErrorDialog(QtWidgets.QDialog):
         """
         super().__init__()
         self.logWindow = logWindow
-        self.setWindowFlags(QtCore.Qt.Window)
+        self.setWindowFlags(QtCore.Qt.Window | QtCore.Qt.WindowStaysOnTopHint)
         # self.setWindowModality(QtCore.Qt.NonModal)
         self.setWindowTitle('Qudi Error')
         wid = QtWidgets.QDesktopWidget()

--- a/gui/manager/errordialog.py
+++ b/gui/manager/errordialog.py
@@ -60,7 +60,7 @@ class ErrorDialog(QtWidgets.QDialog):
         self.msgLabel.setSizePolicy(
             QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
         # self.msgLabel.setFrameStyle(QtGui.QFrame.Box)
-        #self.msgLabel.setStyleSheet('QLabel { font-weight: bold }')
+        # self.msgLabel.setStyleSheet('QLabel { font-weight: bold }')
         self.layout.addWidget(self.msgLabel)
         self.msgLabel.setMaximumWidth(800)
         self.msgLabel.setMinimumWidth(500)
@@ -102,7 +102,7 @@ class ErrorDialog(QtWidgets.QDialog):
 
         # extract list of exceptions
         exceptions = []
-        #helpful = []
+        # helpful = []
         key = 'exception'
         exc = entry
         while key in exc:
@@ -135,7 +135,7 @@ class ErrorDialog(QtWidgets.QDialog):
             self.nextBtn.show()
             self.nextBtn.setEnabled(True)
             self.nextBtn.setText('Show next error ({0:d} more)'.format(
-                                 len(self.messages)))
+                len(self.messages)))
         else:
             w = QtWidgets.QApplication.activeWindow()
             self.nextBtn.hide()

--- a/tools/conda-env-linx64-qt5.yml
+++ b/tools/conda-env-linx64-qt5.yml
@@ -112,6 +112,7 @@ dependencies:
     - gitpython==2.1.9
     - iso8601==0.1.12
     - lmfit==0.9.9
+    - nidaqmx==0.5.7
     - plumbum==1.6.6
     - pydaqmx==1.4.1
     - pyflowgraph-qo==0.0.3.1

--- a/tools/conda-env-win10-64bit-qt5.yml
+++ b/tools/conda-env-win10-64bit-qt5.yml
@@ -102,6 +102,7 @@ dependencies:
     - gitpython==2.1.10
     - iso8601==0.1.12
     - lmfit==0.9.10
+    - nidaqmx==0.5.7
     - plumbum==1.6.6
     - pydaqmx==1.4.1
     - pyflowgraph-qo==0.0.3.1

--- a/tools/conda-env-win7-32bit-qt5.yml
+++ b/tools/conda-env-win7-32bit-qt5.yml
@@ -104,6 +104,7 @@ dependencies:
     - gitpython==2.1.10
     - iso8601==0.1.12
     - lmfit==0.9.10
+    - nidaqmx==0.5.7
     - plumbum==1.6.6
     - pydaqmx==1.4.1
     - pyflowgraph-qo==0.0.3.1

--- a/tools/conda-env-win7-64bit-qt5.yml
+++ b/tools/conda-env-win7-64bit-qt5.yml
@@ -108,6 +108,7 @@ dependencies:
   - lmfit==0.9.10
   - mkl-fft==1.0.0
   - mkl-random==1.0.1
+  - nidaqmx==0.5.7
   - plumbum==1.6.6
   - prompt-toolkit==1.0.15
   - pydaqmx==1.4.1

--- a/tools/conda-env-win8-qt5.yml
+++ b/tools/conda-env-win8-qt5.yml
@@ -107,6 +107,7 @@ dependencies:
     - gitpython==2.1.9
     - iso8601==0.1.12
     - lmfit==0.9.9
+    - nidaqmx==0.5.7
     - plumbum==1.6.6
     - pydaqmx==1.4.1
     - pyflowgraph-qo==0.0.3.1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Making Error messages sticky: The Error messages now stay on top but they do not need to be focused (non-modal).
- deleting the restart method in the manager and rather making use of the realQuit, because only this one respects the dependencies

## Description
<!--- Describe your changes in detail -->
When clicking the restart Button in the manager qudi was restarted, but the individual modules were deloaded in "random" order. This lead to cases where the hardware module was deactivated while the logic still tried to access it. The realQuit does respect the dependencies, so it was easy to just extend it to also handle the restart. the old restart method was then deleted.

Also ran an automatic code cleaning on the files I touched.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Error messages got lost when too many windows were open on the computer.
- Restarts of qudi produced unnecessary errors that might also damage hardware

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
tested with dummy config(s) on Linux 5.7.9-1-MANJARO

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
