### PR TITLE
Consistent return value of pulser hardware

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -4,6 +4,8 @@
 
 Changes/New features:
 
+* Changed all pulser hardware to return only a dict on loading of waveform and sequences. This was previously 
+guaranteed by the pulser interface, but not consistently implemented. 
 * Added support for Keysight M8195A and M8190A AWGs.
 * Added functionality to simultaneously record multiple frequency ranges in the ODMR toolchain 
 in case the hardware supports it.

--- a/hardware/awg/keysight_M3202A.py
+++ b/hardware/awg/keysight_M3202A.py
@@ -268,14 +268,14 @@ class M3202A(Base, PulserInterface):
             self.loaded_waveforms[chnl_num] = waveform
 
         self.last_sequence = None
-        return self.get_loaded_assets()
+        return self.get_loaded_assets()[0]
 
     def load_sequence(self, sequence_name):
         """ Loads a sequence to the channels of the device in order to be ready for playback.
         @param sequence_name:  dict|list, a dictionary with keys being one of the available channel
         @return dict: Dictionary containing the actually loaded waveforms per channel.
         """
-        return self.get_loaded_assets()
+        return self.get_loaded_assets()[0]
 
     def get_loaded_assets(self):
         """

--- a/hardware/awg/keysight_m819x.py
+++ b/hardware/awg/keysight_m819x.py
@@ -260,7 +260,7 @@ class AWGM819X(Base, PulserInterface):
                            'One or more channels to set are not active.\n'
                            'channels_to_set are: ', channels_to_set, 'and\n'
                            'analog_channels are: ', active_analog)
-            return self.get_loaded_assets()
+            return self.get_loaded_assets()[0]
 
         # Check if all waveforms to load are present on device memory
         if not set(load_dict.values()).issubset(self.get_waveform_names()):
@@ -268,19 +268,19 @@ class AWGM819X(Base, PulserInterface):
                            'One or more waveforms to load are missing: {}'.format(
                                                                             set(load_dict.values())
             ))
-            return self.get_loaded_assets()
+            return self.get_loaded_assets()[0]
 
         if load_dict == {}:
             self.log.warning('No file and channel provided for load!\n'
                              'Correct that!\nCommand will be ignored.')
-            return self.get_loaded_assets()
+            return self.get_loaded_assets()[0]
 
         self._load_wave_from_memory(load_dict, to_nextfree_segment=to_nextfree_segment)
 
         self.set_trigger_mode('cont')
         self.check_dev_error()
 
-        return self.get_loaded_assets()
+        return self.get_loaded_assets()[0]
 
     def load_sequence(self, sequence_name):
         """ Loads a sequence to the channels of the device in order to be ready for playback.
@@ -304,7 +304,7 @@ class AWGM819X(Base, PulserInterface):
         if not (set(self.get_loaded_assets()[0].values())).issubset(set([sequence_name])):
             self.log.error('Unable to load sequence into channels.\n'
                            'Make sure to call write_sequence() first.')
-            return self.get_loaded_assets()
+            return self.get_loaded_assets()[0]
 
         self.write_all_ch(':FUNC{}:MODE STS', all_by_one={'m8195a': True})  # activate the sequence mode
         """

--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -571,23 +571,32 @@ class AWG70K(Base, PulserInterface):
 
     def load_waveform(self, load_dict):
         """ Loads a waveform to the specified channel of the pulsing device.
