### PR TITLE
Core pyside2 with modules time series fix

### DIFF
--- a/qudi/gui/time_series/time_series_gui.py
+++ b/qudi/gui/time_series/time_series_gui.py
@@ -429,7 +429,7 @@ class TimeSeriesGui(GuiBase):
         """
         """
         curr_channels = self._time_series_logic.active_channel_names
-        curr_av_channels = self._time_series_logic.averaged_channels
+        curr_av_channels = self._time_series_logic.averaged_channel_names
         for chnl, widgets in self._csd_widgets.items():
             widgets['checkbox1'].setChecked(chnl in curr_channels)
             widgets['checkbox2'].setChecked(chnl in curr_av_channels)

--- a/qudi/hardware/ni_x_series/ni_x_series_in_streamer.py
+++ b/qudi/hardware/ni_x_series/ni_x_series_in_streamer.py
@@ -45,7 +45,7 @@ class NIXSeriesInStreamer(DataInStreamInterface):
     Example config for copy-paste:
 
     nicard_6343_instreamer:
-        module.Class: 'ni_x_series_in_streamer.NIXSeriesInStreamer'
+        module.Class: 'ni_x_series.ni_x_series_in_streamer.NIXSeriesInStreamer'
         device_name: 'Dev1'
         digital_sources:  # optional
             - 'PFI15'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Renamed a variable in _keep_former_channel_settings_ which caused issues when opening up the settings window in the _time_series_gui_ module and closing it again without changes.
- Also changed the suggested default _module.Class_ path in the _ni_x_series_in_streamer_ docstring.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Error raised when opening/closing settings window within _time_series_gui_
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- Tested the changes on two Win10 machines
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x ] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [ ] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
