### PR TITLE
[core_pyside2] fix uic stream

### DIFF
--- a/qudi/core/gui/uic.py
+++ b/qudi/core/gui/uic.py
@@ -29,6 +29,7 @@ __all__ = ('loadUi',)
 import os
 import re
 import tempfile
+import subprocess
 from importlib.util import spec_from_loader, module_from_spec
 from qudi.core.paths import get_artwork_dir
 
@@ -59,14 +60,18 @@ def loadUi(file_path, base_widget):
         try:
             with open(fd, mode='w', closefd=True) as tmp_file:
                 tmp_file.write(converted)
-            stream = os.popen('pyside2-uic "{0}"'.format(file_path))
-        finally:
+        except:
             os.remove(file_path)
-    else:
-        stream = os.popen('pyside2-uic "{0}"'.format(file_path))
-
-    compiled = stream.read()
-    stream.close()
+            raise
+    try:
+        result = subprocess.run(f'pyside2-uic "{file_path}"',
+                                capture_output=True,
+                                text=True,
+                                check=True)
+        compiled = result.stdout
+    finally:
+        if converted is not None:
+            os.remove(file_path)
 
     # Find class name
     match = __ui_class_pattern.search(compiled)

--- a/qudi/core/gui/uic.py
+++ b/qudi/core/gui/uic.py
@@ -59,11 +59,14 @@ def loadUi(file_path, base_widget):
         try:
             with open(fd, mode='w', closefd=True) as tmp_file:
                 tmp_file.write(converted)
-            compiled = os.popen('pyside2-uic "{0}"'.format(file_path)).read()
+            stream = os.popen('pyside2-uic "{0}"'.format(file_path))
         finally:
             os.remove(file_path)
     else:
-        compiled = os.popen('pyside2-uic "{0}"'.format(file_path)).read()
+        stream = os.popen('pyside2-uic "{0}"'.format(file_path))
+
+    compiled = stream.read()
+    stream.close()
 
     # Find class name
     match = __ui_class_pattern.search(compiled)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The new loadUi throws a ResourceWarning on python 3.8.

## Description
<!--- Describe your changes in detail -->
The ResourceWarning comes from an open IOWrapper around a subprocess which compiles the .ui file into python qt objects. Just closing the stream after it has been read solves the problem.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug fix for a warning that appears under python 3.8 but does not seem to show up under 3.7.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on hardware with loading a .ui file in an python 3.8 environment.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply. -->
<!--- If you're unsure about any of these, ask. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