-        For devices that have a workspace (i.e. AWG) this will load the waveform from the device
-        workspace into the channel.
-        For a device without mass memory this will make the waveform/pattern that has been
-        previously written with self.write_waveform ready to play.
-
-        @param load_dict:  dict|list, a dictionary with keys being one of the available channel
-                                      index and values being the name of the already written
-                                      waveform to load into the channel.
-                                      Examples:   {1: rabi_ch1, 2: rabi_ch2} or
-                                                  {1: rabi_ch2, 2: rabi_ch1}
-                                      If just a list of waveform names if given, the channel
-                                      association will be invoked from the channel
-                                      suffix '_ch1', '_ch2' etc.
-
-        @return (dict, str): Dictionary with keys being the channel number and values being the
-                             respective asset loaded into the channel, string describing the asset
-                             type ('waveform' or 'sequence')
+        @param dict|list load_dict: a dictionary with keys being one of the available channel
+                                    index and values being the name of the already written
+                                    waveform to load into the channel.
+                                    Examples:   {1: rabi_ch1, 2: rabi_ch2} or
+                                                {1: rabi_ch2, 2: rabi_ch1}
+                                    If just a list of waveform names if given, the channel
+                                    association will be invoked from the channel
+                                    suffix '_ch1', '_ch2' etc.
+                                        {1: rabi_ch1, 2: rabi_ch2}
+                                    or
+                                        {1: rabi_ch2, 2: rabi_ch1}
+                                    If just a list of waveform names if given,
+                                    the channel association will be invoked from
+                                    the channel suffix '_ch1', '_ch2' etc. A
+                                    possible configuration can be e.g.
+                                        ['rabi_ch1', 'rabi_ch2', 'rabi_ch3']
+        @return dict: Dictionary containing the actually loaded waveforms per
+                      channel.
+        For devices that have a workspace (i.e. AWG) this will load the waveform
+        from the device workspace into the channel. For a device without mass
+        memory, this will make the waveform/pattern that has been previously
+        written with self.write_waveform ready to play.
+        Please note that the channel index used here is not to be confused with the number suffix
+        in the generic channel descriptors (i.e. 'd_ch1', 'a_ch1'). The channel index used here is
+        highly hardware specific and corresponds to a collection of digital and analog channels
+        being associated to a SINGLE wavfeorm asset.
         """
         if isinstance(load_dict, list):
             new_dict = dict()
@@ -626,12 +635,17 @@ class AWG70K(Base, PulserInterface):
         """ Loads a sequence to the channels of the device in order to be ready for playback.
         For devices that have a workspace (i.e. AWG) this will load the sequence from the device
         workspace into the channels.
-
-        @param sequence_name:  str, name of the sequence to load
-
-        @return (dict, str): Dictionary with keys being the channel number and values being the
-                             respective asset loaded into the channel, string describing the asset
-                             type ('waveform' or 'sequence')
+        For a device without mass memory this will make the waveform/pattern that has been
+        previously written with self.write_waveform ready to play.
+        @param dict|list sequence_name: a dictionary with keys being one of the available channel
+                                        index and values being the name of the already written
+                                        waveform to load into the channel.
+                                        Examples:   {1: rabi_ch1, 2: rabi_ch2} or
+                                                    {1: rabi_ch2, 2: rabi_ch1}
+                                        If just a list of waveform names if given, the channel
+                                        association will be invoked from the channel
+                                        suffix '_ch1', '_ch2' etc.
+        @return dict: Dictionary containing the actually loaded waveforms per channel.
         """
         if sequence_name not in self.get_sequence_names():
             self.log.error('Unable to load sequence.\n'

--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -620,7 +620,7 @@ class AWG70K(Base, PulserInterface):
             while self.query('SOUR{0:d}:CASS?'.format(chnl_num)) != waveform:
                 time.sleep(0.1)
 
-        return self.get_loaded_assets()
+        return self.get_loaded_assets()[0]
 
     def load_sequence(self, sequence_name):
         """ Loads a sequence to the channels of the device in order to be ready for playback.
@@ -636,7 +636,7 @@ class AWG70K(Base, PulserInterface):
         if sequence_name not in self.get_sequence_names():
             self.log.error('Unable to load sequence.\n'
                            'Sequence to load is missing on device memory.')
-            return self.get_loaded_assets()
+            return self.get_loaded_assets()[0]
 
         # Get all active channels
         chnl_activation = self.get_active_channels()
@@ -648,7 +648,7 @@ class AWG70K(Base, PulserInterface):
         if trac_num != len(analog_channels):
             self.log.error('Unable to load sequence.\nNumber of tracks in sequence to load does '
                            'not match the number of active analog channels.')
-            return self.get_loaded_assets()
+            return self.get_loaded_assets()[0]
 
         # Load sequence
         for chnl in range(1, trac_num + 1):
@@ -657,7 +657,7 @@ class AWG70K(Base, PulserInterface):
                     sequence_name, chnl):
                 time.sleep(0.2)
 
