### PR TITLE
[new-core] Comments in saved data

### DIFF
--- a/qudi/util/datastorage.py
+++ b/qudi/util/datastorage.py
@@ -361,7 +361,7 @@ class TextDataStorage(DataStorageBase):
 
         if all_metadata:
             header_lines.append('Metadata:')
-            header_lines.append('===========')
+            header_lines.append('=========')
             for param, value in all_metadata.items():
                 if isinstance(value, (float, np.floating)):
                     header_lines.append(f'{param}: {value:.18e}')
@@ -566,7 +566,9 @@ class NpyDataStorage(DataStorageBase):
             all_metadata.update(metadata)
 
         header_lines = list()
-        header_lines.append('Saved Data on {0}'.format(timestamp.strftime('%d.%m.%Y at %Hh%Mm%Ss')))
+        header_lines.append(
+            f'Saved Data on {0}'.format(timestamp.strftime('%d.%m.%Y at %Hh%Mm%Ss'))
+        )
         header_lines.append('')
 
         if notes:
@@ -575,7 +577,7 @@ class NpyDataStorage(DataStorageBase):
 
         if all_metadata:
             header_lines.append('Metadata:')
-            header_lines.append('===========')
+            header_lines.append('=========')
             for param, value in all_metadata.items():
                 if isinstance(value, (float, np.floating)):
                     header_lines.append(f'{param}: {value:.18e}')
@@ -586,7 +588,7 @@ class NpyDataStorage(DataStorageBase):
             header_lines.append('')
 
         header_lines.append('Column headers:')
-        header_lines.append('=====')
+        header_lines.append('===============')
         if self.column_headers is not None:
             if isinstance(self.column_headers, str):
                 header_lines.append(self.column_headers)

--- a/qudi/util/datastorage.py
+++ b/qudi/util/datastorage.py
@@ -229,7 +229,7 @@ class DataStorageBase(metaclass=ABCMeta):
         return file_path
 
     @abstractmethod
-    def save_data(self, data, *, metadata=None, nametag=None, timestamp=None):
+    def save_data(self, data, *, metadata=None, comment=None, nametag=None, timestamp=None):
         """ This method must be implemented in a subclass. It should provide the facility to save an
         entire measurement as a whole along with experiment metadata (to include e.g. in the file
         header). The user can either specify an explicit filename or a generic one will be created.
@@ -237,6 +237,7 @@ class DataStorageBase(metaclass=ABCMeta):
         filename (only if filename parameter is omitted).
 
         @param numpy.ndarray data: data array to be saved (must be 1D or 2D for text files)
+        @param str comment: optional, string that is saved to the comment section of the file header
         @param dict metadata: optional, metadata to be saved in the data header / metadata
         @param str nametag: optional, nametag to include in the generic filename
         @param datetime.datetime timestamp: optional, timestamp to construct a generic filename from
@@ -297,6 +298,14 @@ class DataStorageBase(metaclass=ABCMeta):
             for name in names:
                 cls._global_metadata.pop(name, None)
 
+    def _format_comment(self, comment):
+        # add comments character to every newline in multi line comment strings
+        if hasattr(self, 'comments'):
+            if self.comments:
+                comment = comment.replace("\n", f"\n{self.comments}")
+
+        return comment
+
 
 class TextDataStorage(DataStorageBase):
     """ Helper class to store (measurement)data on disk in a daily directory as text file.
@@ -339,7 +348,7 @@ class TextDataStorage(DataStorageBase):
         self.delimiter = delimiter
         self._current_data_file = None
 
-    def create_header(self, metadata=None, timestamp=None, include_column_headers=True):
+    def create_header(self, metadata=None, comment=None, timestamp=None, include_column_headers=True):
         """
         """
         if timestamp is None:
@@ -363,6 +372,12 @@ class TextDataStorage(DataStorageBase):
                 else:
                     header_lines.append(f'{param}: {value}')
             header_lines.append('')
+        if comment:
+            header_lines.append('Comment:')
+            header_lines.append('===========')
+            header_lines.append(self._format_comment(comment))
+            header_lines.append('')
+
         header_lines.append('Data:')
         header_lines.append('=====')
         if self.column_headers is not None and include_column_headers:
@@ -376,14 +391,16 @@ class TextDataStorage(DataStorageBase):
                                  line_sep.join(header_lines))
         return header + '\n'
 
-    def new_data_file(self, *, metadata=None, filename=None, nametag=None, timestamp=None):
+    def new_data_file(self, *, metadata=None, comment=None, filename=None, nametag=None, timestamp=None):
         """ Create a new data file on disk and write header string to it. Will overwrite old files
         silently if they have the same path.
 
         @param dict metadata: optional, named metadata values to be saved in the data header
+        @param str comment: optional, string that is saved to the comment section of the file header
         @param str filename: optional, filename to use (nametag and timestamp will be ignored)
         @param str nametag: optional, nametag to include in the generic filename
         @param datetime.datetime timestamp: optional, timestamp to construct a generic filename from
+
 
         @return (str, datetime.datetime): Full file path, timestamp used
         """
