### PR TITLE
Handle the case of an ROI with only one POI.

### DIFF
--- a/logic/poi_manager_logic.py
+++ b/logic/poi_manager_logic.py
@@ -1097,11 +1097,11 @@ class PoiManagerLogic(GenericLogic):
             filetag = filename.rsplit('_poi_list.dat', 1)[0]
 
         # Read POI data as well as roi metadata from textfile
-        poi_names = np.loadtxt(complete_path, delimiter='\t', usecols=0, dtype=str)
+        poi_names = np.loadtxt(complete_path, delimiter='\t', usecols=0, dtype=str, ndmin=1)
         if is_legacy_format:
-            poi_coords = np.loadtxt(complete_path, delimiter='\t', usecols=(2, 3, 4), dtype=float)
+            poi_coords = np.loadtxt(complete_path, delimiter='\t', usecols=(2, 3, 4), dtype=float, ndmin=2)
         else:
-            poi_coords = np.loadtxt(complete_path, delimiter='\t', usecols=(1, 2, 3), dtype=float)
+            poi_coords = np.loadtxt(complete_path, delimiter='\t', usecols=(1, 2, 3), dtype=float, ndmin=2)
 
         # Create list of POI instances
         poi_list = [PointOfInterest(pos, poi_names[i]) for i, pos in enumerate(poi_coords)]


### PR DESCRIPTION
This allows the POI manager to load an ROI file with a single POI.

## Description

Add the `ndmin` argument to `loadtxt` to ensure the shape is correct even when there is only one POI to load. Previously the resulting shape for `poi_names` was `()` and for `poi_coords` was `(3,)`, but with the fix it now has the correct shapes `(1,)` and `(1, 3)`.

## Motivation and Context

Currently, the POI manager will fail with an IndexError when attempting to load an ROI with a single ROI since [`loadtxt`](https://numpy.org/doc/stable/reference/generated/numpy.loadtxt.html) [defaults to](https://stackoverflow.com/questions/13528053/numpy-loadtxt-single-line-row-as-list) [squeezing the dimensions](https://stackoverflow.com/questions/23893625/numpy-loadtxt-for-one-and-more-input-lines).

## How Has This Been Tested?

I have tested it manually by loading an ROI with a single POI.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