-        return self.get_loaded_assets()
+        return self.get_loaded_assets()[0]
 
     def get_loaded_assets(self):
         """

--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -606,13 +606,13 @@ class AWG70K(Base, PulserInterface):
         if not channels_to_set.issubset(analog_channels):
             self.log.error('Unable to load waveforms into channels.\n'
                            'One or more channels to set are not active.')
-            return self.get_loaded_assets()
+            return self.get_loaded_assets()[0]
 
         # Check if all waveforms to load are present on device memory
         if not set(load_dict.values()).issubset(self.get_waveform_names()):
             self.log.error('Unable to load waveforms into channels.\n'
                            'One or more waveforms to load are missing on device memory.')
-            return self.get_loaded_assets()
+            return self.get_loaded_assets()[0]
 
         # Load waveforms into channels
         for chnl_num, waveform in load_dict.items():

--- a/hardware/awg/tektronix_awg7k.py
+++ b/hardware/awg/tektronix_awg7k.py
@@ -385,13 +385,13 @@ class AWG7k(Base, PulserInterface):
         if not channels_to_set.issubset(analog_channels):
             self.log.error('Unable to load all waveforms into channels.\n'
                            'One or more channels to set are not active.')
-            return self.get_loaded_assets()
+            return self.get_loaded_assets()[0]
 
         # Check if all waveforms to load are present on device memory
         if not set(load_dict.values()).issubset(self.get_waveform_names()):
             self.log.error('Unable to load waveforms into channels.\n'
                            'One or more waveforms to load are missing on device memory.')
-            return self.get_loaded_assets()
+            return self.get_loaded_assets()[0]
 
         # Load waveforms into channels
         for chnl_num, waveform in load_dict.items():
@@ -401,7 +401,7 @@ class AWG7k(Base, PulserInterface):
                 time.sleep(0.1)
 
         self.set_mode('C')
-        return self.get_loaded_assets()
+        return self.get_loaded_assets()[0]
 
     def load_sequence(self, sequence_name):
         """ Loads a sequence to the channels of the device in order to be ready for playback.
@@ -424,14 +424,14 @@ class AWG7k(Base, PulserInterface):
         if sequence_name not in self.get_sequence_names():
             self.log.error('Unable to load sequence.\n'
                            'Sequence to load is missing on device memory.')
-            return self.get_loaded_assets()
+            return self.get_loaded_assets()[0]
 
         # set the AWG to the event jump mode:
         self.write('AWGC:EVENT:JMODE EJUMP')
         self.set_mode('S')
 
         self._loaded_sequences = [sequence_name]
-        return self.get_loaded_assets()
+        return self.get_loaded_assets()[0]
 
     def get_loaded_assets(self):
         """

--- a/hardware/pulser_dummy.py
+++ b/hardware/pulser_dummy.py
@@ -449,7 +449,7 @@ class PulserDummy(Base, PulserInterface):
                     return self.current_loaded_assets
             new_loaded_assets[channel] = waveform
         self.current_loaded_assets = new_loaded_assets
-        return self.get_loaded_assets()
+        return return self.get_loaded_assets()[0]
 
     def load_sequence(self, sequence_name):
         """ Loads a sequence to the channels of the device in order to be ready for playback.
@@ -465,7 +465,7 @@ class PulserDummy(Base, PulserInterface):
         if sequence_name not in self.sequence_dict:
             self.log.error('Sequence loading failed. No sequence with name "{0}" found on device '
                            'memory.'.format(sequence_name))
-            return self.get_loaded_assets()
+            return return self.get_loaded_assets()[0]
 
         # Determine if the device is purely digital and get all active channels
         analog_channels = natural_sort(chnl for chnl in self.activation_config if chnl.startswith('a'))
@@ -476,12 +476,12 @@ class PulserDummy(Base, PulserInterface):
             self.log.error('Sequence loading failed. Number of active digital channels ({0:d}) does'
                            ' not match the number of tracks in the sequence ({1:d}).'
                            ''.format(len(digital_channels), self.sequence_dict[sequence_name]))
-            return self.get_loaded_assets()
+            return return self.get_loaded_assets()[0]
         if not pure_digital and len(analog_channels) != self.sequence_dict[sequence_name]:
             self.log.error('Sequence loading failed. Number of active analog channels ({0:d}) does'
                            ' not match the number of tracks in the sequence ({1:d}).'
                            ''.format(len(analog_channels), self.sequence_dict[sequence_name]))
