### PR TITLE
Quick Fix in confocalgui.

### DIFF
--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -712,7 +712,8 @@ class ConfocalGui(GUIBase):
         # Otherwise, calculate cb range from percentiles.
         else:
             # Exclude any zeros (which are typically due to unfinished scan)
-            xy_image_nonzero = self.xy_image.image[np.nonzero(self.xy_image.image)]
+            xy_image_flat = self.xy_image.image.flatten() #[np.nonzero(self.xy_image.image)]
+            xy_image_nonzero = xy_image_flat[np.nonzero(xy_image_flat)]
 
             # Read centile range
             low_centile = self._mw.xy_cb_low_percentile_DoubleSpinBox.value()


### PR DESCRIPTION
Qudi crashes on too large clock frequencies while heavily scrolling on the precentiles colorbar range (also happens with the dummy). This few line fix, seems to prevent the issue.

## Description
Flattened the array while assiging it to a new variable. Maybe prevents change of Image during runtime which might cause the issue?

## Motivation and Context
Qudi crashes while scrolling on the percentile colorbar

## How Has This Been Tested?
Dummy Confocal on Win10.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
