### PR TITLE
[core_pyside2] enhance system tray + extend timeouts

### DIFF
--- a/qudi/core/gui/gui.py
+++ b/qudi/core/gui/gui.py
@@ -38,6 +38,7 @@ logger = get_logger(__name__)
 class SystemTrayIcon(QtWidgets.QSystemTrayIcon):
     """Tray icon class subclassing QSystemTrayIcon for custom functionality.
     """
+
     def __init__(self):
         """Tray icon constructor.
         Adds all the appropriate menus and actions.
@@ -46,16 +47,22 @@ class SystemTrayIcon(QtWidgets.QSystemTrayIcon):
         self.setIcon(QtWidgets.QApplication.instance().windowIcon())
         self.right_menu = QtWidgets.QMenu('Quit')
         self.left_menu = QtWidgets.QMenu('Manager')
+
         iconpath = os.path.join(get_artwork_dir(), 'icons', 'oxygen', '22x22')
         self.managericon = QtGui.QIcon()
         self.managericon.addFile(os.path.join(iconpath, 'go-home.png'), QtCore.QSize(16, 16))
+        self.managerAction = QtWidgets.QAction(self.managericon, 'Manager', self.left_menu)
+
         self.exiticon = QtGui.QIcon()
         self.exiticon.addFile(os.path.join(iconpath, 'application-exit.png'), QtCore.QSize(16, 16))
         self.quitAction = QtWidgets.QAction(self.exiticon, 'Quit', self.right_menu)
-        self.managerAction = QtWidgets.QAction(self.managericon, 'Manager', self.left_menu)
+
         self.left_menu.addAction(self.managerAction)
+        self.left_menu.addSeparator()
+
         self.right_menu.addAction(self.quitAction)
         self.setContextMenu(self.right_menu)
+
         self.activated.connect(self.handle_activation)
 
     @QtCore.Slot(QtWidgets.QSystemTrayIcon.ActivationReason)
@@ -213,6 +220,7 @@ class Gui(QtCore.QObject):
             self.main_gui_module.show()
             return
 
+        self.system_tray_icon.managerAction.triggered.connect(self.main_gui_module.show, QtCore.Qt.QueuedConnection)
         self.main_gui_module.module_state.activate()
         QtWidgets.QApplication.instance().processEvents()
 

--- a/qudi/core/gui/main_gui/main_gui.py
+++ b/qudi/core/gui/main_gui/main_gui.py
@@ -249,6 +249,7 @@ class QudiMainGui(GuiBase):
             self.mw.console_widget.reset_font()
             self.mw.console_widget.set_default_style(colors='linux')
             kernel_client = kernel_manager.client()
+            kernel_client.hb_channel.time_to_dead = 10.0
             kernel_client.hb_channel.kernel_died.connect(self.kernel_died_callback)
             kernel_client.start_channels()
             self.mw.console_widget.kernel_manager = kernel_manager

--- a/qudi/core/modulemanager.py
+++ b/qudi/core/modulemanager.py
@@ -564,6 +564,10 @@ class ManagedModule(QtCore.QObject):
                 self.__poll_timer.start()
             else:
                 self._instance.module_state.sigStateChanged.connect(self._state_change_callback)
+
+            if self.is_active:
+                if self._base == 'gui':
+                    self._qudi_main_ref().gui.add_to_system_tray(self._name, self._instance.show)
             return True
 
     @QtCore.Slot()
@@ -643,6 +647,10 @@ class ManagedModule(QtCore.QObject):
             self.__last_state = self.state
             self.sigStateChanged.emit(self._base, self._name, self.__last_state)
             self.sigAppDataChanged.emit(self._base, self._name, self.has_app_data)
+
+            if self._base == 'gui':
+                self._qudi_main_ref().gui.remove_from_system_tray(self._name)
+
             return success
 
     @QtCore.Slot()

--- a/qudi/core/modulemanager.py
+++ b/qudi/core/modulemanager.py
@@ -564,10 +564,6 @@ class ManagedModule(QtCore.QObject):
                 self.__poll_timer.start()
             else:
                 self._instance.module_state.sigStateChanged.connect(self._state_change_callback)
-
-            if self.is_active:
-                if self._base == 'gui':
-                    self._qudi_main_ref().gui.add_to_system_tray(self._name, self._instance.show)
             return True
 
     @QtCore.Slot()
@@ -647,10 +643,6 @@ class ManagedModule(QtCore.QObject):
             self.__last_state = self.state
             self.sigStateChanged.emit(self._base, self._name, self.__last_state)
             self.sigAppDataChanged.emit(self._base, self._name, self.has_app_data)
-
-            if self._base == 'gui':
-                self._qudi_main_ref().gui.remove_from_system_tray(self._name)
-
             return success
 
     @QtCore.Slot()

--- a/qudi/core/qudikernel.py
+++ b/qudi/core/qudikernel.py
@@ -47,9 +47,9 @@ def install_kernel():
         os.mkdir(path)
 
         kernel_dict = {
-            'argv'        : [sys.executable, kernel_path, '-f', '{connection_file}'],
+            'argv': [sys.executable, kernel_path, '-f', '{connection_file}'],
             'display_name': 'Qudi',
-            'language'    : 'python'
+            'language': 'python'
         }
         # write the kernelspec file
         with open(os.path.join(path, 'kernel.json'), 'w') as f:
@@ -79,6 +79,7 @@ def uninstall_kernel():
 class QudiKernelService(rpyc.Service):
     """
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._background_server = None
@@ -103,6 +104,7 @@ class QudiKernelService(rpyc.Service):
 class QudiKernelClient:
     """
     """