@@ -393,7 +410,7 @@ class TextDataStorage(DataStorageBase):
         # Determine full file path and create containing directories if needed
         file_path = self.create_file_path(timestamp=timestamp, filename=filename, nametag=nametag)
         # Create header
-        header = self.create_header(metadata=metadata, timestamp=timestamp)
+        header = self.create_header(metadata=metadata, comment=comment, timestamp=timestamp)
         with open(file_path, 'w') as file:
             file.write(header)
         self._current_data_file = file_path
@@ -427,14 +444,15 @@ class TextDataStorage(DataStorageBase):
                 np.savetxt(file, data, delimiter=self.delimiter, fmt=self.number_format)
         return (1, data.shape[0]) if data.ndim == 1 else data.shape
 
-    def save_data(self, data, *, metadata=None, filename=None, nametag=None, timestamp=None):
+    def save_data(self, data, *, metadata=None, filename=None, nametag=None, timestamp=None, comment=None):
         """ See: DataStorageBase.save_data()
         """
         # Create new data file (overwrite old one if it exists)
         file_path, timestamp = self.new_data_file(metadata=metadata,
                                                   filename=filename,
                                                   nametag=nametag,
-                                                  timestamp=timestamp)
+                                                  timestamp=timestamp,
+                                                  comment=comment)
         # Append data to file
         rows, columns = self.append_data_file(data)
         return file_path, timestamp, (rows, columns)
@@ -506,15 +524,15 @@ class CsvDataStorage(TextDataStorage):
         kwargs['delimiter'] = ','
         super().__init__(**kwargs)
 
-    def create_header(self, metadata=None, timestamp=None):
+    def create_header(self, metadata=None, comment=None, timestamp=None):
         """ See: TextDataStorage.create_header()
         """
         if timestamp is None:
             timestamp = datetime.now()
         if isinstance(self.column_headers, str):
-            header = super().create_header(metadata, timestamp, True)
+            header = super().create_header(metadata, comment, timestamp, True)
         else:
-            header = super().create_header(metadata, timestamp, False)
+            header = super().create_header(metadata, comment, timestamp, False)
             if self.column_headers is not None:
                 header += ','.join(self.column_headers) + '\n'
         return header
@@ -530,12 +548,12 @@ class CsvDataStorage(TextDataStorage):
 class NpyDataStorage(DataStorageBase):
     """ Helper class to store (measurement)data on disk as binary .npy file.
     """
-    def __init__(self, **kwargs):
+    def __init__(self, comments=None, **kwargs):
         kwargs['file_extension'] = '.npy'
-        kwargs['comments'] = None
+        self.comments = comments if isinstance(comments, str) else None
         super().__init__(**kwargs)
 
-    def create_header(self, data_filename, metadata=None, timestamp=None, include_column_headers=True):
+    def create_header(self, data_filename, metadata=None, comment=None, timestamp=None, include_column_headers=True):
         """
         """
         if timestamp is None:
@@ -562,6 +580,12 @@ class NpyDataStorage(DataStorageBase):
                     header_lines.append('{0}: {1:d}'.format(param, value))
                 else:
                     header_lines.append('{0}: {1}'.format(param, value))
+        if comment:
+            header_lines.append('')
+            header_lines.append('Comment:')
+            header_lines.append('===========')
+            header_lines.append(self._format_comment(comment))
+
         if self.column_headers is not None and include_column_headers:
             header_lines.append('')
             header_lines.append('Column headers:')
@@ -576,7 +600,7 @@ class NpyDataStorage(DataStorageBase):
                                  line_sep.join(header_lines))
         return header + '\n'
 
-    def save_data(self, data, *, metadata=None, filename=None, nametag=None, timestamp=None):
+    def save_data(self, data, *, metadata=None, comment=None, filename=None, nametag=None, timestamp=None):
         """ Saves a binary file containing the data array.
         Also saves alongside a text file containing the (global) metadata and column headers for
         this data set. The filename of the text file will be the same as for the binary file
@@ -598,6 +622,7 @@ class NpyDataStorage(DataStorageBase):
         # Create header to save in a separate text file
         param_file_path = file_path.rsplit('.', 1)[0] + '_metadata.txt'
         header = self.create_header(data_filename=os.path.split(file_path)[-1],
+                                    comment=comment,
                                     metadata=metadata,
                                     timestamp=timestamp)
         with open(param_file_path, 'w') as file:


### PR DESCRIPTION
Allow a comment string to be passed to a data storage object.

## Description
DataStorageBase defines a comment parameters in save_data(). For text, csv, npy I implemented the handling of the passed string to a comment section in the saved file.

## How Has This Been Tested?
Tested in newcore dummy for pulsed gui with .npy, .txt, .csv files.

## Screenshots 
![image](https://user-images.githubusercontent.com/5861249/117973688-faa54480-b32c-11eb-800d-9f4c63bb81c5.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
