### PR TITLE
[core_pyside2] rpyc module proxy

### DIFF
--- a/qudi/core/application.py
+++ b/qudi/core/application.py
@@ -101,7 +101,8 @@ class Qudi(QtCore.QObject):
                 protocol_config=remote_server_config.get('protocol_config', None),
                 ssl_version=remote_server_config.get('ssl_version', None),
                 cert_reqs=remote_server_config.get('cert_reqs', None),
-                ciphers=remote_server_config.get('ciphers', None)
+                ciphers=remote_server_config.get('ciphers', None),
+                force_remote_calls_by_value=self.configuration.force_remote_calls_by_value
             )
         else:
             self.remote_modules_server = None
@@ -109,7 +110,8 @@ class Qudi(QtCore.QObject):
             parent=self,
             qudi=self,
             name='local-namespace-server',
-            port=self.configuration.namespace_server_port
+            port=self.configuration.namespace_server_port,
+            force_remote_calls_by_value=self.configuration.force_remote_calls_by_value
         )
         self.watchdog = None
         self.gui = None

--- a/qudi/core/config.py
+++ b/qudi/core/config.py
@@ -365,6 +365,16 @@ class Configuration(QtCore.QObject):
         self.sigConfigChanged.emit(self)
 
     @property
+    def force_remote_calls_by_value(self):
+        return self._global_config.get('force_remote_calls_by_value', True)
+
+    @force_remote_calls_by_value.setter
+    def force_remote_calls_by_value(self, flag):
+        assert isinstance(flag, bool), 'force_remote_calls_by_value flag must be bool type.'
+        self._global_config['force_remote_calls_by_value'] = flag
+        self.sigConfigChanged.emit(self)
+
+    @property
     def stylesheet(self):
         """ Absolute .qss file path used as stylesheet for qudi Qt application.
 
@@ -631,6 +641,8 @@ class Configuration(QtCore.QObject):
         new_config.daily_data_dirs = global_cfg.pop('daily_data_dirs', None)
         new_config.default_data_dir = global_cfg.pop('default_data_dir', None)
         new_config.namespace_server_port = global_cfg.pop('namespace_server_port', 18861)
+        new_config.force_remote_calls_by_value = global_cfg.pop('force_remote_calls_by_value',
+                                                                True)
         new_config.remote_modules_server = global_cfg.pop('remote_modules_server', None)
         if global_cfg:
             warn(f'Found additional entries in global config. The following entries will be '

--- a/qudi/core/default.cfg
+++ b/qudi/core/default.cfg
@@ -13,6 +13,14 @@ global:
     # Used by e.g. the Qudi jupyter kernel.
     namespace_server_port: 18861
 
+    # If this flag is set (True), all arguments passed to qudi module APIs from remote
+    # (jupyter notebook, qudi console, remote modules) will be wrapped and passed "per value"
+    # (serialized and de-serialized). This is avoiding a lot of inconveniences with using numpy in
+    # remote clients.
+    # If you do not want to use this workaround and know what you are doing, you can disable this
+    # feature by setting this flag to False.
+    force_remote_calls_by_value: True
+
     # Qss stylesheet for controlling the appearance of the GUIs.
     # Absolute path or relative to qudi.artwork.styles
     stylesheet: 'qdark.qss'

--- a/qudi/core/meta.py
+++ b/qudi/core/meta.py
@@ -23,41 +23,13 @@ top-level directory of this distribution and at
 __all__ = ('ABCQObjectMeta', 'ModuleMeta', 'QObjectMeta')
 
 from abc import ABCMeta
-from functools import wraps
-from inspect import signature, isfunction
 from PySide2.QtCore import QObject
 from qudi.core.statusvariable import StatusVar
 from qudi.core.connector import Connector
 from qudi.core.configoption import ConfigOption
-from qudi.util.network import netobtain
 
 
 QObjectMeta = type(QObject)
-
-
-def _module_rpyc_argument_wrapper(func):
-    sig = signature(func)
-    if len(sig.parameters) > 0 and isinstance(func, staticmethod):
-
-        @wraps(func)
-        def wrapped(*args, **kwargs):
-            sig.bind(*args, **kwargs)
-            args = [netobtain(arg) for arg in args]
-            kwargs = {name: netobtain(arg) for name, arg in kwargs.items()}
-            return func(*args, **kwargs)
-        wrapped.__signature__ = sig
-        return wrapped
-    elif len(sig.parameters) > 1:
-
-        @wraps(func)
-        def wrapped(self, *args, **kwargs):
-            sig.bind(self, *args, **kwargs)
-            args = [netobtain(arg) for arg in args]
-            kwargs = {name: netobtain(arg) for name, arg in kwargs.items()}
-            return func(self, *args, **kwargs)
-        wrapped.__signature__ = sig
-        return wrapped
-    return func
 
 
 class ABCQObjectMeta(ABCMeta, QObjectMeta):
@@ -65,14 +37,6 @@ class ABCQObjectMeta(ABCMeta, QObjectMeta):
     """
 
     def __new__(mcs, name, bases, attributes):