-            return self.get_loaded_assets()
+            return return self.get_loaded_assets()[0]
 
         new_loaded_assets = dict()
         if pure_digital:
@@ -494,7 +494,7 @@ class PulserDummy(Base, PulserInterface):
                 new_loaded_assets[chnl_num] = '{0}_{1:d}'.format(sequence_name, track_index)
 
         self.current_loaded_assets = new_loaded_assets
-        return self.get_loaded_assets()
+        return return self.get_loaded_assets()[0]
 
     def get_loaded_assets(self):
         """

--- a/hardware/pulser_dummy.py
+++ b/hardware/pulser_dummy.py
@@ -399,23 +399,35 @@ class PulserDummy(Base, PulserInterface):
 
     def load_waveform(self, load_dict):
         """ Loads a waveform to the specified channel of the pulsing device.
-        For devices that have a workspace (i.e. AWG) this will load the waveform from the device
-        workspace into the channel.
-        For a device without mass memory this will make the waveform/pattern that has been
-        previously written with self.write_waveform ready to play.
 
-        @param load_dict:  dict|list, a dictionary with keys being one of the available channel
-                                      index and values being the name of the already written
-                                      waveform to load into the channel.
-                                      Examples:   {1: rabi_ch1, 2: rabi_ch2} or
-                                                  {1: rabi_ch2, 2: rabi_ch1}
-                                      If just a list of waveform names if given, the channel
-                                      association will be invoked from the channel
-                                      suffix '_ch1', '_ch2' etc.
+        @param dict|list load_dict: a dictionary with keys being one of the available channel
+                                    index and values being the name of the already written
+                                    waveform to load into the channel.
+                                    Examples:   {1: rabi_ch1, 2: rabi_ch2} or
+                                                {1: rabi_ch2, 2: rabi_ch1}
+                                    If just a list of waveform names if given, the channel
+                                    association will be invoked from the channel
+                                    suffix '_ch1', '_ch2' etc.
+                                        {1: rabi_ch1, 2: rabi_ch2}
+                                    or
+                                        {1: rabi_ch2, 2: rabi_ch1}
+                                    If just a list of waveform names if given,
+                                    the channel association will be invoked from
+                                    the channel suffix '_ch1', '_ch2' etc. A
+                                    possible configuration can be e.g.
+                                        ['rabi_ch1', 'rabi_ch2', 'rabi_ch3']
+        @return dict: Dictionary containing the actually loaded waveforms per
+                      channel.
 
-        @return (dict, str): Dictionary with keys being the channel number and values being the
-                             respective asset loaded into the channel, string describing the asset
-                             type ('waveform' or 'sequence')
+        For devices that have a workspace (i.e. AWG) this will load the waveform
+        from the device workspace into the channel. For a device without mass
+        memory, this will make the waveform/pattern that has been previously
+        written with self.write_waveform ready to play.
+
+        Please note that the channel index used here is not to be confused with the number suffix
+        in the generic channel descriptors (i.e. 'd_ch1', 'a_ch1'). The channel index used here is
+        highly hardware specific and corresponds to a collection of digital and analog channels
+        being associated to a SINGLE wavfeorm asset.
         """
         if isinstance(load_dict, list):
             new_dict = dict()
@@ -455,12 +467,18 @@ class PulserDummy(Base, PulserInterface):
         """ Loads a sequence to the channels of the device in order to be ready for playback.
         For devices that have a workspace (i.e. AWG) this will load the sequence from the device
         workspace into the channels.
+        For a device without mass memory this will make the waveform/pattern that has been
+        previously written with self.write_waveform ready to play.
 
