### PR TITLE
Fixed two typing errors, where float values are passed to PyQt5 metho…

### DIFF
--- a/core/garbage_collector.py
+++ b/core/garbage_collector.py
@@ -45,7 +45,7 @@ class GarbageCollector(QObject):
 
         self.threshold = gc.get_threshold()
         gc.disable()
-        self.timer.start(interval * 1000)
+        self.timer.start(round(interval * 1000))
 
     @Slot()
     def check(self):

--- a/gui/manager/errordialog.py
+++ b/gui/manager/errordialog.py
@@ -47,8 +47,8 @@ class ErrorDialog(QtWidgets.QDialog):
         wid = QtWidgets.QDesktopWidget()
         screenWidth = wid.screen(wid.primaryScreen()).width()
         screenHeight = wid.screen(wid.primaryScreen()).height()
-        self.setGeometry((screenWidth - 500) / 2,
-                         (screenHeight - 100) / 2, 500, 100)
+        self.setGeometry(round((screenWidth - 500) / 2),
+                         round((screenHeight - 100) / 2), 500, 100)
         self.layout = QtWidgets.QVBoxLayout()
         self.layout.setContentsMargins(3, 3, 3, 3)
         self.setLayout(self.layout)


### PR DESCRIPTION
Fixed two typing errors, where float values are passed to PyQt5 methods that expect integers.

This issue leads to exceptions being thrown in (at least) Python 3.10.6 with PyQt5.

The solution is to round the float values prior to passing them as parameters.

it is conceivable that more issues like this are present in the code-base, but I haven't encountered them. Perhaps a thorough use of mypy could help to spot them.