-        module_bases = ('GuiBase', 'LogicBase', 'Base')
-        if any(base.__name__ in module_bases for base in bases) and name not in module_bases:
-            exclude_attrs = ('on_activate', 'on_deactivate', 'move_to_main_thread', 'show')
-            for attr_name in list(attributes):
-                attr = attributes[attr_name]
-                if isfunction(attr) and attr_name not in exclude_attrs and attr_name[0] != '_':
-                    attributes[attr_name] = _module_rpyc_argument_wrapper(attr)
-
         cls = super(ABCQObjectMeta, mcs).__new__(mcs, name, bases, attributes)
         # Compute set of abstract method names
         abstracts = {

--- a/qudi/core/servers.py
+++ b/qudi/core/servers.py
@@ -224,8 +224,10 @@ class RemoteModulesServer(BaseServer):
     """
     """
 
-    def __init__(self, **kwargs):
-        kwargs['service_instance'] = RemoteModulesService()
+    def __init__(self, force_remote_calls_by_value=False, **kwargs):
+        kwargs['service_instance'] = RemoteModulesService(
+            force_remote_calls_by_value=force_remote_calls_by_value
+        )
         super().__init__(**kwargs)
 
     def share_module(self, module):
@@ -244,16 +246,20 @@ class QudiNamespaceServer(BaseServer):
     Actual rpyc server runs in a QThread.
     """
 
-    def __init__(self, qudi, name, port, parent=None):
+    def __init__(self, qudi, name, port, force_remote_calls_by_value=False, parent=None):
         """
         @param qudi.Qudi qudi: The governing qudi main application instance
         @param str name: Server name (used as name for the associated QThread)
         @param int port: port the RPyC server should listen to
         @param PySide2.QtCore.QObject parent: optional, parent Qt QObject
         """
+        service_instance = QudiNamespaceService(
+            qudi=qudi,
+            force_remote_calls_by_value=force_remote_calls_by_value
+        )
         super().__init__(parent=parent,
                          qudi=qudi,
-                         service_instance=QudiNamespaceService(qudi=qudi),
+                         service_instance=service_instance,
                          name=name,
                          host='localhost',
                          port=port)

--- a/qudi/core/services.py
+++ b/qudi/core/services.py
@@ -23,7 +23,6 @@ __all__ = ('RemoteModulesService', 'QudiNamespaceService')
 
 import rpyc
 import weakref
-import numpy as np
 from functools import wraps
 from inspect import signature, isfunction, ismethod
 
@@ -205,13 +204,13 @@ class QudiNamespaceService(rpyc.Service):
 
 
 class ModuleRpycProxy:
-    """ Instances of this class serve as proxies for objects containing attributes of type
-    OverloadedAttribute. It can be used to hide the overloading mechanism by fixing the overloaded
-    attribute access key in a OverloadProxy instance. This allows for interfacing an overloaded
-    attribute in the object represented by this proxy by normal "pythonic" means without the
-    additional key-mapping lookup usually required by OverloadedAttribute.
+    """ Instances of this class serve as proxies for qudi modules accessed via RPyC.
+    It currently wraps all API methods (none- and single-underscore methods) to only receive
+    parameters "by value", i.e. using qudi.util.network.netobtain. This will only work if all
+    method arguments are "pickle-able".
+    In addition all values passed to __setattr__ are also received "by value".
 
-    Heavily inspired by this python recipe under PSF License:
+    Proxy class concept heavily inspired by this python recipe under PSF License:
     https://code.activestate.com/recipes/496741-object-proxying/
     """
 

--- a/qudi/core/services.py
+++ b/qudi/core/services.py
@@ -111,7 +111,7 @@ class RemoteModulesService(rpyc.Service):
                     logger.error(f'Unable to share requested module "{name}" with client. Module '
                                  f'can not be activated.')
                     return None
-            return module.instance
+            return ModuleRpycProxy(module.instance)
 
     def exposed_get_available_module_names(self):
         """ Returns the currently shared module names independent of the current module state.
@@ -154,9 +154,6 @@ class QudiNamespaceService(rpyc.Service):
         super().__init__(*args, **kwargs)
         self.__qudi_ref = weakref.ref(qudi)
         self._notifier_callbacks = dict()
-
-        self.test = Test(111, 222)
-        self.test_wrapper = ModuleRpycProxy(self.test)
 
     @property
     def _qudi(self):
@@ -201,47 +198,10 @@ class QudiNamespaceService(rpyc.Service):
 
         @return dict: Names (keys) and object references (values)
         """
-        # self._module_wrappers = {name: mod.instance for name, mod in self._module_manager.items() if mod.is_active}
-        # self._module_wrappers['qudi'] = self._qudi
-        mods = {name: mod.instance for name, mod in self._module_manager.items() if mod.is_active}
+        mods = {name: ModuleRpycProxy(mod.instance) for name, mod in self._module_manager.items() if
+                mod.is_active}
         mods['qudi'] = self._qudi
-        mods['test_wrapper'] = self.test_wrapper
         return mods
-
-
-class Test:
-    def __init__(self, a=42, b=96):
-        self.a = a
-        self.b = b
-        self.arr = np.random.rand(100)
-        self.test = Test2()
-
-    def __call__(self):
-        print(type(self.arr))
-        print(self.arr)
-
-    def set_arr(self, new_arr=0):
-        """ Yep, that's it
-
-        @param numpy.ndarray new_arr: This is an array
-        """
-        print(type(new_arr))
-        self.arr = new_arr
-
-
-class Test2:
-    def __init__(self, a=42, b=96):
-        self.a = a
-        self.b = b
-        self.arr = np.random.rand(100)
-
-    def __call__(self):
-        print(type(self.arr))
-        print(self.arr)
-
-    def set_arr(self, new_arr):
-        print(type(new_arr))
-        self.arr = new_arr
 
 
 class ModuleRpycProxy:

--- a/qudi/tools/config_editor/global_editor.py
+++ b/qudi/tools/config_editor/global_editor.py
@@ -79,6 +79,18 @@ class GlobalConfigurationWidget(QtWidgets.QWidget):
         layout.addWidget(label, 0, 0)
         layout.addWidget(self.local_port_spinbox, 0, 1)
 
+        # Create flag editor to enforce remote calls by value
+        label = QtWidgets.QLabel('Force remote calls by value:')
+        label.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
+        self.force_calls_by_value_checkbox = QtWidgets.QCheckBox()
+        self.force_calls_by_value_checkbox.setToolTip(
+            'Will force all arguments from remote calls to qudi API methods to pass by value '
+            '(serialized -> sent to qudi -> de-serialized).'
+        )
+        self.force_calls_by_value_checkbox.setChecked(True)
+        layout.addWidget(label, 1, 0)
+        layout.addWidget(self.force_calls_by_value_checkbox, 1, 1)
+
         # Create startup modules editor
         label = QtWidgets.QLabel('Startup Modules:')
         label.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
@@ -86,8 +98,8 @@ class GlobalConfigurationWidget(QtWidgets.QWidget):
         self.startup_lineedit.setPlaceholderText('No startup modules')
         self.startup_lineedit.setToolTip('Modules to be automatically activated on qudi startup.\n'
                                          'Separate multiple module names with commas.')
-        layout.addWidget(label, 1, 0)
-        layout.addWidget(self.startup_lineedit, 1, 1)
+        layout.addWidget(label, 2, 0)
+        layout.addWidget(self.startup_lineedit, 2, 1)
 
         # Create stylesheet file path editor
         label = QtWidgets.QLabel('Stylesheet:')
@@ -98,8 +110,8 @@ class GlobalConfigurationWidget(QtWidgets.QWidget):
             'Absolute file path for qudi QSS stylesheet to use. If just a file name is given '
             'without full path, the file must be located in the "<qudi>/artwork/styles/".'
         )
