### PR TITLE
Bugfix with terminating all digital input tasks

### DIFF
--- a/hardware/ni_x_series_in_streamer.py
+++ b/hardware/ni_x_series_in_streamer.py
@@ -1080,16 +1080,16 @@ class NIXSeriesInStreamer(Base, DataInStreamInterface):
         self._di_readers = list()
         self._ai_reader = None
 
-        for i in range(len(self._di_task_handles)):
+        while len(self._di_task_handles) > 0:
             try:
-                if not self._di_task_handles[i].is_task_done():
-                    self._di_task_handles[i].stop()
-                self._di_task_handles[i].close()
+                if not self._di_task_handles[-1].is_task_done():
+                    self._di_task_handles[-1].stop()
+                self._di_task_handles[-1].close()
             except ni.DaqError:
                 self.log.exception('Error while trying to terminate digital counter task.')
                 err = -1
             finally:
-                del self._di_task_handles[i]
+                del self._di_task_handles[-1]
         self._di_task_handles = list()
 
         if self._ai_task_handle is not None:


### PR DESCRIPTION
## Description
Small bugfix

## Motivation and Context
Everytime you stopped the new time series streamer while having multiple input channels configured, you got an exception. This PR fixes it.

## How Has This Been Tested?
IQO Setup 9 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
