### PR TITLE
Hot-fixing Keysight AWG

### DIFF
--- a/hardware/awg/keysight_m819x.py
+++ b/hardware/awg/keysight_m819x.py
@@ -1478,7 +1478,7 @@ class AWGM819X(Base, PulserInterface):
         if incl_ch_postfix:
             return fname.split(".")[0]
         else:
-            return fname.split("_ch")[0].split(".")[0]
+            return re.split("(_ch[0-9])", fname)[0]
 
     def _check_uploaded_wave_name(self, ch_num, wave_name, segment_id):
 

--- a/hardware/awg/keysight_m819x.py
+++ b/hardware/awg/keysight_m819x.py
@@ -1509,7 +1509,7 @@ class AWGM819X(Base, PulserInterface):
 
             comb_samples = self._compile_bin_samples(analog_samples, digital_samples, ch_str)
 
-            t_start = time.time()
+            t_start = time.perf_counter()
 
             if self._wave_mem_mode == 'pc_hdd':
                 # todo: check if working for awg8195a
@@ -1572,12 +1572,14 @@ class AWGM819X(Base, PulserInterface):
 
             else:
                 raise ValueError("Unknown memory mode: {}".format(self._wave_mem_mode))
-
-            transfer_speed_mbs = (comb_samples.nbytes/(1024*1024))/(time.time() - t_start)
-            self.log.debug('Written ({2:.1f} MB/s) to ch={0}: max ampl: {1}'.format(ch_str,
+            try:
+                transfer_speed_mbs = (comb_samples.nbytes/(1024*1024))/(time.perf_counter() - t_start)
+                self.log.debug('Written ({2:.1f} MB/s) to ch={0}: max ampl: {1}'.format(ch_str,
                                                                                 analog_samples[ch_str].max(),
                                                                                 transfer_speed_mbs))
-
+            except ZeroDivisionError:
+                pass
+            
         return waveforms
 
     def has_sequence_mode(self):


### PR DESCRIPTION
1. ZeroDivisionError was raised for a debug message measuring upload times. If the upload fails time.time() may return idential values, causing the error.
2. Waveforms containing "_ch" in their name couldn't be deleted due to erroneous string handling.

## Description
- use better time.perf_counter()
- catch and ignore ZeroDivisionError
- use regex to split name strings

## Motivation and Context

## How Has This Been Tested?
Tested on setup3


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
