### PR TITLE
adding scaling option to toggle switch

### DIFF
--- a/qudi/core/gui/qtwidgets/toggle_switch.py
+++ b/qudi/core/gui/qtwidgets/toggle_switch.py
@@ -29,7 +29,7 @@ class ToggleSwitch(QtWidgets.QAbstractButton):
 
     """
 
-    def __init__(self, parent=None, off_state=None, on_state=None, thumb_track_ratio=1):
+    def __init__(self, parent=None, off_state=None, on_state=None, thumb_track_ratio=1, scaling=1.):
         assert off_state is None or isinstance(off_state, str), 'off_state must be str or None'
         assert on_state is None or isinstance(on_state, str), 'on_state must be str or None'
         super().__init__(parent=parent)
@@ -43,11 +43,11 @@ class ToggleSwitch(QtWidgets.QAbstractButton):
         # Get default track height from QLineEdit sizeHint if thumb_track_ratio <= 1
         # If thumb_track_ratio > 1 the QLineEdit height will serve as thumb diameter
         if thumb_track_ratio > 1:
-            self._thumb_radius = int(round(QtWidgets.QLineEdit().sizeHint().height() / 2))
+            self._thumb_radius = int(round(QtWidgets.QLineEdit().sizeHint().height() / 2) * scaling)
             self._track_radius = max(1, int(round(self._thumb_radius / thumb_track_ratio)))
             self._text_font = QtWidgets.QLabel().font()
         else:
-            self._track_radius = int(round(QtWidgets.QLineEdit().sizeHint().height() / 2))
+            self._track_radius = int(round(QtWidgets.QLineEdit().sizeHint().height() / 2) * scaling)
             self._thumb_radius = max(1, int(round(self._track_radius * thumb_track_ratio)))
         self._track_margin = max(0, self._thumb_radius - self._track_radius)
         self._thumb_origin = max(self._thumb_radius, self._track_radius)

--- a/qudi/gui/switch/switch_gui.py
+++ b/qudi/gui/switch/switch_gui.py
@@ -23,6 +23,7 @@ from enum import IntEnum
 from PySide2 import QtWidgets, QtCore, QtGui
 
 from qudi.core.connector import Connector
+from qudi.core.configoption import ConfigOption
 from qudi.core.statusvariable import StatusVar
 from qudi.core.module import GuiBase
 
@@ -97,6 +98,9 @@ class SwitchGui(GuiBase):
 
     # declare connectors
     switchlogic = Connector(interface='SwitchLogic')
+
+    # declare config options
+    _toggle_switch_scaling = ConfigOption(name='toggle_switch_scaling', default=1.)
 
     # declare status variables
     _switch_style = StatusVar(name='switch_style',
@@ -189,9 +193,13 @@ class SwitchGui(GuiBase):
                 switch_widget.sigStateChanged.connect(self.__get_state_update_func(switch))
             elif self._switch_style == SwitchStyle.TOGGLE_SWITCH:
                 if self._alt_toggle_switch_style:
-                    switch_widget = ToggleSwitchWidget(switch_states=states, thumb_track_ratio=1.35)
+                    switch_widget = ToggleSwitchWidget(switch_states=states,
+                                                       thumb_track_ratio=1.35,
+                                                       scaling=self._toggle_switch_scaling)
                 else:
-                    switch_widget = ToggleSwitchWidget(switch_states=states, thumb_track_ratio=0.9)
+                    switch_widget = ToggleSwitchWidget(switch_states=states,
+                                                       thumb_track_ratio=0.9,
+                                                       scaling=self._toggle_switch_scaling)
                 self._widgets[switch] = (label, switch_widget)
                 switch_widget.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
                                             QtWidgets.QSizePolicy.Fixed)

--- a/qudi/gui/switch/switch_state_widgets.py
+++ b/qudi/gui/switch/switch_state_widgets.py
@@ -111,7 +111,7 @@ class ToggleSwitchWidget(QtWidgets.QWidget):
 
     sigStateChanged = QtCore.Signal(str)
 
-    def __init__(self, parent=None, switch_states=('Off', 'On'), thumb_track_ratio=1):
+    def __init__(self, parent=None, switch_states=('Off', 'On'), thumb_track_ratio=1, scaling=1):
         super().__init__(parent=parent)
         assert len(switch_states) == 2, 'switch_states must be tuple of exactly 2 strings'
         assert all(isinstance(s, str) and s for s in switch_states), \
@@ -123,7 +123,7 @@ class ToggleSwitchWidget(QtWidgets.QWidget):
         layout.setAlignment(QtCore.Qt.AlignCenter)
         layout.setContentsMargins(2, 2, 2, 2)
         self.setLayout(layout)
-        self.toggle_switch = ToggleSwitch(None, *switch_states, thumb_track_ratio)
+        self.toggle_switch = ToggleSwitch(None, *switch_states, thumb_track_ratio, scaling)
         self.toggle_switch.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
         if thumb_track_ratio > 1:
             self.labels = (QtWidgets.QLabel(switch_states[0]), QtWidgets.QLabel(switch_states[1]))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The toggle switch can now be scaled to make it bigger.

## Description
<!--- Describe your changes in detail -->
On touch screens bigger buttons are useful, so I introduced an option to scale the toggle button.
This can be activated in the switch gui by the config option `toggle_switch_scaling`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bigger buttons on touch screens.
This options feature can be activated by config option in the switch gui.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
tested with dummy switches and the two types of toggle switches in the switch gui.

## Screenshots (only if appropriate, delete if not):
![grafik](https://user-images.githubusercontent.com/18718646/119501509-35659e80-bd69-11eb-8302-2a353cb4d07c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