+
     def __init__(self):
         self.service_instance = QudiKernelService()
         self.connection = None
@@ -134,9 +136,10 @@ class QudiKernelClient:
         port = config.namespace_server_port
         self.connection = rpyc.connect(host='localhost',
                                        config={'allow_all_attrs': True,
-                                               'allow_setattr'  : True,
-                                               'allow_delattr'  : True,
-                                               'allow_pickle'   : True},
+                                               'allow_setattr': True,
+                                               'allow_delattr': True,
+                                               'allow_pickle': True,
+                                               'sync_request_timeout': 3600},
                                        port=port,
                                        service=self.service_instance)
 
@@ -153,6 +156,7 @@ class QudiKernelClient:
 class QudiIPythonKernel(IPythonKernel):
     """
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._qudi_client = QudiKernelClient()
@@ -192,4 +196,5 @@ if __name__ == '__main__':
         uninstall_kernel()
     else:
         from ipykernel.kernelapp import IPKernelApp
+
         IPKernelApp.launch_instance(kernel_class=QudiIPythonKernel)

--- a/qudi/core/servers.py
+++ b/qudi/core/servers.py
@@ -48,9 +48,10 @@ def get_remote_module_instance(remote_url, certfile=None, keyfile=None, protocol
     parsed = urlparse(remote_url)
     if protocol_config is None:
         protocol_config = {'allow_all_attrs': True,
-                           'allow_setattr'  : True,
-                           'allow_delattr'  : True,
-                           'allow_pickle'   : True}
+                           'allow_setattr': True,
+                           'allow_delattr': True,
+                           'allow_pickle': True,
+                           'sync_request_timeout': 3600}
     connection = rpyc.ssl_connect(host=parsed.hostname,
                                   port=parsed.port,
                                   config=protocol_config,
@@ -64,6 +65,7 @@ class _ServerRunnable(QtCore.QObject):
     """ QObject containing the actual long-running code to execute in a separate thread for qudi
     RPyC servers.
     """
+
     def __init__(self, service, host, port, certfile=None, keyfile=None, protocol_config=None,
                  ssl_version=None, cert_reqs=None, ciphers=None):
         super().__init__()
@@ -77,9 +79,10 @@ class _ServerRunnable(QtCore.QObject):
         self.keyfile = keyfile
         if protocol_config is None:
             self.protocol_config = {'allow_all_attrs': True,
-                                    'allow_setattr'  : True,
-                                    'allow_delattr'  : True,
-                                    'allow_pickle'   : True}
+                                    'allow_setattr': True,
+                                    'allow_delattr': True,
+                                    'allow_pickle': True,
+                                    'sync_request_timeout': 3600}
         else:
             self.protocol_config = protocol_config
         self.ssl_version = ssl.PROTOCOL_TLSv1_2 if ssl_version is None else ssl_version
@@ -136,6 +139,7 @@ class BaseServer(QtCore.QObject):
     USE SSL AUTHENTICATION WHEN LISTENING ON ANYTHING ELSE THAN "localhost"/127.0.0.1.
     Actual RPyC server runs in a QThread.
     """
+
     def __init__(self, qudi, service_instance, name, host, port, certfile=None,
                  keyfile=None, protocol_config=None, ssl_version=None, cert_reqs=None,
                  ciphers=None, parent=None):
@@ -219,6 +223,7 @@ class BaseServer(QtCore.QObject):
 class RemoteModulesServer(BaseServer):
     """
     """
+
     def __init__(self, **kwargs):
         kwargs['service_instance'] = RemoteModulesService()
         super().__init__(**kwargs)
@@ -238,6 +243,7 @@ class QudiNamespaceServer(BaseServer):
     clients.
     Actual rpyc server runs in a QThread.
     """
+
     def __init__(self, qudi, name, port, parent=None):
         """
         @param qudi.Qudi qudi: The governing qudi main application instance


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- The system tray was not functional because the signals were not connected. Fixed that.
- Also added all GUI modules to the system tray.
- Extended the timeout of rpyc to 1 hour to allow long running cells in a notebook.
- Extended the timeout to declare a kernel dead to 10 seconds to allow for slower PCs that need long to start a new kernel.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now by selecting the GUI in the system tray it can be brought to the front, even if the window was closed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with dummy on core_pyside2 for Windows 10 21H1.

## Screenshots (only if appropriate, delete if not):
![grafik](https://user-images.githubusercontent.com/18718646/125288274-3b660d80-e31e-11eb-9013-0e945345b224.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