-        layout.addWidget(label, 2, 0)
-        layout.addWidget(self.stylesheet_lineedit, 2, 1)
+        layout.addWidget(label, 3, 0)
+        layout.addWidget(self.stylesheet_lineedit, 3, 1)
 
         # Create path extensions editor
         label = QtWidgets.QLabel('Extension Paths:')
@@ -108,8 +120,8 @@ class GlobalConfigurationWidget(QtWidgets.QWidget):
         self.extensions_lineedit.setPlaceholderText('No qudi extensions')
         self.extensions_lineedit.setToolTip('Extension module search paths for Qudi.\nSeparate '
                                             'multiple paths with commas.')
-        layout.addWidget(label, 3, 0)
-        layout.addWidget(self.extensions_lineedit, 3, 1)
+        layout.addWidget(label, 4, 0)
+        layout.addWidget(self.extensions_lineedit, 4, 1)
 
         # Create default data path editor
         label = QtWidgets.QLabel('Data Directory:')
@@ -118,8 +130,19 @@ class GlobalConfigurationWidget(QtWidgets.QWidget):
         self.data_directory_lineedit.setPlaceholderText('Default "<UserHome>/qudi/Data/"')
         self.data_directory_lineedit.setToolTip('Default data directory for qudi modules to save '
                                                 'measurement data into.')
