### PR TITLE
Update poimangui.py

### DIFF
--- a/gui/poimanager/poimangui.py
+++ b/gui/poimanager/poimangui.py
@@ -626,6 +626,8 @@ class PoiManagerGui(GUIBase):
         new_pos = self.poimanagerlogic().roi_origin
         new_pos[0] = pos.x()
         new_pos[1] = pos.y()
+        new_pos[2] = self.poimanagerlogic().scanner_position[2]  #Added by rmgonzal
+        
         self.sigAddPoiByClick.emit(new_pos)
         return
 


### PR DESCRIPTION
Z-position from the scanner is not saved when you add a point of interest (POI)

## Description

This bug is affected because POI on the confocal image only saves the x, y position into the roi_origin, and since, by default, the values are set to zero. Since the z position is not saved into the POI file (which should be a fixed value) and take it from ROI origin.
So simply adding new_pos[2] = self.poimanagerlogic().scanner_position[2] line 629 "gui/poimanger/poimangui.py" will fix this bug.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The main motivation to fix this problem is to have the right focal plane for your POI file. This bug is caused when you select a point by clicking into the poi_manager, by default, the values before clicking are set to zero (np.zeros(3)), so when you select more than one POI the Z position is not stored.

So simply adding new_pos[2] = self.poimanagerlogic().scanner_position[2] line 629 "gui/poimanger/poimangui.py" will fix this bug.

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/Ulm-IQO/qudi/issues/512#issue-440787920

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
This has been tested by me in two different confocal setups
<!--- Include details of your testing environment, tests ran to see how -->

You can test this by adding more than one POI and checking the file in the console
```ruby
In[1]: poimanagerlogic.poi_positions
```
and the last value should be different from zero (e.g. 5 points same Z pos value).

```ruby
Out[1]: 
{'poi_20210322102945044728': array([3.67941896e-05, 5.56220471e-05, 5.00000000e-05]),
 'poi_20210322102946548945': array([3.15235204e-05, 3.33681106e-05, 5.00000000e-05]),
 'poi_20210322102947693560': array([7.01750944e-05, 5.21082677e-05, 5.00000000e-05]),
 'poi_20210324133553994647': array([2.09481774e-05, 7.84616136e-05, 5.00000000e-05]),
 'poi_20210324133554617894': array([1.27493587e-05, 5.09370079e-05, 5.00000000e-05])}
```
<!--- your change affects other areas of the code, etc. -->


## Screenshots (only if appropriate, delete if not):

![image](https://user-images.githubusercontent.com/51966905/112311197-bd65f400-8ca5-11eb-8e2d-91d687a5d402.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [ ] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.