### PR TITLE
Pid timestep config option

### DIFF
--- a/config/example/default.cfg
+++ b/config/example/default.cfg
@@ -121,6 +121,7 @@ logic:
 
     pidlogic:
         module.Class: 'pid_logic.PIDLogic'
+        timestep: 0.1
         connect:
             controller: 'softpid'
             savelogic: 'savelogic'

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -86,6 +86,7 @@ please use _ni_x_series_in_streamer.py_ as hardware module.
 * Update hardware module controlling the cryocon temperature regulator
 * Added a hardware file to interface Thorlabs filter wheels via scripts
 * Bug fixes to core: made error messages sticky, respecting dependencies when restarting.
+* Added a config option to regulate pid logic timestep length
 *
 
 

--- a/logic/pid_logic.py
+++ b/logic/pid_logic.py
@@ -24,6 +24,7 @@ import numpy as np
 
 from core.connector import Connector
 from core.statusvariable import StatusVar
+from core.configoption import ConfigOption
 from core.util.mutex import Mutex
 from logic.generic_logic import GenericLogic
 from qtpy import QtCore
@@ -40,7 +41,7 @@ class PIDLogic(GenericLogic):
 
     # status vars
     bufferLength = StatusVar('bufferlength', 1000)
-    timestep = StatusVar(default=100)
+    timestep = ConfigOption('timestep', 100e-3)  # timestep in seconds
 
     # signals
     sigUpdateDisplay = QtCore.Signal()
@@ -64,7 +65,7 @@ class PIDLogic(GenericLogic):
         self.enabled = False
         self.timer = QtCore.QTimer()
         self.timer.setSingleShot(True)
-        self.timer.setInterval(self.timestep)
+        self.timer.setInterval(self.timestep * 1000)  # in ms
         self.timer.timeout.connect(self.loop)
 
     def on_deactivate(self):
@@ -80,7 +81,7 @@ class PIDLogic(GenericLogic):
         """ Start the data recording loop.
         """
         self.enabled = True
-        self.timer.start(self.timestep)
+        self.timer.start(self.timestep * 1000)  # in ms
 
     def stopLoop(self):
         """ Stop the data recording loop.
@@ -96,7 +97,7 @@ class PIDLogic(GenericLogic):
         self.history[2, -1] = self._controller.get_setpoint()
         self.sigUpdateDisplay.emit()
         if self.enabled:
-            self.timer.start(self.timestep)
+            self.timer.start(self.timestep * 1000)  # in ms
 
     def getSavingState(self):
         """ Return whether we are saving data

--- a/logic/pid_logic.py
+++ b/logic/pid_logic.py
@@ -31,8 +31,17 @@ from qtpy import QtCore
 
 
 class PIDLogic(GenericLogic):
-    """
-    Control a process via software PID.
+    """ Logic module to monitor and control a PID process
+
+    Example config:
+
+    pidlogic:
+        module.Class: 'pid_logic.PIDLogic'
+        timestep: 0.1
+        connect:
+            controller: 'softpid'
+            savelogic: 'savelogic'
+
     """
 
     # declare connectors


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In this small PR, I've changed the timestep variable of pidlogic main loop from StatusVariable (which can not be set in GUI) to ConfigOption.

## Motivation and Context
The timestep should be easily adaptable to the user need. A config option solve this issue efficiently.

## How Has This Been Tested?
This was tested with dummy PID logic.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