-        layout.addWidget(label, 4, 0)
-        layout.addWidget(self.data_directory_lineedit, 4, 1)
+        layout.addWidget(label, 5, 0)
+        layout.addWidget(self.data_directory_lineedit, 5, 1)
+
+        # Create flag editor to auomatically create a data sub-directory for each day
+        label = QtWidgets.QLabel('Create daily data directories:')
+        label.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
+        self.daily_data_dirs_checkbox = QtWidgets.QCheckBox()
+        self.daily_data_dirs_checkbox.setToolTip(
+            'Whether to automatically create daily sub-directories in the data directory '
+        )
+        self.daily_data_dirs_checkbox.setChecked(True)
+        layout.addWidget(label, 6, 0)
+        layout.addWidget(self.daily_data_dirs_checkbox, 6, 1)
 
         # Create another layout to hold custom global config options
         self.custom_opt_layout = QtWidgets.QGridLayout()
@@ -169,13 +192,17 @@ class GlobalConfigurationWidget(QtWidgets.QWidget):
         extensions = [path.strip() for path in self.extensions_lineedit.text().strip().split(',')]
         stylesheet = self.stylesheet_lineedit.text().strip()
         startup = [mod.strip() for mod in self.startup_lineedit.text().strip().split(',')]
+        daily_data_dirs = self.daily_data_dirs_checkbox.isChecked()
+        force_remote_calls_by_value = self.force_calls_by_value_checkbox.isChecked()
 
         # Create config dict
         cfg_dict = {'default_data_dir': default_data_dir if default_data_dir else None,
+                    'daily_data_dirs': daily_data_dirs,
                     'extensions': extensions if extensions else None,
                     'stylesheet': stylesheet if stylesheet else None,
                     'remote_modules_server': remote_modules_server,
                     'namespace_server_port': namespace_server_port,
+                    'force_remote_calls_by_value': force_remote_calls_by_value,
                     'startup': startup if startup else None}
 
         # Add custom config options
@@ -190,6 +217,7 @@ class GlobalConfigurationWidget(QtWidgets.QWidget):
         # Create shallow copy of dict
         cfg_dict = cfg_dict.copy()
         default_data_dir = cfg_dict.pop('default_data_dir', None)
+        daily_data_dirs = cfg_dict.pop('daily_data_dirs', True)
         extensions = cfg_dict.pop('extensions', None)
         stylesheet = cfg_dict.pop('stylesheet', None)
         startup = cfg_dict.pop('startup', None)
@@ -199,6 +227,7 @@ class GlobalConfigurationWidget(QtWidgets.QWidget):
         certfile = remote_modules_server.get('certfile', None)
         keyfile = remote_modules_server.get('keyfile', None)
         namespace_server_port = cfg_dict.pop('namespace_server_port', None)
+        force_remote_calls_by_value = cfg_dict.pop('force_remote_calls_by_value', True)
 
         self.data_directory_lineedit.setText('' if default_data_dir is None else default_data_dir)
         self.stylesheet_lineedit.setText('' if stylesheet is None else stylesheet)
@@ -211,6 +240,8 @@ class GlobalConfigurationWidget(QtWidgets.QWidget):
         self.local_port_spinbox.setValue(
             0 if namespace_server_port is None else int(namespace_server_port)
         )
+        self.force_calls_by_value_checkbox.setChecked(force_remote_calls_by_value)
+        self.daily_data_dirs_checkbox.setChecked(daily_data_dirs)
 
         # Handle custom options (all remaining items in cfg_dict)
         self._clear_custom_widgets()


### PR DESCRIPTION
## Description
**NEEDS TESTING**

This PR tries to wrap all qudi module API methods (including single-underscore methods) to only receive parameters by value if addressed via qudi kernel (IPC via RPyC).
It also forces `__setattr__` of qudi modules to be set by value.

So far this PR only enables the server side (qudi) to receive "by value". Objects returned to the client (IPython kernel) are still received as RPyC references and need to be actively "copied" over (if needed) via the helper function `qudi.util.network.netobtain`.

I'm not yet sure if passing all parameters "by value" could cause more harm than good. At least with this PR it would only happen for IPC calls and not in the local qudi process (like it is currently done in the module meta class).

For testing, you could branch out e.g. from `core_pyside2_with_modules` and merge this PR into the newly created test branch.

## Motivation and Context
Passing and receiving some objects like numpy arrays via RPyC is far from unproblematic.
Since the entire communication between qudi IPython kernel and qudi modules is done via RPyC and a lot of modules heavily use numpy, this issue needs to be addressed asap.

## How Has This Been Tested?
I tried to test it artificially in a dummy environment, but this PR needs proper testing with complex notebooks on a real setup!

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