-        @param sequence_name:  str, name of the sequence to load
-
-        @return (dict, str): Dictionary with keys being the channel number and values being the
-                             respective asset loaded into the channel, string describing the asset
-                             type ('waveform' or 'sequence')
+        @param dict|list sequence_name: a dictionary with keys being one of the available channel
+                                        index and values being the name of the already written
+                                        waveform to load into the channel.
+                                        Examples:   {1: rabi_ch1, 2: rabi_ch2} or
+                                                    {1: rabi_ch2, 2: rabi_ch1}
+                                        If just a list of waveform names if given, the channel
+                                        association will be invoked from the channel
+                                        suffix '_ch1', '_ch2' etc.
+        @return dict: Dictionary containing the actually loaded waveforms per channel.
         """
         if sequence_name not in self.sequence_dict:
             self.log.error('Sequence loading failed. No sequence with name "{0}" found on device '

--- a/hardware/pulser_dummy.py
+++ b/hardware/pulser_dummy.py
@@ -449,7 +449,7 @@ class PulserDummy(Base, PulserInterface):
                     return self.current_loaded_assets
             new_loaded_assets[channel] = waveform
         self.current_loaded_assets = new_loaded_assets
-        return return self.get_loaded_assets()[0]
+        return self.get_loaded_assets()[0]
 
     def load_sequence(self, sequence_name):
         """ Loads a sequence to the channels of the device in order to be ready for playback.
@@ -465,7 +465,7 @@ class PulserDummy(Base, PulserInterface):
         if sequence_name not in self.sequence_dict:
             self.log.error('Sequence loading failed. No sequence with name "{0}" found on device '
                            'memory.'.format(sequence_name))
-            return return self.get_loaded_assets()[0]
+            return self.get_loaded_assets()[0]
 
         # Determine if the device is purely digital and get all active channels
         analog_channels = natural_sort(chnl for chnl in self.activation_config if chnl.startswith('a'))
@@ -476,12 +476,12 @@ class PulserDummy(Base, PulserInterface):
             self.log.error('Sequence loading failed. Number of active digital channels ({0:d}) does'
                            ' not match the number of tracks in the sequence ({1:d}).'
                            ''.format(len(digital_channels), self.sequence_dict[sequence_name]))
-            return return self.get_loaded_assets()[0]
+            return self.get_loaded_assets()[0]
         if not pure_digital and len(analog_channels) != self.sequence_dict[sequence_name]:
             self.log.error('Sequence loading failed. Number of active analog channels ({0:d}) does'
                            ' not match the number of tracks in the sequence ({1:d}).'
                            ''.format(len(analog_channels), self.sequence_dict[sequence_name]))
-            return return self.get_loaded_assets()[0]
+            return self.get_loaded_assets()[0]
 
         new_loaded_assets = dict()
         if pure_digital:
@@ -494,7 +494,7 @@ class PulserDummy(Base, PulserInterface):
                 new_loaded_assets[chnl_num] = '{0}_{1:d}'.format(sequence_name, track_index)
 
         self.current_loaded_assets = new_loaded_assets
-        return return self.get_loaded_assets()[0]
+        return self.get_loaded_assets()[0]
 
     def get_loaded_assets(self):
         """

--- a/hardware/spincore/pulse_blaster_esrpro.py
+++ b/hardware/spincore/pulse_blaster_esrpro.py
@@ -1387,12 +1387,12 @@ class PulseBlasterESRPRO(Base, SwitchInterface, PulserInterface):
         else:
             self.log.error('Method load_waveform expects a list of waveform '
                            'names or a dict.')
-            return self.get_loaded_assets()
+            return self.get_loaded_assets()[0]
 
         if len(waveforms) != 1:
             self.log.error('PulseBlaster expects exactly one waveform name for '
                            'load_waveform.')
-            return self.get_loaded_assets()
+            return self.get_loaded_assets()[0]
 
         waveform = waveforms[0]
         if waveform != self._current_pb_waveform_name:
@@ -1400,7 +1400,7 @@ class PulseBlasterESRPRO(Base, SwitchInterface, PulserInterface):
                            'PulseBlaster.\n'
                            'Only one waveform at a time can be '
                            'held.'.format(waveform))
-            return self.get_loaded_assets()
+            return self.get_loaded_assets()[0]
 
         self.write_pulse_form(self._current_pb_waveform)
         self._currently_loaded_waveform = waveform


### PR DESCRIPTION
Currently, pulser hardware files have different return values on their load_waveform() and load_sequence() methods.
a) return dict of loaded assets
b) return dict of loaded assets, type of asset
This PR makes this consistent in all hw files and chooses (a) in accordance with the the pulser interface.

## How Has This Been Tested?
setup3 with Keysight m819x hardware. Waveforms are still uploading. Didn't check sequences.
Don't expect impact inside qudi, as the return value is never used in our code.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
