### PR TITLE
Odmr fit on all ranges

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -91,6 +91,7 @@ please use _ni_x_series_in_streamer.py_ as hardware module.
 * Added biexponential fit function, model and estimator
 * Added custom circular loading indicator widget `qtwidgets.loading_indicator.CircleLoadingIndicator`
 * added property disable_wheel to custom ScienSponBox and ScienDSpinBox to deactivate wheel scrolling if required
+* Added possibility to fit data of all ranges in ODMR module when Fit range is -1
 
 
 Config changes:

--- a/gui/odmr/ui_odmrgui.ui
+++ b/gui/odmr/ui_odmrgui.ui
@@ -633,7 +633,7 @@
      <item row="1" column="0">
       <widget class="QLabel" name="fit_range_Label">
        <property name="text">
-        <string>Range</string>
+        <string>Fit range</string>
        </property>
       </widget>
      </item>

--- a/gui/odmr/ui_odmrgui.ui
+++ b/gui/odmr/ui_odmrgui.ui
@@ -626,7 +626,7 @@
      <item row="1" column="1">
       <widget class="QSpinBox" name="fit_range_SpinBox">
        <property name="maximum">
-        <number>0</number>
+        <number>-1</number>
        </property>
       </widget>
      </item>

--- a/logic/odmr_logic.py
+++ b/logic/odmr_logic.py
@@ -839,13 +839,17 @@ class ODMRLogic(GenericLogic):
         Execute the currently configured fit on the measurement data. Optionally on passed data
         """
         if (x_data is None) or (y_data is None):
-            x_data = self.frequency_lists[fit_range]
-            x_data_full_length = np.zeros(len(self.final_freq_list))
-            # how to insert the data at the right position?
-            start_pos = np.where(np.isclose(self.final_freq_list, self.mw_starts[fit_range]))[0][0]
-            x_data_full_length[start_pos:(start_pos + len(x_data))] = x_data
-            y_args = np.array([ind_list[0] for ind_list in np.argwhere(x_data_full_length)])
-            y_data = self.odmr_plot_y[channel_index][y_args]
+            if fit_range >= 0:
+                x_data = self.frequency_lists[fit_range]
+                x_data_full_length = np.zeros(len(self.final_freq_list))
+                # how to insert the data at the right position?
+                start_pos = np.where(np.isclose(self.final_freq_list, self.mw_starts[fit_range]))[0][0]
+                x_data_full_length[start_pos:(start_pos + len(x_data))] = x_data
+                y_args = np.array([ind_list[0] for ind_list in np.argwhere(x_data_full_length)])
+                y_data = self.odmr_plot_y[channel_index][y_args]
+            else:
+                x_data = self.final_freq_list
+                y_data = self.odmr_plot_y[channel_index]
         if fit_function is not None and isinstance(fit_function, str):
             if fit_function in self.get_fit_functions():
                 self.fc.set_current_fit(fit_function)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding the possibility to do fits in cw odmr not only on a single range but on the data of all ranges. 

## Description
<!--- Describe your changes in detail -->
If the Fit range is set to -1 the data of all odmr ranges is used for the fit. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Useful for example for fitting the NV center mS = +1 and -1 resonances in two different ranges at the same time. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with dummy on Windows 10. 

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
