### PR TITLE
Fix fastcomtec set binwidth

### DIFF
--- a/hardware/fastcomtec/fastcomtecmcs6.py
+++ b/hardware/fastcomtec/fastcomtecmcs6.py
@@ -454,7 +454,6 @@ class FastComtec(Base, FastCounterInterface):
 
         @return int: asks the actual bitshift and returns the red out value
         """
-        #cmd = 'BITSHIFT={0}'.format(bitshift)
         cmd = 'BITSHIFT={0}'.format(hex(bitshift))
         self.dll.RunCmd(0, bytes(cmd, 'ascii'))
         return self.get_bitshift()

--- a/hardware/fastcomtec/fastcomtecmcs6.py
+++ b/hardware/fastcomtec/fastcomtecmcs6.py
@@ -454,7 +454,8 @@ class FastComtec(Base, FastCounterInterface):
 
         @return int: asks the actual bitshift and returns the red out value
         """
-        cmd = 'BITSHIFT={0}'.format(bitshift)
+        #cmd = 'BITSHIFT={0}'.format(bitshift)
+        cmd = 'BITSHIFT={0}'.format(hex(bitshift))
         self.dll.RunCmd(0, bytes(cmd, 'ascii'))
         return self.get_bitshift()
 

--- a/logic/odmr_logic.py
+++ b/logic/odmr_logic.py
@@ -217,6 +217,7 @@ class ODMRLogic(GenericLogic):
 
         if type(self.final_freq_list) == list:
             self.final_freq_list = np.array(final_freq_list)
+        self.final_freq_list = final_freq_list
 
         self.odmr_plot_x = np.array(self.final_freq_list)
         self.odmr_plot_y = np.zeros([len(self.get_odmr_channels()), self.odmr_plot_x.size])
@@ -1145,9 +1146,16 @@ class ODMRLogic(GenericLogic):
             time.sleep(1)
 
         # Perform fit if requested
+
+        #if fit_function != 'No Fit':
+        #    #self.do_fit(fit_function, channel_index=channel, fit_range=self.range_to_fit)
+        #    self.do_fit(fit_function, channel_index=channel)
+        #    fit_params = self.fc.current_fit_param
+
         if fit_function != 'No Fit':
-            self.do_fit(fit_function, channel_index=channel)
-            fit_params = self.fc.current_fit_param
+            for n in range(0,self.ranges):
+                self.do_fit(fit_function, channel_index=channel, fit_range=n)
+                fit_params = self.fc.current_fit_param
         else:
             fit_params = None
 

--- a/logic/odmr_logic.py
+++ b/logic/odmr_logic.py
@@ -1146,12 +1146,6 @@ class ODMRLogic(GenericLogic):
             time.sleep(1)
 
         # Perform fit if requested
-
-        #if fit_function != 'No Fit':
-        #    #self.do_fit(fit_function, channel_index=channel, fit_range=self.range_to_fit)
-        #    self.do_fit(fit_function, channel_index=channel)
-        #    fit_params = self.fc.current_fit_param
-
         if fit_function != 'No Fit':
             for n in range(0,self.ranges):
                 self.do_fit(fit_function, channel_index=channel, fit_range=n)

--- a/logic/odmr_logic.py
+++ b/logic/odmr_logic.py
@@ -217,7 +217,6 @@ class ODMRLogic(GenericLogic):
 
         if type(self.final_freq_list) == list:
             self.final_freq_list = np.array(final_freq_list)
-        self.final_freq_list = final_freq_list
 
         self.odmr_plot_x = np.array(self.final_freq_list)
         self.odmr_plot_y = np.zeros([len(self.get_odmr_channels()), self.odmr_plot_x.size])
@@ -1147,9 +1146,8 @@ class ODMRLogic(GenericLogic):
 
         # Perform fit if requested
         if fit_function != 'No Fit':
-            for n in range(0,self.ranges):
-                self.do_fit(fit_function, channel_index=channel, fit_range=n)
-                fit_params = self.fc.current_fit_param
+            self.do_fit(fit_function, channel_index=channel)
+            fit_params = self.fc.current_fit_param
         else:
             fit_params = None
 


### PR DESCRIPTION
Fix set_binwidth( ) hardware file fastcomtecmcs6 

## Description
Fix set_binwidth( ) method with changing the bitshift format to hex as there was a bug for bins  =>2**9=512 bins

## Motivation and Context
Now correct bins are set in the hardware for bins =>2**9=512 bins

## How Has This Been Tested?
Tested on Windows 8.1 on current qudi version

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
