### PR TITLE
Bug fix in confocal module 

### DIFF
--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -1107,6 +1107,10 @@ class ConfocalGui(GUIBase):
             self._mw.xy_ViewWidget.set_crosshair_pos(pos)
         h_pos, v_pos = pos
 
+        if self._scanning_logic.depth_img_is_xz:
+            self.update_roi_depth(h=h_pos)
+        else:
+            self.update_roi_depth(h=v_pos)
         self.update_slider_x(h_pos)
         self.update_slider_y(v_pos)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When changing the crosshair in the xy scan window, the crosshair in the depth scan (xz or yz) is not updated accordingly as raised in issue #613 . With this pull request the bug is fixed.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> 
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes described bug #613 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. --> 
Has been tested with Dummy and confocal setup in laser lab 2 (ZQB).

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
