### PR TITLE
Allow data to be saved in subfolders

### DIFF
--- a/qudi/util/datastorage.py
+++ b/qudi/util/datastorage.py
@@ -175,11 +175,21 @@ class DataStorageBase(metaclass=ABCMeta):
 
         @param datetime.datetime timestamp: optional, timestamp to construct a generic filename from
         @param str filename: optional, filename to use (nametag and timestamp will be ignored)
-        @param str nametag: optional, nametag to include in the generic filename
+        @param str nametag: optional, nametag to include in the generic filename.
+                            May include sub directory, eg. "<subdir>/<nametag>".
         @param str file_extension: optional, the file extension to use
 
         @return str: Full absolute path of the data file
         """
+
+        subdir = os.path.dirname(nametag)
+        # catch user delivering absolute path by mistake
+        if os.path.isabs(subdir):
+            subdir = subdir.lstrip("\\").lstrip("/")
+        self.sub_directory += ("/" + subdir)
+
+        nametag = os.path.basename(nametag)
+
         if filename is None:
             if timestamp is None:
                 timestamp = datetime.now()
@@ -193,6 +203,7 @@ class DataStorageBase(metaclass=ABCMeta):
             file_extension = '.' + file_extension
         if file_extension is not None and not filename.endswith(file_extension):
             filename += file_extension
+
         return os.path.join(self.get_data_directory(timestamp=timestamp, create_missing=True),
                             filename)
 

--- a/qudi/util/datastorage.py
+++ b/qudi/util/datastorage.py
@@ -186,6 +186,8 @@ class DataStorageBase(metaclass=ABCMeta):
         # catch user delivering absolute path by mistake
         if os.path.isabs(subdir):
             subdir = subdir.lstrip("\\").lstrip("/")
+
+        save_sub_dir = self.sub_directory
         self.sub_directory += ("/" + subdir)
 
         nametag = os.path.basename(nametag)
@@ -204,8 +206,11 @@ class DataStorageBase(metaclass=ABCMeta):
         if file_extension is not None and not filename.endswith(file_extension):
             filename += file_extension
 
-        return os.path.join(self.get_data_directory(timestamp=timestamp, create_missing=True),
+        full_path = os.path.join(self.get_data_directory(timestamp=timestamp, create_missing=True),
                             filename)
+        self.sub_directory = save_sub_dir
+
+        return full_path
 
     def save_thumbnail(self, mpl_figure, timestamp=None, filename=None, nametag=None):
         """ Save a matplotlib figure visualizing the saved data in the image format provided.

--- a/qudi/util/datastorage.py
+++ b/qudi/util/datastorage.py
@@ -546,9 +546,9 @@ class CsvDataStorage(TextDataStorage):
 class NpyDataStorage(DataStorageBase):
     """ Helper class to store (measurement)data on disk as binary .npy file.
     """
-    def __init__(self, **kwargs):
+    def __init__(self, comments=None, **kwargs):
         kwargs['file_extension'] = '.npy'
-        kwargs['comments'] = None
+        self.comments = comments if isinstance(comments, str) else None
         super().__init__(**kwargs)
 
     def create_header(self, data_filename, metadata=None, timestamp=None, include_column_headers=True):


### PR DESCRIPTION
Currently, calling save_data() to a DataStorage object will always save to a constant directory that is fixed during construction of the DataStorage object.
This PR introduces a lightweight possibility to specify a sub directory.
It might come in handy when an external script is running the same measurement on different POI targets (see screenshot).

## Description
To be minimal code invasive, the nametag is checked for a possibly containing path. Eg. instead of using a 'pulsed_measurement' nametag, one could specify 'nv0/pulsed_measurement'. Although it overloads the nametag with additional functionality, I find this more elegant than introducing new parameters in all methods of the save toolchain. Importantly, external scripts can still use the save_measurement_data() methods of any module and would just need to alter the nametag provided.


## How Has This Been Tested?
Tested on dummy and saving pulsed measurement data. As saving is not implemented for most modules yet, it's currently hard to expand testing.

## Screenshots (only if appropriate, delete if not):
![image](https://user-images.githubusercontent.com/5861249/117811604-0aefed80-b261-11eb-8e89-51ff79397e16.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
