### PR TITLE
Fix typo to show name in format string

### DIFF
--- a/logic/poi_manager_logic.py
+++ b/logic/poi_manager_logic.py
@@ -196,7 +196,7 @@ class RegionOfInterest:
         if name not in self._pois:
             raise KeyError('Name "{0}" not found in POI list.'.format(name))
         if new_name in self._pois:
-            raise NameError('New POI name "{0}" already present in current POI list.')
+            raise NameError('New POI name "{0}" already present in current POI list.'.format(new_name))
         self._pois[name].name = new_name
         self._pois[new_name] = self._pois.pop(name)
         return


### PR DESCRIPTION
Fixes a typo in the format string for a NameError on a duplicate name.

## Description

Fix the NameError so that is says e.g.

    'New POI name "my-name" already present in current POI list.'"

instead of

    "'New POI name "{0}" already present in current POI list.'"

There's also an trailing newline at the end that the Github text editor added automatically.

## Motivation and Context

This gives a more informative error message.

## How Has This Been Tested?

Trivial change, has been tested manually.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
